### PR TITLE
SCRUM-245: add spock testing and compatible mocking frameworks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,9 @@
 		<quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
 		<quarkus.platform.version>2.2.1.Final</quarkus.platform.version>
 		<surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+		<spock-core.version>2.0-groovy-3.0</spock-core.version>
+		<byte-buddy.version>1.11.15</byte-buddy.version>
+		<objenesis.version>3.2</objenesis.version>
 	</properties>
 
 	<dependencyManagement>
@@ -148,6 +151,25 @@
 			<groupId>io.quarkus</groupId>
 			<artifactId>quarkus-smallrye-health</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.spockframework</groupId>
+			<artifactId>spock-core</artifactId>
+			<version>${spock-core.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency> <!-- enables mocking of classes (in addition to interfaces) -->
+			<groupId>net.bytebuddy</groupId>
+			<artifactId>byte-buddy</artifactId>
+			<version>${byte-buddy.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency> <!-- enables mocking of classes without default constructor (together with
+        CGLIB) -->
+			<groupId>org.objenesis</groupId>
+			<artifactId>objenesis</artifactId>
+			<version>${objenesis.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -176,6 +198,18 @@
 					<parameters>${maven.compiler.parameters}</parameters>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.gmavenplus</groupId>
+				<artifactId>gmavenplus-plugin</artifactId>
+				<version>1.9.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>compileTests</goal>
+						</goals>
+					</execution>
+				</executions>
+        </plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${surefire-plugin.version}</version>


### PR DESCRIPTION
Ticket:
https://agr-jira.atlassian.net/browse/SCRUM-245


Evidence of integration tests running:

![Screenshot_20210907_152503](https://user-images.githubusercontent.com/143268/132406543-258144f5-f046-4e8c-9b4f-b1c2c7c4f5e5.png)

With class:
![Screenshot_20210907_152604](https://user-images.githubusercontent.com/143268/132406658-895a8e53-9098-46f6-9af9-2ccfe1261267.png)

And test (not an integration, but just for running something):
![Screenshot_20210907_152605](https://user-images.githubusercontent.com/143268/132406724-59bb5901-e422-448f-bd35-dbbd6c7370b0.png)

Class and Test only added to my local, not in pull request.