### PR TITLE
SCRUM-249 initial commit of JSON test files for gene loading

### DIFF
--- a/src/test/resources/gene/00_mod_examples.json
+++ b/src/test/resources/gene/00_mod_examples.json
@@ -1,0 +1,24068 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:245905"
+               },
+               {
+                  "id" : "MGI:1934609",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:1934609",
+            "synonyms" : [
+               "GENA 358"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Heterozygotes for an ethylnitrosourea-induced mutation exhibit dilated pupils. [provided by MGI curators]",
+         "name" : "dilated pupils 3",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Dilp3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:245906"
+               },
+               {
+                  "id" : "MGI:1934610",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:1934610",
+            "synonyms" : [
+               "GENA 372"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Heterozygotes for an ethylnitrosourea-induced mutation exhibit dilated pupils. [provided by MGI curators]",
+         "name" : "dilated pupils 4",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Dilp4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:117587"
+               },
+               {
+                  "id" : "MGI:2152879",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:2152879",
+            "synonyms" : [
+               "Apoc"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygous mutation of this gene results in embryonic lethality. Heterozygous mutant animals display cataracts and reduced litter size. Non-Mendelian segregation of this allele suggests semilethality. [provided by MGI curators]",
+         "name" : "anterior polar cataract",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Apoca"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000027551"
+               },
+               {
+                  "id" : "NCBI_Gene:22722"
+               },
+               {
+                  "id" : "PANTHER:PTHR24403"
+               },
+               {
+                  "id" : "UniProtKB:A2AQR2"
+               },
+               {
+                  "id" : "UniProtKB:A2AQR3"
+               },
+               {
+                  "id" : "UniProtKB:A2AQR4"
+               },
+               {
+                  "id" : "UniProtKB:Q99KE8"
+               },
+               {
+                  "id" : "MGI:107342",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:ZFP64"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "2",
+                  "endPosition" : 168955587,
+                  "startPosition" : 168893331,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:107342",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-35808"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "zinc finger protein 64",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Zfp64"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000050605"
+               },
+               {
+                  "id" : "NCBI_Gene:22719"
+               },
+               {
+                  "id" : "PANTHER:PTHR24377"
+               },
+               {
+                  "id" : "UniProtKB:D3Z6B8"
+               },
+               {
+                  "id" : "UniProtKB:Q3UG26"
+               },
+               {
+                  "id" : "UniProtKB:Q62518"
+               },
+               {
+                  "id" : "UniProtKB:Q923D1"
+               },
+               {
+                  "id" : "MGI:99663",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "7",
+                  "endPosition" : 24301232,
+                  "startPosition" : 24291039,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:99663",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-16448"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "zinc finger protein 61",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Zfp61"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:111262"
+               },
+               {
+                  "id" : "MGI:98335",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "9"
+               }
+            ],
+            "primaryId" : "MGI:98335",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-14465"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "U1 small nuclear ribonucleoprotein 1A, related sequence 3",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Snrp1a-rs3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000037689"
+               },
+               {
+                  "id" : "NCBI_Gene:78469"
+               },
+               {
+                  "id" : "PANTHER:PTHR36691"
+               },
+               {
+                  "id" : "UniProtKB:A0A0J9YTS2"
+               },
+               {
+                  "id" : "UniProtKB:Q497K7"
+               },
+               {
+                  "id" : "MGI:1925719",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "17",
+                  "endPosition" : 86922367,
+                  "startPosition" : 86917348,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:1925719",
+            "synonyms" : [
+               "1700090G07Rik",
+               "RIKEN cDNA 1700090G07 gene"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Male mice homozygous for a mutation are viable and show normal fertility. [provided by MGI curators]",
+         "name" : "transmembrane protein 247",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tmem247"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000020090"
+               },
+               {
+                  "id" : "NCBI_Gene:237362"
+               },
+               {
+                  "id" : "PANTHER:PTHR24241"
+               },
+               {
+                  "id" : "UniProtKB:E9Q468"
+               },
+               {
+                  "id" : "UniProtKB:Q80T60"
+               },
+               {
+                  "id" : "MGI:2685082",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype",
+                     "gene/phenotypes_impc"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:Neuropeptide FF receptor 1"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "10",
+                  "endPosition" : 61628565,
+                  "startPosition" : 61595492,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:2685082",
+            "synonyms" : [
+               "G protein-coupled receptor 147",
+               "Gm236",
+               "Gpr147",
+               "LOC237362",
+               "NPFF1",
+               "NPFF1R",
+               "gene model 236, (NCBI)"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice homozygous for a null mutation display abnormal pituitary function with abnormal levels of follicle stimulating and luteinizing hormone levels and increased litter sizes.  [provided by MGI curators]",
+         "name" : "neuropeptide FF receptor 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Npffr1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000022715"
+               },
+               {
+                  "id" : "NCBI_Gene:74720"
+               },
+               {
+                  "id" : "PANTHER:PTHR20516"
+               },
+               {
+                  "id" : "UniProtKB:Q9D563"
+               },
+               {
+                  "id" : "MGI:1921970",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "16",
+                  "endPosition" : 8425136,
+                  "startPosition" : 8409276,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:1921970",
+            "synonyms" : [
+               "4930511J11Rik",
+               "Cldn26",
+               "RIKEN cDNA 4930511J11 gene",
+               "claudin 26"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice exhibit normal male fertility. [provided by MGI curators]",
+         "name" : "transmembrane protein 114",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tmem114"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3837210",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "7"
+               }
+            ],
+            "primaryId" : "MGI:3837210",
+            "synonyms" : [
+               "mmu-mir-1965"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "microRNA 1965",
+         "soTermId" : "SO:0001265",
+         "symbol" : "Mir1965"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3030091",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "15"
+               }
+            ],
+            "primaryId" : "MGI:3030091",
+            "synonyms" : [
+               "GA_x6K02T2N22H-3824-2865"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "olfactory receptor 257",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Olfr257"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:2676261",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "10",
+                  "endPosition" : 53772211,
+                  "startPosition" : 11642896,
+                  "strand" : "."
+               }
+            ],
+            "primaryId" : "MGI:2676261",
+            "synonyms" : [
+               "1.19"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "X inactivation autosomal factor 3",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Xiaf3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:96292",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:96292",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-11023"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mutations in this gene result in preaxial ploydactyly in heterozygotes and lethality in homozygotes. [provided by MGI curators]",
+         "name" : "hallux duplex",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Hxd"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:95550",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:95550",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-9820"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygotes for a possibly irradiation-induced mutation exhibit reduced size at birth, outwardly bent radius and ulna bones, poor viability, male sterility, and reduced fertility in females. [provided by MGI curators]",
+         "name" : "flipper-arm",
+         "soTermId" : "SO:0001500",
+         "symbol" : "fl"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:96708",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:96708",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-11666"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mutations in this gene produce tail and balance abnormalities. [provided by MGI curators]",
+         "name" : "kinky-waltzer",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Kw"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3800745",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:3800745",
+            "synonyms" : [
+               "cholr1",
+               "recessive hypocholesterolemia 1"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "recessive hypocholesterolemia 1a",
+         "soTermId" : "SO:0001500",
+         "symbol" : "cholr1a"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:4367793",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:4367793",
+            "secondaryIds" : [
+               "MGI:3686717"
+            ],
+            "synonyms" : [
+               "GENA93",
+               "Gena93",
+               "Genetics Harwell, 93",
+               "shhd",
+               "short head"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Heterozygotes for this ENU-induced mutation exhibit a shortened head. [provided by MGI curators]",
+         "name" : "shorthead 2",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Sho2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:5629256",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:5629256",
+            "secondaryIds" : [
+               "MGI:5426055"
+            ],
+            "synonyms" : [
+               "SCA001",
+               "serum calcium mutant 001"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice homozygous for an ENU-induced allele exhibit increased circulating calcium level. [provided by MGI curators]",
+         "name" : "Martin Hrabe de Angelis serum calcium mutant 1",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Mhdasca1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:5792207",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:5792207",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "muta-ped-c3pde 201, Harwell",
+         "soTermId" : "SO:0001500",
+         "symbol" : "mpc201H"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:5560778",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:5560778",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "Mutant line 2140",
+         "soTermId" : "SO:0001500",
+         "symbol" : "b2b2140Clo"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3800739",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:3800739",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "dominant hypocholesterolemia 10",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Chold10"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000018381"
+               },
+               {
+                  "id" : "NCBI_Gene:66610"
+               },
+               {
+                  "id" : "PANTHER:PTHR10460"
+               },
+               {
+                  "id" : "UniProtKB:F6RXN4"
+               },
+               {
+                  "id" : "UniProtKB:Q8BYZ1"
+               },
+               {
+                  "id" : "MGI:1913860",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:ABI3"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "11",
+                  "endPosition" : 95842476,
+                  "startPosition" : 95830074,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:1913860",
+            "secondaryIds" : [
+               "MGI:2144332"
+            ],
+            "synonyms" : [
+               "2210414K06Rik",
+               "AI987680",
+               "RIKEN cDNA 2210414K06 gene",
+               "expressed sequence AI987680"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "ABI family member 3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Abi3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000104669"
+               },
+               {
+                  "id" : "NCBI_Gene:329711"
+               },
+               {
+                  "id" : "MGI:5621296",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "3",
+                  "endPosition" : 94371023,
+                  "startPosition" : 94365535,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:5621296",
+            "secondaryIds" : [
+               "MGI:5663443"
+            ],
+            "synonyms" : [
+               "Gm43306",
+               "predicted gene 43306"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "predicted gene, 38411",
+         "soTermId" : "SO:0002127",
+         "symbol" : "Gm38411"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000107847"
+               },
+               {
+                  "id" : "NCBI_Gene:102639529"
+               },
+               {
+                  "id" : "MGI:5594981",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "6",
+                  "endPosition" : 10970125,
+                  "startPosition" : 10895496,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:5594981",
+            "secondaryIds" : [
+               "MGI:5690396"
+            ],
+            "synonyms" : [
+               "Gm44004",
+               "predicted gene, 44004"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "predicted gene, 35822",
+         "soTermId" : "SO:0002127",
+         "symbol" : "Gm35822"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000003282"
+               },
+               {
+                  "id" : "NCBI_Gene:56711"
+               },
+               {
+                  "id" : "PANTHER:PTHR24388"
+               },
+               {
+                  "id" : "UniProtKB:D6RES7"
+               },
+               {
+                  "id" : "UniProtKB:Q9QYE0"
+               },
+               {
+                  "id" : "MGI:1891916",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype",
+                     "gene/phenotypes_impc"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:PLAG1"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "4",
+                  "endPosition" : 3938423,
+                  "startPosition" : 3900996,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:1891916",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygous null mice display reduced male fertility, small seminal vesicles and ventral prostate, reduced litter size (females only), reduced embryonic and postnatal growth, and delayed eyelid opening. [provided by MGI curators]",
+         "name" : "pleiomorphic adenoma gene 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Plag1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000044583"
+               },
+               {
+                  "id" : "NCBI_Gene:170743"
+               },
+               {
+                  "id" : "PANTHER:PTHR47410"
+               },
+               {
+                  "id" : "UniProtKB:A2AHJ1"
+               },
+               {
+                  "id" : "UniProtKB:A2AHJ2"
+               },
+               {
+                  "id" : "UniProtKB:P58681"
+               },
+               {
+                  "id" : "UniProtKB:Q3T997"
+               },
+               {
+                  "id" : "UniProtKB:Q548J0"
+               },
+               {
+                  "id" : "UniProtKB:Q599W9"
+               },
+               {
+                  "id" : "MGI:2176882",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:TLR 7"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "X",
+                  "endPosition" : 167330558,
+                  "startPosition" : 167304929,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:2176882",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: The innate immune response to viral infection is affected in homozygous null mice. Mice homozygous or hemizygous for a point mutation produce little or no tumor necrosis factor (TNF) alpha in response to stimulation by a single stranded RNA analog. [provided by MGI curators]",
+         "name" : "toll-like receptor 7",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tlr7"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000026890"
+               },
+               {
+                  "id" : "NCBI_Gene:16874"
+               },
+               {
+                  "id" : "PANTHER:PTHR24208"
+               },
+               {
+                  "id" : "UniProtKB:E9QN32"
+               },
+               {
+                  "id" : "UniProtKB:H3BLG4"
+               },
+               {
+                  "id" : "UniProtKB:H9H9T0"
+               },
+               {
+                  "id" : "UniProtKB:Q3UED5"
+               },
+               {
+                  "id" : "UniProtKB:Q8C1U0"
+               },
+               {
+                  "id" : "UniProtKB:Q9R1R0"
+               },
+               {
+                  "id" : "MGI:1306803",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:LHX6"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "2",
+                  "endPosition" : 36105408,
+                  "startPosition" : 36081953,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:1306803",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygous mutation of this gene results in impaired migration and specification of cortical interneurons, postnatal lethality and weakness. [provided by MGI curators]",
+         "name" : "LIM homeobox protein 6",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Lhx6"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:13509"
+               },
+               {
+                  "id" : "MGI:107510",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:107510",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-36080"
+            ],
+            "synonyms" : [
+               "dsc"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "declival sulcus of cerebellum",
+         "soTermId" : "SO:0001500",
+         "symbol" : "dscb"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:20691"
+               },
+               {
+                  "id" : "MGI:102786",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:102786",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-19694"
+            ],
+            "synonyms" : [
+               "MAb 4A11"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "sperm peptide antigen",
+         "soTermId" : "SO:0000704",
+         "symbol" : "Span"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:107960"
+               },
+               {
+                  "id" : "MGI:109371",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:109371",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-38416"
+            ],
+            "synonyms" : [
+               "mouse homolog of bLAP"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "heterochromatin protein 1, binding protein 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Hp1bp1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:104142"
+               },
+               {
+                  "id" : "MGI:96772",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:96772",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-11785",
+               "MGD_old:MGD-MRK-11787"
+            ],
+            "synonyms" : [
+               "Len-2",
+               "eye lens protein 2 (beta-crystallin-like)",
+               "protein 2 (beta-crystallin-like)"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Len2 encodes a 23kDa major lens protein similar to beta-crystallin, synthesized from embryonic day 14 to postnatal day 14. Variation is seen by isolelectric focusing: the a allele in O20/A, M.m. molossinus and in wild mice from California and Peru; the ballele in all other strains tested. [provided by MGI curators]",
+         "name" : "eye lens protein 2",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Len2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:20767"
+               },
+               {
+                  "id" : "MGI:98390",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:98390",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-14546",
+               "MGD_old:MGD-MRK-8817"
+            ],
+            "synonyms" : [
+               "dd",
+               "drop dead"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mutations in this gene result in neurological and convulsive behaviors resulting in early death. [provided by MGI curators]",
+         "name" : "spontaneous seizure",
+         "soTermId" : "SO:0001500",
+         "symbol" : "sps"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:19412"
+               },
+               {
+                  "id" : "MGI:97859",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:97859",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-13769",
+               "MGD_old:MGD-MRK-1428"
+            ],
+            "synonyms" : [
+               "asr",
+               "audiogenic seizure resistance"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice homozygous for a spontaneous allele display spontaneous and intermittent spike waves in brain wave recordings after a sound stimulus, but are not susceptible to audiogenic seizures. [provided by MGI curators]",
+         "name" : "resistance to audiogenic seizures",
+         "soTermId" : "SO:0001500",
+         "symbol" : "ras"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:16748"
+               },
+               {
+                  "id" : "MGI:96729",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "1"
+               }
+            ],
+            "primaryId" : "MGI:96729",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-11674",
+               "MGD_old:MGD-MRK-11717"
+            ],
+            "synonyms" : [
+               "l(1)-7Rk"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice homozygous for this chemically-induced mutation exhibit prenatal lethality. [provided by MGI curators]",
+         "name" : "lethal, Chr 1, Roderick 7",
+         "soTermId" : "SO:0001500",
+         "symbol" : "l1Rk7"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:109603"
+               },
+               {
+                  "id" : "MGI:95422",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "8"
+               }
+            ],
+            "primaryId" : "MGI:95422",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-9590",
+               "MGD_old:MGD-MRK-9623"
+            ],
+            "synonyms" : [
+               "Es-11"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: This locus controls polymorphism of a carboxylesterase in liver, kidney and small intestine. The a allele occurs in C57BL, BALB/c and other inbreds; the b allele in IS/Cam and many wild mice; the c allele in M. spretus; the d allele in M. m. molossinus. [provided by MGI curators]",
+         "name" : "esterase 11",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Es11"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:104244"
+               },
+               {
+                  "id" : "MGI:98396",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "14"
+               }
+            ],
+            "primaryId" : "MGI:98396",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-14554",
+               "MGD_old:MGD-MRK-14555"
+            ],
+            "synonyms" : [
+               "Sr-1"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: This locus regulates isoelectric focusing (IEF) pattern of the IgG anti-inulin antibodies produced in mice bearing the a haplotype of Igh. The a allele in BALB/c determines a single spectrotype by IEF. The b allele of C57BL/6, when carried by Igha-bearing mice, determines a more complex pattern. [provided by MGI curators]",
+         "name" : "spectrotype regulation",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Sr1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3780192",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "4",
+                  "endPosition" : 42756365,
+                  "startPosition" : 42754525,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:3780192",
+            "secondaryIds" : [
+               "MGI:3779198",
+               "MGI:3779199"
+            ],
+            "synonyms" : [
+               "100039053",
+               "ENSMUSG00000078736",
+               "ENSMUSG00000078738",
+               "predicted gene, 100039053",
+               "predicted gene, ENSMUSG00000078736",
+               "predicted gene, ENSMUSG00000078738"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "predicted gene 2023",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Gm2023"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:95571",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:95571",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-9859",
+               "MGD_old:MGD-MRK-9863"
+            ],
+            "synonyms" : [
+               "For-3"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "formamidase 3",
+         "soTermId" : "SO:0001500",
+         "symbol" : "For3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:95572",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:95572",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-9860",
+               "MGD_old:MGD-MRK-9864"
+            ],
+            "synonyms" : [
+               "For-4"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "formamidase 4",
+         "soTermId" : "SO:0001500",
+         "symbol" : "For4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:95430",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:95430",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-9598",
+               "MGD_old:MGD-MRK-9631"
+            ],
+            "synonyms" : [
+               "Es-19"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: This arylesterase (EC 3.1.1.2) differs significantly from other mouse esterases. No electrophoretically detected polymorphism is known. The esterase occurs in many organs, but not in red cells or plasma. Protein is detectable with alpha-naphthyl acetate after inhibition of the comigrating ES7. [provided by MGI curators]",
+         "name" : "esterase 19",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Es19"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:95266",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:95266",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-9270",
+               "MGD_old:MGD-MRK-9281"
+            ],
+            "synonyms" : [
+               "Ea-3"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: This locus controls an antigen present on erythrocytes. The a allele determines presence of the antigen and occurs in strain C57L/J; the b allele determines absence of the antigen and occurs in strains A/Mv, BALB/cDe, C3H/He, and C57BL/10. [provided by MGI curators]",
+         "name" : "erythrocyte antigen 3",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Ea3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:96707",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:96707",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-11662",
+               "MGD_old:MGD-MRK-11664"
+            ],
+            "synonyms" : [
+               "Kth-2"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: The a allele determines a protein of pI 6.8 or higher; the o allele determines absence of protein. These alleles are randomly distributed among inbred strains. [provided by MGI curators]",
+         "name" : "kidney 30-40 thousand Mol. Wt. protein 2",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Kth2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000079491"
+               },
+               {
+                  "id" : "NCBI_Gene:15024"
+               },
+               {
+                  "id" : "MGI:95942",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "17",
+                  "endPosition" : 36121444,
+                  "startPosition" : 36115871,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:95942",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-10425",
+               "MGD_old:MGD-MRK-10538"
+            ],
+            "synonyms" : [
+               "H-2T10"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "histocompatibility 2, T region locus 10",
+         "soTermId" : "SO:0001841",
+         "symbol" : "H2-T10"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:108196"
+               },
+               {
+                  "id" : "MGI:97557",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "17"
+               }
+            ],
+            "primaryId" : "MGI:97557",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-13260",
+               "MGD_old:MGD-MRK-13268"
+            ],
+            "synonyms" : [
+               "Pgk-1ps2"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "phosphoglycerate kinase 1, pseudogene 2",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Pgk1-ps2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000060600"
+               },
+               {
+                  "id" : "NCBI_Gene:13808"
+               },
+               {
+                  "id" : "PANTHER:PTHR11902"
+               },
+               {
+                  "id" : "UniProtKB:J3QPZ9"
+               },
+               {
+                  "id" : "UniProtKB:P21550"
+               },
+               {
+                  "id" : "UniProtKB:Q4FK59"
+               },
+               {
+                  "id" : "UniProtKB:Q5SX59"
+               },
+               {
+                  "id" : "UniProtKB:Q5SX60"
+               },
+               {
+                  "id" : "UniProtKB:Q5SX61"
+               },
+               {
+                  "id" : "MGI:95395",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:ENO3"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "11",
+                  "endPosition" : 70662513,
+                  "startPosition" : 70657202,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:95395",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-9505",
+               "MGD_old:MGD-MRK-9508"
+            ],
+            "synonyms" : [
+               "Eno-3"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "enolase 3, beta muscle",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Eno3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:108246"
+               },
+               {
+                  "id" : "MGI:87903",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:87903",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-1085",
+               "MGD_old:MGD-MRK-1086"
+            ],
+            "synonyms" : [
+               "Acta2-rs1",
+               "actin, alpha 2, skeletal muscle related sequence 1"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "actin, alpha 1, skeletal muscle related sequence 1",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Acta1-rs1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:104210"
+               },
+               {
+                  "id" : "MGI:105040",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:105040",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-1228",
+               "MGD_old:MGD-MRK-1232",
+               "MGD_old:MGD-MRK-32079"
+            ],
+            "synonyms" : [
+               "Ahr-4",
+               "Ahr4"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "aldehyde reductase 4",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Aldr4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:103958"
+               },
+               {
+                  "id" : "MGI:103066",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:103066",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-13931",
+               "MGD_old:MGD-MRK-13943",
+               "MGD_old:MGD-MRK-23928"
+            ],
+            "synonyms" : [
+               "7S RNA-4a",
+               "Rn7s-4a",
+               "Rn7s4a"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "7S RNA 4",
+         "soTermId" : "SO:0001269",
+         "symbol" : "Rn7s4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:15570"
+               },
+               {
+                  "id" : "MGI:96286",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:96286",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-11014"
+            ],
+            "synonyms" : [
+               "jaundice"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mutations in this gene produce jaudice in newborn mice, male infertility and abnormal maternal behavior. [provided by MGI curators]",
+         "name" : "hyper-unconjugated bilirubinemia",
+         "soTermId" : "SO:0001500",
+         "symbol" : "hubb"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:107485"
+               },
+               {
+                  "id" : "MGI:88419",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:88419",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-2010"
+            ],
+            "synonyms" : [
+               "H-9"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mutant animals exhibit closed eyes and microphthalmia. [provided by MGI curators]",
+         "name" : "closed eyes and microphthalmia",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Cle"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:103993"
+               },
+               {
+                  "id" : "MGI:88210",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:88210",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-1676"
+            ],
+            "synonyms" : [
+               "splenic lipofuscinosis"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygotes and heterozygotes have lipofuscin (black pigment) in the anterior end of the spleen. [provided by MGI curators]",
+         "name" : "black spleen",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Bsp"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:105243804"
+               },
+               {
+                  "id" : "MGI:5622456",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "11"
+               }
+            ],
+            "primaryId" : "MGI:5622456",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "predicted gene, 39571",
+         "soTermId" : "SO:0002127",
+         "symbol" : "Gm39571"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:105244366"
+               },
+               {
+                  "id" : "MGI:5622874",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "11"
+               }
+            ],
+            "primaryId" : "MGI:5622874",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "predicted gene, 39989",
+         "soTermId" : "SO:0002127",
+         "symbol" : "Gm39989"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:71413"
+               },
+               {
+                  "id" : "MGI:1918663",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "17",
+                  "endPosition" : 35263604,
+                  "startPosition" : 35262269,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:1918663",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "RIKEN cDNA 5430410E06 gene",
+         "soTermId" : "SO:0002127",
+         "symbol" : "5430410E06Rik"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000034832"
+               },
+               {
+                  "id" : "NCBI_Gene:194388"
+               },
+               {
+                  "id" : "PANTHER:PTHR23358"
+               },
+               {
+                  "id" : "UniProtKB:A0A087WP90"
+               },
+               {
+                  "id" : "UniProtKB:A0A5K1VVP6"
+               },
+               {
+                  "id" : "UniProtKB:Q80U11"
+               },
+               {
+                  "id" : "UniProtKB:Q8BG87"
+               },
+               {
+                  "id" : "UniProtKB:Q8BNB2"
+               },
+               {
+                  "id" : "MGI:2446229",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "6",
+                  "endPosition" : 83457208,
+                  "startPosition" : 83362373,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:2446229",
+            "secondaryIds" : [
+               "MGI:2444739"
+            ],
+            "synonyms" : [
+               "B430006D22Rik",
+               "BC037432",
+               "D230004J03Rik",
+               "RIKEN cDNA B430006D22 gene",
+               "RIKEN cDNA D230004J03 gene",
+               "cDNA sequence BC037432"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice inheriting a null allele from a germ cell conditional null mother display impaired reprogramming of the paternal genome resulting in reduced embryo viability. [provided by MGI curators]",
+         "name" : "tet methylcytosine dioxygenase 3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tet3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000032717"
+               },
+               {
+                  "id" : "NCBI_Gene:17240"
+               },
+               {
+                  "id" : "PANTHER:PTHR15304"
+               },
+               {
+                  "id" : "UniProtKB:D3YUT8"
+               },
+               {
+                  "id" : "UniProtKB:D3YVA0"
+               },
+               {
+                  "id" : "UniProtKB:D3YZ53"
+               },
+               {
+                  "id" : "UniProtKB:D3Z3N7"
+               },
+               {
+                  "id" : "UniProtKB:D3Z6Q8"
+               },
+               {
+                  "id" : "UniProtKB:P70331"
+               },
+               {
+                  "id" : "MGI:107687",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:MDFI"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "17",
+                  "endPosition" : 47834691,
+                  "startPosition" : 47815328,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:107687",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-36262"
+            ],
+            "synonyms" : [
+               "I-mf",
+               "I-mfa"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygotes for a targeted null mutation on a C57BL/6 background exhibit a placental defect and die around embryonic day 10.5, but on a 129/Sv background, mutants survive to adulthood and show delayed caudal neural tube closure and skeletal abnormalities. [provided by MGI curators]",
+         "name" : "MyoD family inhibitor",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Mdfi"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000089704"
+               },
+               {
+                  "id" : "NCBI_Gene:108148"
+               },
+               {
+                  "id" : "PANTHER:PTHR11675"
+               },
+               {
+                  "id" : "UniProtKB:Q6PB93"
+               },
+               {
+                  "id" : "MGI:894694",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/phenotype",
+                     "gene/phenotypes_impc"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:GALNT2"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "8",
+                  "endPosition" : 124345722,
+                  "startPosition" : 124231394,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:894694",
+            "secondaryIds" : [
+               "MGI:2142569"
+            ],
+            "synonyms" : [
+               "AI480629",
+               "expressed sequence AI480629",
+               "ppGaNTase-T2"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice homozygous for a knock-out allele exhibit decreased circulating HDL cholesterol levels under both chow- and Western diet-fed conditions, a marked elevation in fasting triglyceride levels, and delayed postprandial triglyceride clearance.   [provided by MGI curators]",
+         "name" : "polypeptide N-acetylgalactosaminyltransferase 2",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Galnt2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3575186",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:3575186",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mutant mice are obese and exhibit increased body weight and percent body fat after consuming an atherogenic diet. [provided by MGI curators]",
+         "name" : "heart, lung and blood 230",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Hlb230"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:5490291",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:5490291",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice carrying this mutation are described as passive. [provided by MGI curators]",
+         "name" : "Genetics Harwell, 144",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Gena144"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:5425982",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:5425982",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice homozygous for an ENU-induced allele exhibit decreased circulating phosphate level. [provided by MGI curators]",
+         "name" : "bone phosphate low mutant 011",
+         "soTermId" : "SO:0001500",
+         "symbol" : "BPL011"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3038446",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:3038446",
+            "synonyms" : [
+               "Ska12",
+               "Ska<m12Jus>",
+               "misplaced tail"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Heterozygous mice exhibit abnormal tail placement, a wavy tail, and hyperactivity. [provided by MGI curators]",
+         "name" : "skeletal/axial 12",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Skax12"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:2682685",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:2682685",
+            "synonyms" : [
+               "Gsfkta32",
+               "gsf kinked tail 32"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mutant mice have a kinked tail. [provided by MGI curators]",
+         "name" : "Martin Hrabe de Angelis kinked tail 32",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Mhdakta32"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:2682683",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:2682683",
+            "synonyms" : [
+               "Gsfkta30",
+               "gsf kinked tail 30"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mutant mice have a kinked tail. [provided by MGI curators]",
+         "name" : "Martin Hrabe de Angelis kinked tail 30",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Mhdakta30"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:5515454",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "13"
+               }
+            ],
+            "primaryId" : "MGI:5515454",
+            "synonyms" : [
+               "line 1073"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice hemizygous for this mutation exhibit craniofacial and neurological defects. Mice heterozygous for this mutation exhibit decreased anxiety-related response. [provided by MGI curators]",
+         "name" : "mutant 1073b",
+         "soTermId" : "SO:0001500",
+         "symbol" : "M1073b"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:5629529",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "9"
+               }
+            ],
+            "primaryId" : "MGI:5629529",
+            "synonyms" : [
+               "WBS012"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice heterozygous for an ENU-induced mutation at this locus exhibit a white belly spot. [provided by MGI curators]",
+         "name" : "Martin Hrabe de Angelis white belly spot 12",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Mhdawbs12"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3589219",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "15"
+               }
+            ],
+            "primaryId" : "MGI:3589219",
+            "synonyms" : [
+               "158TNR"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygotes for this ENU-induced mutation exhibit increased preference and consumption of alcohol. [provided by MGI curators]",
+         "name" : "Tennessee Mouse Genome Consortium 49",
+         "soTermId" : "SO:0001500",
+         "symbol" : "tmgc49"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:98375",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:98375",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-14519"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "sphaerozytose",
+         "soTermId" : "SO:0001500",
+         "symbol" : "sph-(H)"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:98323",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:98323",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-14448"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "small ear",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Sme"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:96627",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:96627",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-11514"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "jaw lethal",
+         "soTermId" : "SO:0001500",
+         "symbol" : "j"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000095586"
+               },
+               {
+                  "id" : "NCBI_Gene:257935"
+               },
+               {
+                  "id" : "UniProtKB:Q7TQY1"
+               },
+               {
+                  "id" : "MGI:3031121",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "2",
+                  "endPosition" : 111450059,
+                  "startPosition" : 111449142,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:3031121",
+            "synonyms" : [
+               "GA_x6K02T2Q125-72500603-72501520",
+               "MOR248-15"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "olfactory receptor 1287",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Olfr1287"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000090778"
+               },
+               {
+                  "id" : "NCBI_Gene:100041254"
+               },
+               {
+                  "id" : "MGI:3781413",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "8",
+                  "endPosition" : 91629729,
+                  "startPosition" : 91621448,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:3781413",
+            "synonyms" : [
+               "100041254",
+               "predicted gene, 100041254"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "predicted gene 3235",
+         "soTermId" : "SO:0002127",
+         "symbol" : "Gm3235"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000065617"
+               },
+               {
+                  "id" : "NCBI_Gene:723839"
+               },
+               {
+                  "id" : "MGI:3619334",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "12",
+                  "endPosition" : 109712593,
+                  "startPosition" : 109712508,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:3619334",
+            "synonyms" : [
+               "Mirn323",
+               "mir 323",
+               "mmu-mir-323"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "microRNA 323",
+         "soTermId" : "SO:0001265",
+         "symbol" : "Mir323"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:23915"
+               },
+               {
+                  "id" : "MGI:1345617",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:1345617",
+            "synonyms" : [
+               "F23"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "induced in fatty liver dystrophy 4",
+         "soTermId" : "SO:0000704",
+         "symbol" : "Ifld4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:387148"
+               },
+               {
+                  "id" : "MGI:2676814",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:2676814",
+            "synonyms" : [
+               "Mirn129"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "microRNA 129",
+         "soTermId" : "SO:0001265",
+         "symbol" : "Mir129"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:613124"
+               },
+               {
+                  "id" : "MGI:3580634",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:3580634",
+            "synonyms" : [
+               "A6P'"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "UDP glucuronosyltransferase 1 family, polypeptide A7A, pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Ugt1a7a-ps"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:12016"
+               },
+               {
+                  "id" : "MGI:99827",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "4"
+               }
+            ],
+            "primaryId" : "MGI:99827",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-16613"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygous deletion of baf results in runting during postnatal development. [provided by MGI curators]",
+         "name" : "b-associated fitness",
+         "soTermId" : "SO:0001500",
+         "symbol" : "baf"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000003665"
+               },
+               {
+                  "id" : "NCBI_Gene:15116"
+               },
+               {
+                  "id" : "PANTHER:PTHR22913"
+               },
+               {
+                  "id" : "UniProtKB:Q05A37"
+               },
+               {
+                  "id" : "UniProtKB:Q3UUP6"
+               },
+               {
+                  "id" : "UniProtKB:Q61647"
+               },
+               {
+                  "id" : "UniProtKB:Q8BPN0"
+               },
+               {
+                  "id" : "MGI:106590",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:HAS1"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "17",
+                  "endPosition" : 17855205,
+                  "startPosition" : 17843323,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:106590",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-35046"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice homozygous for a knock-out allele are viable and appear grossly normal. [provided by MGI curators]",
+         "name" : "hyaluronan synthase 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Has1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:11885"
+               },
+               {
+                  "id" : "MGI:88078",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "14"
+               }
+            ],
+            "primaryId" : "MGI:88078",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-1408"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: This gene controls anti-sarcolemma autoantibody response to coxsackievirus B3-induced myocarditis. A/J carries the recessive responsive form. [provided by MGI curators]",
+         "name" : "anti-sarcolemmal autoantibodies",
+         "soTermId" : "SO:0001500",
+         "symbol" : "asa"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:2670248",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "15"
+               }
+            ],
+            "primaryId" : "MGI:2670248",
+            "secondaryIds" : [
+               "MGI:2448635"
+            ],
+            "synonyms" : [
+               "l15R6",
+               "lethal, Chr 15, Oak Ridge 6"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mutant mice display postnatal lethality, balance abnormalities, and abnormal cerebellar foliation. [provided by MGI curators]",
+         "name" : "Tennessee Mouse Genome Consortium 32",
+         "soTermId" : "SO:0001500",
+         "symbol" : "tmgc32"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3850508",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "1"
+               }
+            ],
+            "primaryId" : "MGI:3850508",
+            "secondaryIds" : [
+               "MGI:3849162"
+            ],
+            "synonyms" : [
+               "EN1",
+               "m1Haro",
+               "mutation 1, Howard A Rockman"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygotes for this ENU-induced mutation exhibit dilated cardiomyopathy, increase in left ventricle end diastolic and end systolic diameters, and reduced fractional shortening. [provided by MGI curators]",
+         "name" : "cardiomyopathy 1",
+         "soTermId" : "SO:0001500",
+         "symbol" : "cmy1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:2387751",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "4",
+                  "endPosition" : 67182171,
+                  "startPosition" : 45658442,
+                  "strand" : "."
+               }
+            ],
+            "primaryId" : "MGI:2387751",
+            "secondaryIds" : [
+               "MGI:3686749"
+            ],
+            "synonyms" : [
+               "GENA 243",
+               "Gena243",
+               "Genetics Harwell, 243"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice heterozygous for this ENU-induced mutation exhibit decreased circulating total and HDL cholesterol levels. [provided by MGI curators]",
+         "name" : "low cholesterol 2",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Lch2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:5477310",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "8"
+               }
+            ],
+            "primaryId" : "MGI:5477310",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "predicted gene, 26816",
+         "soTermId" : "SO:0002127",
+         "symbol" : "Gm26816"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:5508089",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "17"
+               }
+            ],
+            "primaryId" : "MGI:5508089",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "predicted gene 27138",
+         "soTermId" : "SO:0000704",
+         "symbol" : "Gm27138"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:5508025",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "3"
+               }
+            ],
+            "primaryId" : "MGI:5508025",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "predicted gene 27074",
+         "soTermId" : "SO:0000704",
+         "symbol" : "Gm27074"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:107927"
+               },
+               {
+                  "id" : "MGI:96279",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:96279",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-11005"
+            ],
+            "synonyms" : [
+               "5-hydroxytryptamine (serotonin) receptor 1E alpha",
+               "Htr1ea"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "5-hydroxytryptamine (serotonin) receptor 1E",
+         "soTermId" : "SO:0000704",
+         "symbol" : "Htr1e"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:22135"
+               },
+               {
+                  "id" : "PANTHER:PTHR23211"
+               },
+               {
+                  "id" : "UniProtKB:Q3ULZ6"
+               },
+               {
+                  "id" : "UniProtKB:Q62314"
+               },
+               {
+                  "id" : "MGI:105079",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:TGOLN2"
+               }
+            ],
+            "primaryId" : "MGI:105079",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-32119"
+            ],
+            "synonyms" : [
+               "TGN38B",
+               "TGN41",
+               "TGN46",
+               "Ttgn2"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "trans-golgi network protein 2",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tgoln2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:108181"
+               },
+               {
+                  "id" : "MGI:98119",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:98119",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-14145"
+            ],
+            "synonyms" : [
+               "Rps16-ps",
+               "ribosomal protein S16 pseudogene",
+               "ribosomal protein S16, pseudogene"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "ribosomal protein S16, pseudogene 1",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Rps16-ps1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:104347"
+               },
+               {
+                  "id" : "MGI:1298396",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:1298396",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Chlorpromazine impairs performance of mice pre-trained in active avoidance tasks. Two loci control difference in impairment of BALB/cBy and C57BL/By strains. BALB/cBy carries an allele for high chlorpromazine effect and C57BL/6By an allele for low effect. [provided by MGI curators]",
+         "name" : "chlorpromazine avoidance",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Cpza"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:170646"
+               },
+               {
+                  "id" : "MGI:1891009",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:1891009",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Heterozygotes for a spontaneous mutation exhibit progressive hair loss and become hairless, ulcerative skin lesions, vibrissae abnormalities, excessive scratching, and increased mast cells and IgE levels. [provided by MGI curators]",
+         "name" : "Naruto Otsuka atrichia",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Noa"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:245904"
+               },
+               {
+                  "id" : "MGI:2149028",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:2149028",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice homozygous for this ENU-induced mutation display white, non-progressive cataracts and microphthalmia. Heterozygous mutant mice show an early-onset lens clouding which progresses to a white cataract. [provided by MGI curators]",
+         "name" : "lens cloudy",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Lcl"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:15455"
+               },
+               {
+                  "id" : "MGI:96220",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "8",
+                  "endPosition" : 49186665,
+                  "startPosition" : 49184532,
+                  "strand" : "."
+               }
+            ],
+            "primaryId" : "MGI:96220",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-10925"
+            ],
+            "synonyms" : [
+               "HC1"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "human papillomavirus 18 E5 central sequence motif gene 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Hpvc1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000027201"
+               },
+               {
+                  "id" : "NCBI_Gene:17876"
+               },
+               {
+                  "id" : "PANTHER:PTHR23003"
+               },
+               {
+                  "id" : "UniProtKB:Q8C854"
+               },
+               {
+                  "id" : "MGI:104592",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "2",
+                  "endPosition" : 125123661,
+                  "startPosition" : 125084628,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:104592",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-26026"
+            ],
+            "synonyms" : [
+               "mKIAA1341"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "myelin basic protein expression factor 2, repressor",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Myef2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000066463"
+               },
+               {
+                  "id" : "NCBI_Gene:18379"
+               },
+               {
+                  "id" : "UniProtKB:F6ZJR3"
+               },
+               {
+                  "id" : "UniProtKB:G3UY58"
+               },
+               {
+                  "id" : "UniProtKB:G3X9W2"
+               },
+               {
+                  "id" : "UniProtKB:G5E8X8"
+               },
+               {
+                  "id" : "MGI:106620",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "9",
+                  "endPosition" : 78314796,
+                  "startPosition" : 78311972,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:106620",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-35077"
+            ],
+            "synonyms" : [
+               "OM2a"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "oocyte maturation, alpha",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Omt2a"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000029656"
+               },
+               {
+                  "id" : "NCBI_Gene:110382"
+               },
+               {
+                  "id" : "PANTHER:PTHR45742"
+               },
+               {
+                  "id" : "UniProtKB:Q8BH35"
+               },
+               {
+                  "id" : "MGI:88236",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "4",
+                  "endPosition" : 104804548,
+                  "startPosition" : 104766317,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:88236",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-1714",
+               "MGI:1921221",
+               "MGI:2140338"
+            ],
+            "synonyms" : [
+               "4930439B20Rik",
+               "AI595927",
+               "RIKEN cDNA 4930439B20 gene",
+               "expressed sequence AI595927"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: In a controlled microbial environment (\"clean\") laboratory, mice homozygous for an inactivating mutation of this gene are viable and fertile and exhibit no apparent abonormal phenotype. [provided by MGI curators]",
+         "name" : "complement component 8, beta polypeptide",
+         "soTermId" : "SO:0001217",
+         "symbol" : "C8b"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000020017"
+               },
+               {
+                  "id" : "NCBI_Gene:15109"
+               },
+               {
+                  "id" : "PANTHER:PTHR10362"
+               },
+               {
+                  "id" : "UniProtKB:B2RXW1"
+               },
+               {
+                  "id" : "UniProtKB:F8WH73"
+               },
+               {
+                  "id" : "UniProtKB:P35492"
+               },
+               {
+                  "id" : "UniProtKB:Q8CE60"
+               },
+               {
+                  "id" : "UniProtKB:Q9D3I5"
+               },
+               {
+                  "id" : "MGI:96010",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:Histidine ammonia-lyase"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "10",
+                  "endPosition" : 93516761,
+                  "startPosition" : 93488768,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:96010",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-10611",
+               "MGD_old:MGD-MRK-10720",
+               "MGD_old:MGD-MRK-10944"
+            ],
+            "synonyms" : [
+               "Hsd",
+               "his",
+               "histidase",
+               "histidase synthetic rate",
+               "histidinemia"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mutations in this gene cause elevated histidine levels. [provided by MGI curators]",
+         "name" : "histidine ammonia lyase",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Hal"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000026374"
+               },
+               {
+                  "id" : "NCBI_Gene:22099"
+               },
+               {
+                  "id" : "PANTHER:PTHR10741"
+               },
+               {
+                  "id" : "UniProtKB:Q545E6"
+               },
+               {
+                  "id" : "UniProtKB:Q62348"
+               },
+               {
+                  "id" : "MGI:109263",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:TSN (gene)"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "1",
+                  "endPosition" : 118311461,
+                  "startPosition" : 118298514,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:109263",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-38308",
+               "MGI:1916495",
+               "MGI:2138483"
+            ],
+            "synonyms" : [
+               "2610034C24Rik",
+               "AU040286",
+               "RIKEN cDNA 2610034C24 gene",
+               "TB-RBP",
+               "expressed sequence AU040286"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Inactivation of this gene results in reduced female fertility, growth defects, and abnormalities related to activity and dexterity. [provided by MGI curators]",
+         "name" : "translin",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tsn"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:108109"
+               },
+               {
+                  "id" : "MGI:95599",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:95599",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-9899",
+               "MGD_old:MGD-MRK-9905"
+            ],
+            "synonyms" : [
+               "Fv-5"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Alleles at this locus determine response to Friend Virus-P (VF-P) infection. DBA/2, BALB/c and AKR (p allele) show early polycythemia (high hematocrit); CBA/J and C3H (a allele) show early anemic response (low hematocrit). Heterozygotes have slight polycythemia with intermediate hematocrits. [provided by MGI curators]",
+         "name" : "Friend virus P-induced early anemia, polycythemia susceptibility",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Fv5"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:104204"
+               },
+               {
+                  "id" : "MGI:95984",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:95984",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-10456",
+               "MGD_old:MGD-MRK-10580"
+            ],
+            "synonyms" : [
+               "H-36"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: This locus was detected in B6.C congenic strains. C57BL/6By carries the b allele; and BALB/cBy and the congenic carry the c allele. Antigens are present on tail skin and in other tissues. [provided by MGI curators]",
+         "name" : "histocompatibility 36",
+         "soTermId" : "SO:0001217",
+         "symbol" : "H36"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:16931"
+               },
+               {
+                  "id" : "MGI:96808",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:96808",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-11843",
+               "MGD_old:MGD-MRK-11856"
+            ],
+            "synonyms" : [
+               "lop-2"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mutations in this gene result in cataract formation. [provided by MGI curators]",
+         "name" : "lens opacity 2",
+         "soTermId" : "SO:0001500",
+         "symbol" : "lop2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:96749",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "9"
+               }
+            ],
+            "primaryId" : "MGI:96749",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-11748",
+               "MGD_old:MGD-MRK-11750",
+               "MGD_old:MGD-MRK-1330"
+            ],
+            "synonyms" : [
+               "Lap-1"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "leucine arylaminopeptidase 1, intestinal",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Lap1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000032081"
+               },
+               {
+                  "id" : "NCBI_Gene:11814"
+               },
+               {
+                  "id" : "PANTHER:PTHR14225"
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4J1N3"
+               },
+               {
+                  "id" : "UniProtKB:D3YXN8"
+               },
+               {
+                  "id" : "UniProtKB:E9QP56"
+               },
+               {
+                  "id" : "UniProtKB:P33622"
+               },
+               {
+                  "id" : "MGI:88055",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype",
+                     "gene/phenotypes_impc"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:Apolipoprotein C3"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "9",
+                  "endPosition" : 46235636,
+                  "startPosition" : 46233050,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:88055",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-1371",
+               "MGD_old:MGD-MRK-1374"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygotes for a targeted null mutation exhibit reduced fasted triglyceride levels, increased triglyceride secretion rate, and loss of postprandial and obesity-associated hypertriglyceridemia. [provided by MGI curators]",
+         "name" : "apolipoprotein C-III",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Apoc3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000032193"
+               },
+               {
+                  "id" : "NCBI_Gene:16835"
+               },
+               {
+                  "id" : "PANTHER:PTHR24270"
+               },
+               {
+                  "id" : "UniProtKB:A0A1L1SRE8"
+               },
+               {
+                  "id" : "UniProtKB:P35951"
+               },
+               {
+                  "id" : "UniProtKB:Q3TDD1"
+               },
+               {
+                  "id" : "UniProtKB:Q3TVR4"
+               },
+               {
+                  "id" : "UniProtKB:Q3U8R7"
+               },
+               {
+                  "id" : "UniProtKB:Q8CAV5"
+               },
+               {
+                  "id" : "UniProtKB:Q8VCT0"
+               },
+               {
+                  "id" : "UniProtKB:Q91ZJ1"
+               },
+               {
+                  "id" : "MGI:96765",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:LDL receptor"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "9",
+                  "endPosition" : 21749919,
+                  "startPosition" : 21723576,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:96765",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-11774",
+               "MGI:2683059"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygous targeted mutants exhibit 2X higher total plasma cholesterol and 7-9X higher IDL and LDL levels on a normal diet compared to controls. On a high cholesterol diet, mutant effects dramatically increase and mice develop xanthomatosis and atherosclerosis. [provided by MGI curators]",
+         "name" : "low density lipoprotein receptor",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Ldlr"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:108197"
+               },
+               {
+                  "id" : "MGI:97853",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:97853",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-13762"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "RAS related protein 1a, pseudogene 1",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Rap1a-ps1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:108235"
+               },
+               {
+                  "id" : "MGI:101936",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:101936",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-18768"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "small nuclear ribonucleoprotein E, pseudogene 1",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Snrpe-ps1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:108247"
+               },
+               {
+                  "id" : "MGI:106905",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:106905",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-35366"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "RNA, Y1 small cytoplasmic, Ro-associated, pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Rny1-ps"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000029423"
+               },
+               {
+                  "id" : "NCBI_Gene:57749"
+               },
+               {
+                  "id" : "PANTHER:PTHR22891"
+               },
+               {
+                  "id" : "UniProtKB:A0A0G2JEK6"
+               },
+               {
+                  "id" : "UniProtKB:Q9JMB7"
+               },
+               {
+                  "id" : "MGI:1928897",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:PIWIL1"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "5",
+                  "endPosition" : 128755474,
+                  "startPosition" : 128736071,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:1928897",
+            "synonyms" : [
+               "MIWI"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygotes for a targeted null mutation exhibit male sterility due to a block in spermatogenesis beginning at the round spermatid stage. [provided by MGI curators]",
+         "name" : "piwi-like RNA-mediated gene silencing 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Piwil1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000027222"
+               },
+               {
+                  "id" : "NCBI_Gene:18633"
+               },
+               {
+                  "id" : "PANTHER:PTHR13299"
+               },
+               {
+                  "id" : "UniProtKB:Q3TRJ6"
+               },
+               {
+                  "id" : "UniProtKB:Q91XC9"
+               },
+               {
+                  "id" : "MGI:1338829",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:PEX16"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "2",
+                  "endPosition" : 92381217,
+                  "startPosition" : 92374676,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:1338829",
+            "synonyms" : [
+               "peroxisome biogenesis factor 16"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice homozygous for a conditional allele activated in adipose tissue exhibit impaired cold tolerance, decreased energy expenditure, and increased diet-induced obesity. [provided by MGI curators]",
+         "name" : "peroxisomal biogenesis factor 16",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Pex16"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000039315"
+               },
+               {
+                  "id" : "NCBI_Gene:27278"
+               },
+               {
+                  "id" : "PANTHER:PTHR14098"
+               },
+               {
+                  "id" : "UniProtKB:E9PXZ8"
+               },
+               {
+                  "id" : "UniProtKB:Q9QZE2"
+               },
+               {
+                  "id" : "MGI:1351468",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype",
+                     "gene/phenotypes_impc"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "5",
+                  "endPosition" : 38876812,
+                  "startPosition" : 38706462,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:1351468",
+            "synonyms" : [
+               "MIST"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice homozygous for a reporter allele display altered natural killer (NK) T cell physiology and enhanced NK cell cytolysis. Mice homozygous for  knock-out allele display abnormal mast cell physiology as well as enhanced NK cell cytolysis. [provided by MGI curators]",
+         "name" : "cytokine-dependent hematopoietic cell linker",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Clnk"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3033211",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:3033211",
+            "synonyms" : [
+               "MrgC13"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "MAS-related GPR, member C13, pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Mrgprc13-ps"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3033183",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:3033183",
+            "synonyms" : [
+               "MrgA22"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "MAS-related GPR, member A22, pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Mrgpra22-ps"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:5620747",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:5620747",
+            "synonyms" : [
+               "KTA27"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "Martin Hrabe de Angelis kinked tail 27",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Mhdakta27"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3652023",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "7"
+               }
+            ],
+            "primaryId" : "MGI:3652023",
+            "synonyms" : [
+               "OTTMUSG00000016591",
+               "predicted gene, OTTMUSG00000016591"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "predicted gene 14423",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Gm14423"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3805555",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "16"
+               }
+            ],
+            "primaryId" : "MGI:3805555",
+            "synonyms" : [
+               "OTTMUSG00000024784",
+               "predicted gene, OTTMUSG00000024784"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "predicted gene 15646",
+         "soTermId" : "SO:0002182",
+         "symbol" : "Gm15646"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3649257",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "11"
+               }
+            ],
+            "primaryId" : "MGI:3649257",
+            "synonyms" : [
+               "OTTMUSG00000000040",
+               "predicted gene, OTTMUSG00000000040"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "predicted gene 11187",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Gm11187"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:2669973",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "15"
+               }
+            ],
+            "primaryId" : "MGI:2669973",
+            "synonyms" : [
+               "22-TNJ",
+               "22TNJ-2"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mutant mice display hyperactive behavior in an open field test and in response to ethanol. [provided by MGI curators]",
+         "name" : "Tennessee Mouse Genome Consortium 20",
+         "soTermId" : "SO:0001500",
+         "symbol" : "tmgc20"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3038443",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "6"
+               }
+            ],
+            "primaryId" : "MGI:3038443",
+            "synonyms" : [
+               "Ska9",
+               "Ska<m09Jus>",
+               "dino toe 2"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Heterozygous mice exhibit syndactyly of the 2nd/3rd digits on the hind feet. [provided by MGI curators]",
+         "name" : "skeletal/axial 9",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Skax9"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3764933",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "X"
+               }
+            ],
+            "primaryId" : "MGI:3764933",
+            "synonyms" : [
+               "Pafl",
+               "patchy fur-like"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygous females and hemizygous males appear almost bald. Heterozygotes exhibit focal hair loss. [provided by MGI curators]",
+         "name" : "bad hair day",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Bhrd"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:97943",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "17",
+                  "endPosition" : 39848200,
+                  "startPosition" : 39845170,
+                  "strand" : "."
+               }
+            ],
+            "primaryId" : "MGI:97943",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-13919"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "18S ribosomal RNA",
+         "soTermId" : "SO:0001637",
+         "symbol" : "Rn18s"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:98572",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "14"
+               }
+            ],
+            "primaryId" : "MGI:98572",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-14864"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "T cell receptor alpha, variable 8",
+         "soTermId" : "SO:3000000",
+         "symbol" : "Tcra-V8"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:99746",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "14"
+               }
+            ],
+            "primaryId" : "MGI:99746",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-16532"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "T cell receptor alpha, variable 2.1",
+         "soTermId" : "SO:3000000",
+         "symbol" : "Tcra-V2.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:5620729",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:5620729",
+            "synonyms" : [
+               "HWE008"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice heterozygous for an ENU-induced mutation at this locus achieve heavier weights postnatally than wild-type controls. [provided by MGI curators]",
+         "name" : "Martin Hrabe de Angelis heavy weight 8",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Mhdahwe8"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:2671615",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:2671615",
+            "synonyms" : [
+               "ruby eye m1Jus"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: A mutation in this unidentified gene results in a diluted coat color phenotype and dark red eyes in homozygotes. [provided by MGI curators]",
+         "name" : "skin/coat color 22",
+         "soTermId" : "SO:0001500",
+         "symbol" : "skc22"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3815176",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:3815176",
+            "synonyms" : [
+               "M101475"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice with a mutation of this gene have curly vibrissae. [provided by MGI curators]",
+         "name" : "RIKEN Genomic Sciences Center (GSC), 1475",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Rgsc1475"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:732537"
+               },
+               {
+                  "id" : "MGI:3629696",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:3629696",
+            "synonyms" : [
+               "Gt(Ayu21)50Imeg",
+               "GtAyu21-50"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "gene trap 50, Institute of Molecular Embryology and Genetics",
+         "soTermId" : "SO:0000704",
+         "symbol" : "Gt(pU21)50Imeg"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:100124455"
+               },
+               {
+                  "id" : "MGI:3718559",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:3718559",
+            "synonyms" : [
+               "Mirn714",
+               "mmu-mir-714"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "microRNA  714",
+         "soTermId" : "SO:0001265",
+         "symbol" : "Mir714"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:732519"
+               },
+               {
+                  "id" : "MGI:3629687",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:3629687",
+            "synonyms" : [
+               "Gt(Ayu21)11Imeg",
+               "GtAyu21-11"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "gene trap 11, Institute of Molecular Embryology and Genetics",
+         "soTermId" : "SO:0000704",
+         "symbol" : "Gt(pU21)11Imeg"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000104804"
+               },
+               {
+                  "id" : "NCBI_Gene:102466996"
+               },
+               {
+                  "id" : "MGI:5562773",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "6",
+                  "endPosition" : 127788143,
+                  "startPosition" : 127788084,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:5562773",
+            "synonyms" : [
+               "mmu-mir-7233"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "microRNA 7233",
+         "soTermId" : "SO:0001265",
+         "symbol" : "Mir7233"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000048824"
+               },
+               {
+                  "id" : "NCBI_Gene:230143"
+               },
+               {
+                  "id" : "UniProtKB:Q8R022"
+               },
+               {
+                  "id" : "MGI:2685414",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "4",
+                  "endPosition" : 47010781,
+                  "startPosition" : 47008316,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:2685414",
+            "synonyms" : [
+               "LOC230143"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "predicted gene 568",
+         "soTermId" : "SO:0002127",
+         "symbol" : "Gm568"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000063507"
+               },
+               {
+                  "id" : "NCBI_Gene:115489557"
+               },
+               {
+                  "id" : "UniProtKB:D3Z460"
+               },
+               {
+                  "id" : "UniProtKB:F6TZH1"
+               },
+               {
+                  "id" : "UniProtKB:Q6IE35"
+               },
+               {
+                  "id" : "MGI:2686176",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "2",
+                  "endPosition" : 148999336,
+                  "startPosition" : 148996797,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:2686176",
+            "synonyms" : [
+               "LOC383753"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "predicted gene 1330",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Gm1330"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:18462"
+               },
+               {
+                  "id" : "MGI:97469",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:97469",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-13121"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygotes are either stillborn or die within hours of birth displaying severe shortening of the extremities, a smaller head with a reduction in maxillary and mandibular growth, a shortened intestine, and rib and vertebral column defects as well as a large median cleft palate and chondrodystrophy. [provided by MGI curators]",
+         "name" : "paddle",
+         "soTermId" : "SO:0001500",
+         "symbol" : "pad"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:104310"
+               },
+               {
+                  "id" : "MGI:97743",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:97743",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-13584"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mutations in this gene result in ovulation of a high proportion of oocytes as diploid primary oocytes resulting in a high incidence of triploid embryos at fertilization. [provided by MGI curators]",
+         "name" : "primary oocyte ovulation",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Poo"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:104017"
+               },
+               {
+                  "id" : "MGI:95319",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:95319",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-9362"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice carrying this phenotypic allele exhibit cataracts at 6 to 8 months of age. [provided by MGI curators]",
+         "name" : "Emory cataract",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Em"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:108180"
+               },
+               {
+                  "id" : "MGI:97984",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "19"
+               }
+            ],
+            "primaryId" : "MGI:97984",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-13986",
+               "MGD_old:MGD-MRK-13992"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "U3B small nuclear RNA pseudogene 6",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Rnu3b-ps6"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:111236"
+               },
+               {
+                  "id" : "MGI:96225",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "7"
+               }
+            ],
+            "primaryId" : "MGI:96225",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-10932",
+               "MGD_old:MGD-MRK-19425"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "Harvey rat sarcoma virus oncogene, pseudogene 1",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Hras1-ps1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:108178"
+               },
+               {
+                  "id" : "MGI:97982",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "10"
+               }
+            ],
+            "primaryId" : "MGI:97982",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-13984",
+               "MGD_old:MGD-MRK-13990"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "U3B small nuclear RNA pseudogene 4",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Rnu3b-ps4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:107456",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "8",
+                  "endPosition" : 92728652,
+                  "startPosition" : 90905517,
+                  "strand" : "."
+               }
+            ],
+            "primaryId" : "MGI:107456",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-35927",
+               "MGI:2142660"
+            ],
+            "synonyms" : [
+               "Ft"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice heterozygous for a deletion caused by transgenic insertional mutagenesis show syndactyly, thymic hyperplasia, and altered thymopoiesis. Homozygotes die by E13.5 showing craniofacial defects, digit anomalies, and abnormal left-right axis formation, brain development, and germ cell proliferation. [provided by MGI curators]",
+         "name" : "fused toes",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Fts"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:95570",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:95570",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-9858",
+               "MGD_old:MGD-MRK-9862"
+            ],
+            "synonyms" : [
+               "For-1",
+               "formamidase 1, liver, kidney"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: This locus controls formamidase activity in liver. a allele strains C3Hf/Rl, 129, DBA, 101, etc. show low activity/heat stability; b allele strains C57BL/10ScSn, BALB/c, SEC, C57BL/6, etc. show high activity/heat stability. Heterozygotes have intermediate activity. [provided by MGI curators]",
+         "name" : "formamidase 1",
+         "soTermId" : "SO:0001500",
+         "symbol" : "For1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:96994",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:96994",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-12252",
+               "MGD_old:MGD-MRK-15338"
+            ],
+            "synonyms" : [
+               "uc",
+               "uncoordinated"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice homozygous for this spontaneous mutation display prenatal and postnatal lethality, a severe loss of myelin, and impaired motor coordination. [provided by MGI curators]",
+         "name" : "myelin-less",
+         "soTermId" : "SO:0001500",
+         "symbol" : "ml"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:96850",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:96850",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-11923",
+               "MGD_old:MGD-MRK-11927"
+            ],
+            "synonyms" : [
+               "Ltw-6",
+               "liver 20-30 thousand M.Wt. protein 6"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: One of many loci showing variation in liver cytosol polypeptides detected by high resolution 2D electrophoresis. Allele a is present in most strains; allele b is found in strains SWR/J, BUB, PL, and MA/My. [provided by MGI curators]",
+         "name" : "liver 20-30 thousand Mol. Wt. protein 6",
+         "soTermId" : "SO:0001500",
+         "symbol" : "Ltw6"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:107601"
+               },
+               {
+                  "id" : "MGI:98843",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:98843",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-15258",
+               "MGD_old:MGD-MRK-15262"
+            ],
+            "synonyms" : [
+               "Ts-3"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "Trichinella spiralis resistance 3",
+         "soTermId" : "SO:0000704",
+         "symbol" : "Ts3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:104301"
+               },
+               {
+                  "id" : "MGI:97781",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:97781",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-13638",
+               "MGD_old:MGD-MRK-13643"
+            ],
+            "synonyms" : [
+               "Prt-6"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "pancreatic proteinase 6",
+         "soTermId" : "SO:0000704",
+         "symbol" : "Prt6"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:104261"
+               },
+               {
+                  "id" : "MGI:97921",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:97921",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-13881",
+               "MGD_old:MGD-MRK-13883"
+            ],
+            "synonyms" : [
+               "Rig-2"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "regulation of Igh-1b 2",
+         "soTermId" : "SO:0000704",
+         "symbol" : "Rig2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000040054"
+               },
+               {
+                  "id" : "NCBI_Gene:116848"
+               },
+               {
+                  "id" : "PANTHER:PTHR45915"
+               },
+               {
+                  "id" : "UniProtKB:A0A1W2P6L0"
+               },
+               {
+                  "id" : "UniProtKB:A0A1W2P6X9"
+               },
+               {
+                  "id" : "UniProtKB:A0A5F8MPQ7"
+               },
+               {
+                  "id" : "UniProtKB:E9Q374"
+               },
+               {
+                  "id" : "UniProtKB:F8VPM0"
+               },
+               {
+                  "id" : "UniProtKB:Q05CX2"
+               },
+               {
+                  "id" : "UniProtKB:Q3UET2"
+               },
+               {
+                  "id" : "UniProtKB:Q3USB1"
+               },
+               {
+                  "id" : "UniProtKB:Q3UXC9"
+               },
+               {
+                  "id" : "UniProtKB:Q3V0H2"
+               },
+               {
+                  "id" : "UniProtKB:Q6PE75"
+               },
+               {
+                  "id" : "UniProtKB:Q80VL8"
+               },
+               {
+                  "id" : "UniProtKB:Q8BRP6"
+               },
+               {
+                  "id" : "UniProtKB:Q8CGH2"
+               },
+               {
+                  "id" : "UniProtKB:Q91YE5"
+               },
+               {
+                  "id" : "MGI:2151152",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype",
+                     "gene/phenotypes_impc"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:BAZ2A"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "10",
+                  "endPosition" : 128129303,
+                  "startPosition" : 128091577,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:2151152",
+            "secondaryIds" : [
+               "MGI:1925788",
+               "MGI:2143475",
+               "MGI:2143919"
+            ],
+            "synonyms" : [
+               "AA415431",
+               "C030005G16Rik",
+               "C78388",
+               "RIKEN cDNA C030005G16 gene",
+               "Tip5",
+               "Walp3",
+               "expressed sequence AA415431",
+               "expressed sequence C78388",
+               "mKIAA0314"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "bromodomain adjacent to zinc finger domain, 2A",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Baz2a"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000102918"
+               },
+               {
+                  "id" : "NCBI_Gene:93706"
+               },
+               {
+                  "id" : "PANTHER:PTHR24028"
+               },
+               {
+                  "id" : "UniProtKB:A0A0A6YWM6"
+               },
+               {
+                  "id" : "UniProtKB:Q4KMN6"
+               },
+               {
+                  "id" : "UniProtKB:Q91XX1"
+               },
+               {
+                  "id" : "MGI:1935201",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/phenotypes_impc"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:PCDHGC3"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "18",
+                  "endPosition" : 37841873,
+                  "startPosition" : 37806410,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:1935201",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-27054",
+               "MGI:104691"
+            ],
+            "synonyms" : [
+               "PC43",
+               "Pcdh2",
+               "protocadherin 2"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "protocadherin gamma subfamily C, 3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Pcdhgc3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000083079"
+               },
+               {
+                  "id" : "NCBI_Gene:545562"
+               },
+               {
+                  "id" : "MGI:104547",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "3",
+                  "endPosition" : 113156727,
+                  "startPosition" : 113147656,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:104547",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-25979",
+               "MGI:3705852"
+            ],
+            "synonyms" : [
+               "Amy-X",
+               "Amy2-2",
+               "OTTMUSG00000022462",
+               "mAmy2-1",
+               "predicted gene, OTTMUSG00000022462"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "amylase 2b",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Amy2b"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:Q6XAS0"
+               },
+               {
+                  "id" : "MGI:2446776",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:2446776",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "synovial sarcoma, X member B7",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Ssxb7"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:71802"
+               },
+               {
+                  "id" : "MGI:1919052",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:1919052",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "RIKEN cDNA 1500010C09 gene",
+         "soTermId" : "SO:0002127",
+         "symbol" : "1500010C09Rik"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:102641880"
+               },
+               {
+                  "id" : "MGI:2181531",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "MGI:2181531",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "mitogen-activated protein kinase 6, pseudogene 1",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Mapk6-ps1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000027420"
+               },
+               {
+                  "id" : "NCBI_Gene:12075"
+               },
+               {
+                  "id" : "PANTHER:PTHR14069"
+               },
+               {
+                  "id" : "UniProtKB:A2AMT1"
+               },
+               {
+                  "id" : "MGI:101770",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:BFSP1"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "2",
+                  "endPosition" : 143863173,
+                  "startPosition" : 143826528,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:101770",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-18577"
+            ],
+            "synonyms" : [
+               "filensin"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mutations in this gene produce lens abnormalities progressing to cataracts. [provided by MGI curators]",
+         "name" : "beaded filament structural protein 1, in lens-CP94",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Bfsp1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000018698"
+               },
+               {
+                  "id" : "NCBI_Gene:16869"
+               },
+               {
+                  "id" : "PANTHER:PTHR24208"
+               },
+               {
+                  "id" : "UniProtKB:A0A087WNK8"
+               },
+               {
+                  "id" : "UniProtKB:A0A0A0MQA9"
+               },
+               {
+                  "id" : "UniProtKB:P63006"
+               },
+               {
+                  "id" : "UniProtKB:Q3URX6"
+               },
+               {
+                  "id" : "UniProtKB:Q569N5"
+               },
+               {
+                  "id" : "UniProtKB:Q8BNR0"
+               },
+               {
+                  "id" : "UniProtKB:Q8CCU9"
+               },
+               {
+                  "id" : "MGI:99783",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:LHX1"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "11",
+                  "endPosition" : 84525535,
+                  "startPosition" : 84518284,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:99783",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-16569"
+            ],
+            "synonyms" : [
+               "Lim1"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygotes for targeted null mutations are small, fail to develop head structures anterior to rhombomere 3 in the hindbrain, lack kidneys and gonads, and show aberrant trajectories of limb motor axons. Most mutants die around embryonic day 10. [provided by MGI curators]",
+         "name" : "LIM homeobox protein 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Lhx1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSMUSG00000027009"
+               },
+               {
+                  "id" : "NCBI_Gene:16401"
+               },
+               {
+                  "id" : "PANTHER:PTHR23220"
+               },
+               {
+                  "id" : "UniProtKB:Q00651"
+               },
+               {
+                  "id" : "UniProtKB:Q3TAI7"
+               },
+               {
+                  "id" : "UniProtKB:Q3U0V9"
+               },
+               {
+                  "id" : "UniProtKB:Q3U1F2"
+               },
+               {
+                  "id" : "UniProtKB:Q6NV53"
+               },
+               {
+                  "id" : "UniProtKB:Q78E20"
+               },
+               {
+                  "id" : "UniProtKB:Q792F9"
+               },
+               {
+                  "id" : "UniProtKB:Q8BQ25"
+               },
+               {
+                  "id" : "UniProtKB:T2HRB1"
+               },
+               {
+                  "id" : "MGI:96603",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+               {
+                  "id" : "WIKIP:CD49d"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "2",
+                  "endPosition" : 79333114,
+                  "startPosition" : 79255426,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:96603",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-11482"
+            ],
+            "synonyms" : [
+               "VLA-4 receptor, alpha 4 subunit"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice homozygous for disruptions in this gene exhibit embryonic lethality either due to failure of chorioallantoic fusion or cardiac abnormalities, including hemorrhage around the heart and defects in epicardium formation. [provided by MGI curators]",
+         "name" : "integrin alpha 4",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Itga4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:5446199",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "11"
+               }
+            ],
+            "primaryId" : "MGI:5446199",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Mice heterozygous for an ENU-induced allele exhibit excessive production of platelets following 5-FU treatment. [provided by MGI curators]",
+         "name" : "mutation 7325, William L Stanford",
+         "soTermId" : "SO:0001500",
+         "symbol" : "M7325Wlst"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3708136",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "10"
+               }
+            ],
+            "primaryId" : "MGI:3708136",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygous mice with this mutation exhibit a low auditory startle response and are severely hearing impaired. [provided by MGI curators]",
+         "name" : "salsa rueda",
+         "soTermId" : "SO:0001500",
+         "symbol" : "salr"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:3708257",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/phenotype"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "9",
+                  "endPosition" : 56901655,
+                  "startPosition" : 50753738,
+                  "strand" : "."
+               }
+            ],
+            "primaryId" : "MGI:3708257",
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "PHENOTYPE: Homozygotes for this ENU-induced mutation exhibit male and female infertility. Males have low testis and seminal vesicle weight, azoospermia, and arrest of male meiosis. Females have small ovaries and sometimes hemorrhagic cysts in the ovaries. [provided by MGI curators]",
+         "name" : "reproductive mutant 46, JAX Reproductive Mutagenesis Program",
+         "soTermId" : "SO:0001500",
+         "symbol" : "repro46"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:104300",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "",
+                  "chromosome" : "X"
+               }
+            ],
+            "primaryId" : "MGI:104300",
+            "secondaryIds" : [
+               "MGD_old:MGD-MRK-25628"
+            ],
+            "synonyms" : [
+               "Hmg1-rs14",
+               "high mobility group protein 1, related sequence 14"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "high mobility group box 1, related sequence 14",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Hmgb1-rs14"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:1922053",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "15",
+                  "endPosition" : 76295129,
+                  "startPosition" : 76294267,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "MGI:1922053",
+            "secondaryIds" : [
+               "MGI:3035037"
+            ],
+            "synonyms" : [
+               "AU015352",
+               "expressed sequence AU015352"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "RIKEN cDNA 4930551A22 gene",
+         "soTermId" : "SO:0002127",
+         "symbol" : "4930551A22Rik"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "MGI:2141497",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCm38",
+                  "chromosome" : "6",
+                  "endPosition" : 21236156,
+                  "startPosition" : 21233598,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "MGI:2141497",
+            "secondaryIds" : [
+               "MGI:2141701"
+            ],
+            "synonyms" : [
+               "AI848395",
+               "AW554807",
+               "expressed sequence AI848395",
+               "expressed sequence AW554807"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "name" : "RIKEN cDNA 6430519N07 gene",
+         "soTermId" : "SO:0002127",
+         "symbol" : "6430519N07Rik"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000032542"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000029443"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000004196"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000028939"
+               },
+               {
+                  "id" : "NCBI_Gene:108352650"
+               },
+               {
+                  "id" : "PANTHER:PTHR12010"
+               },
+               {
+                  "id" : "UniProtKB:P62275"
+               },
+               {
+                  "id" : "RGD:11376557",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "13",
+                  "endPosition" : 91334323,
+                  "startPosition" : 91333998,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "6",
+                  "endPosition" : 91456696,
+                  "startPosition" : 91455333,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "3",
+                  "endPosition" : 147490666,
+                  "startPosition" : 147490496,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "7",
+                  "endPosition" : 76980210,
+                  "startPosition" : 76980040,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:11376557",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to enable zinc ion binding activity. Predicted to be involved in cytoplasmic translation. Predicted to be located in polysomal ribosome. Human ortholog(s) of this gene implicated in Diamond-Blackfan anemia 13. Orthologous to human RPS29 (ribosomal protein S29).",
+         "name" : "40S ribosomal protein S29",
+         "soTermId" : "SO:0001217",
+         "symbol" : "LOC108352650"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000042160"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000000376"
+               },
+               {
+                  "id" : "NCBI_Gene:108349010"
+               },
+               {
+                  "id" : "PANTHER:PTHR46815"
+               },
+               {
+                  "id" : "UniProtKB:D3ZSX4"
+               },
+               {
+                  "id" : "RGD:11454336",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "20",
+                  "endPosition" : 26537164,
+                  "startPosition" : 26534434,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "2",
+                  "endPosition" : 211352540,
+                  "startPosition" : 211348762,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:11454336",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to be located in Golgi membrane. Predicted to be integral component of membrane. Orthologous to human TMEM167B (transmembrane protein 167B).",
+         "name" : "protein kish-B",
+         "soTermId" : "SO:0001217",
+         "symbol" : "LOC108349010"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000047332"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000045993"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000047291"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000060027"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000053897"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000049831"
+               },
+               {
+                  "id" : "NCBI_Gene:100910409"
+               },
+               {
+                  "id" : "RGD:6498554",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "8",
+                  "endPosition" : 42944070,
+                  "startPosition" : 42943138,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "8",
+                  "endPosition" : 43044026,
+                  "startPosition" : 43043094,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "2",
+                  "endPosition" : 115208202,
+                  "startPosition" : 115207270,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "2",
+                  "endPosition" : 35416967,
+                  "startPosition" : 35416035,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "2",
+                  "endPosition" : 115273088,
+                  "startPosition" : 115272156,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "2",
+                  "endPosition" : 35210601,
+                  "startPosition" : 35209669,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:6498554",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to enable G protein-coupled receptor activity. Predicted to be involved in detection of chemical stimulus involved in sensory perception of smell. Predicted to be located in plasma membrane. Predicted to be integral component of membrane. Orthologous to human OR8G1 (olfactory receptor family 8 subfamily G member 1) and OR8G5 (olfactory receptor family 8 subfamily G member 5).",
+         "name" : "olfactory receptor 146-like",
+         "soTermId" : "SO:0001217",
+         "symbol" : "LOC100910409"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:691676"
+               },
+               {
+                  "id" : "RGD:1597218",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "1",
+                  "endPosition" : 67093394,
+                  "startPosition" : 67092442,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:1597218",
+            "synonyms" : [
+               "LOC691676",
+               "similar to vomeronasal 1 receptor, G3",
+               "vomeronasal 1 receptor, pseudogene 51"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "vomeronasal 1 receptor pseudogene 51",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Vom1r-ps51"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:102549992"
+               },
+               {
+                  "id" : "RGD:7666146",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "14",
+                  "endPosition" : 101130154,
+                  "startPosition" : 101129618,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:7666146",
+            "synonyms" : [
+               "LOC689376",
+               "similar to 60S ribosomal protein L21"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "60S ribosomal protein L21-like",
+         "soTermId" : "SO:0000336",
+         "symbol" : "LOC102549992"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:102549556"
+               },
+               {
+                  "id" : "RGD:7720526",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "13",
+                  "endPosition" : 103138031,
+                  "startPosition" : 103128062,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:7720526",
+            "synonyms" : [
+               "LOC102549497",
+               "uncharacterized LOC102549497"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "uncharacterized LOC102549556",
+         "soTermId" : "SO:0001263",
+         "symbol" : "LOC102549556"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000060267"
+               },
+               {
+                  "id" : "RGD:15013197",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "8",
+                  "endPosition" : 44992879,
+                  "startPosition" : 44992796,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:15013197",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "Small nucleolar RNA SNORD14",
+         "soTermId" : "SO:0001267",
+         "symbol" : "SNORD14"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:103691421"
+               },
+               {
+                  "id" : "RGD:9139482",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "2",
+                  "endPosition" : 21524566,
+                  "startPosition" : 21519833,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:9139482",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "keratin-associated protein 10-3-like",
+         "soTermId" : "SO:0001217",
+         "symbol" : "LOC103691421"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:100363523"
+               },
+               {
+                  "id" : "RGD:2322824",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "4",
+                  "endPosition" : 113945047,
+                  "startPosition" : 113943994,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:2322824",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "hypothetical LOC100363523",
+         "soTermId" : "SO:0000336",
+         "symbol" : "LOC100363523"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000061298"
+               },
+               {
+                  "id" : "NCBI_Gene:102554367"
+               },
+               {
+                  "id" : "RGD:7588003",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "9",
+                  "endPosition" : 114171075,
+                  "startPosition" : 114161943,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "9",
+                  "endPosition" : 114282799,
+                  "startPosition" : 114280957,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:7588003",
+            "synonyms" : [
+               "LOC102555328",
+               "putative sperm motility kinase W",
+               "uncharacterized LOC102555328"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to enable ATP binding activity. Predicted to be integral component of membrane.",
+         "name" : "sperm motility kinase W-like",
+         "soTermId" : "SO:0001263",
+         "symbol" : "LOC102554367"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000031127"
+               },
+               {
+                  "id" : "NCBI_Gene:100360682"
+               },
+               {
+                  "id" : "PANTHER:PTHR11193"
+               },
+               {
+                  "id" : "UniProtKB:D3ZSP1"
+               },
+               {
+                  "id" : "RGD:2321675",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "13",
+                  "endPosition" : 50258951,
+                  "startPosition" : 50252707,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "8",
+                  "endPosition" : 129371973,
+                  "startPosition" : 129371556,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:2321675",
+            "synonyms" : [
+               "LOC100360682",
+               "small nuclear ribonucleoprotein E"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Enables U1 snRNP binding activity. Predicted to be involved in hair cycle and spliceosomal snRNP assembly. Located in nucleus. Part of U1 snRNP. Used to study lupus nephritis. Human ortholog(s) of this gene implicated in hepatocellular carcinoma; hypotrichosis 1; hypotrichosis 11; and lupus nephritis. Orthologous to human SNRPE (small nuclear ribonucleoprotein polypeptide E); PARTICIPATES IN spliceosome pathway; INTERACTS WITH bisphenol A; gentamycin; PhIP.",
+         "name" : "small nuclear ribonucleoprotein polypeptide E",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Snrpe"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000051483"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000013548"
+               },
+               {
+                  "id" : "NCBI_Gene:25545"
+               },
+               {
+                  "id" : "UniProtKB:P63301"
+               },
+               {
+                  "id" : "RGD:3661",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "1",
+                  "endPosition" : 77535765,
+                  "startPosition" : 77530692,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "1",
+                  "endPosition" : 77808513,
+                  "startPosition" : 77803475,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:3661",
+            "synonyms" : [
+               "LOC103689961",
+               "MGC105482",
+               "SelW",
+               "Selenoprotein W muscle 1",
+               "Sepw1",
+               "selenoprotein W, 1",
+               "selenoprotein W, muscle 1",
+               "selenoprotein W-like"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to enable antioxidant activity. Involved in response to selenium ion. Predicted to be active in cytosol. Orthologous to human SELENOW (selenoprotein W); INTERACTS WITH 1-naphthyl isothiocyanate; 2,3,7,8-tetrachlorodibenzodioxine; 2,4-dinitrotoluene.",
+         "name" : "selenoprotein W",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Selenow"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000057921"
+               },
+               {
+                  "id" : "RGD:15011380",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "1",
+                  "endPosition" : 124756178,
+                  "startPosition" : 124743354,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:15011380",
+            "synonyms" : [
+               "AABR07004100.2"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "soTermId" : "SO:0001641",
+         "symbol" : "AABR07004100.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000057023"
+               },
+               {
+                  "id" : "RGD:15010696",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "12",
+                  "endPosition" : 40529655,
+                  "startPosition" : 40529562,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:15010696",
+            "synonyms" : [
+               "AABR07036374.2"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "soTermId" : "SO:0001265",
+         "symbol" : "AABR07036374.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000049764"
+               },
+               {
+                  "id" : "RGD:15005813",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "10",
+                  "endPosition" : 15616013,
+                  "startPosition" : 15615913,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:15005813",
+            "synonyms" : [
+               "AC096051.2"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "soTermId" : "SO:0001265",
+         "symbol" : "AC096051.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000046062"
+               },
+               {
+                  "id" : "NCBI_Gene:103694506"
+               },
+               {
+                  "id" : "UniProtKB:M0R3Q5"
+               },
+               {
+                  "id" : "RGD:9288456",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "X",
+                  "endPosition" : 119178031,
+                  "startPosition" : 119160959,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:9288456",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to enable ubiquitin-protein transferase activity. Predicted to be involved in cellular response to misfolded protein; protein monoubiquitination; and proteolysis involved in cellular protein catabolic process. Predicted to be located in nucleus.",
+         "name" : "ubiquitin-conjugating enzyme E2 W",
+         "soTermId" : "SO:0001217",
+         "symbol" : "LOC103694506"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:366101"
+               },
+               {
+                  "id" : "RGD:1333471",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "3",
+                  "endPosition" : 74298676,
+                  "startPosition" : 74297729,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:1333471",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "olfactory receptor pseudogene",
+         "name" : "olfactory receptor pseudogene 523",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Olr523-ps"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000017837"
+               },
+               {
+                  "id" : "NCBI_Gene:103690203"
+               },
+               {
+                  "id" : "UniProtKB:D3ZY01"
+               },
+               {
+                  "id" : "RGD:9115869",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "1",
+                  "endPosition" : 198685151,
+                  "startPosition" : 198680428,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:9115869",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to enable DNA-binding transcription activator activity, RNA polymerase II-specific; RNA polymerase II cis-regulatory region sequence-specific DNA binding activity; and identical protein binding activity. Predicted to be involved in regulation of transcription by RNA polymerase II. Predicted to be active in nucleus. Orthologous to human ZNF48 (zinc finger protein 48); INTERACTS WITH 2,3,7,8-tetrachlorodibenzodioxine; aflatoxin B1; amphetamine.",
+         "name" : "zinc finger protein 48",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Znf48"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000049667"
+               },
+               {
+                  "id" : "UniProtKB:M0R6F6"
+               },
+               {
+                  "id" : "RGD:15005799",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "10",
+                  "endPosition" : 83110145,
+                  "startPosition" : 83104622,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:15005799",
+            "synonyms" : [
+               "AABR07030375.3"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to be integral component of membrane.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "AABR07030375.2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000048800"
+               },
+               {
+                  "id" : "UniProtKB:G3V7U9"
+               },
+               {
+                  "id" : "RGD:15005607",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "18",
+                  "endPosition" : 32670665,
+                  "startPosition" : 32669427,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:15005607",
+            "synonyms" : [
+               "AABR07031756.2"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to enable glucocorticoid receptor activity and steroid binding activity. Predicted to be involved in glucocorticoid mediated signaling pathway and glucocorticoid receptor signaling pathway. Predicted to be located in nucleus.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "AABR07031756.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000045741"
+               },
+               {
+                  "id" : "UniProtKB:D4AAF7"
+               },
+               {
+                  "id" : "UniProtKB:M0R7P6"
+               },
+               {
+                  "id" : "RGD:15004883",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "1",
+                  "endPosition" : 84642305,
+                  "startPosition" : 84639114,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:15004883",
+            "synonyms" : [
+               "AABR07071891.3"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to be involved in regulation of transcription, DNA-templated.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "AABR07071891.2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000056515"
+               },
+               {
+                  "id" : "NCBI_Gene:103690071"
+               },
+               {
+                  "id" : "RGD:9152346",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "17",
+                  "endPosition" : 62910504,
+                  "startPosition" : 62667503,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "17",
+                  "endPosition" : 66769330,
+                  "startPosition" : 66731321,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:9152346",
+            "synonyms" : [
+               "Ankrd26",
+               "LOC102548875",
+               "LOC291249",
+               "ankyrin repeat domain 26",
+               "ankyrin repeat domain-containing protein 26-like",
+               "testis-specific transcript",
+               "trichohyalin-like"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "interaptin-like",
+         "soTermId" : "SO:0001217",
+         "symbol" : "LOC103690071"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000048341"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000049188"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000049910"
+               },
+               {
+                  "id" : "NCBI_Gene:688335"
+               },
+               {
+                  "id" : "UniProtKB:D4A954"
+               },
+               {
+                  "id" : "RGD:1590037",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "8",
+                  "endPosition" : 37563474,
+                  "startPosition" : 37557045,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "8",
+                  "endPosition" : 38696297,
+                  "startPosition" : 38685415,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "8",
+                  "endPosition" : 38397923,
+                  "startPosition" : 38396532,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:1590037",
+            "synonyms" : [
+               "LOC100360143",
+               "rCG64164-like",
+               "secreted seminal-vesicle Ly-6 protein 1-like",
+               "spleen protein 2",
+               "uncharacterized protein LOC688335"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "similar to Spleen protein 1 precursor (RSP-1)",
+         "soTermId" : "SO:0001217",
+         "symbol" : "LOC688335"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000061539"
+               },
+               {
+                  "id" : "NCBI_Gene:688708"
+               },
+               {
+                  "id" : "RGD:1585299",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "10",
+                  "endPosition" : 1809530,
+                  "startPosition" : 1740383,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "10",
+                  "endPosition" : 5228,
+                  "startPosition" : 21,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:1585299",
+            "synonyms" : [
+               "LOC100362702",
+               "LOC102550577",
+               "LOW QUALITY PROTEIN: multidrug resistance-associated protein 1-like",
+               "multidrug resistance-associated protein 1-like"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "similar to ATP-binding cassette, sub-family C (CFTR/MRP), member 1",
+         "soTermId" : "SO:0000336",
+         "symbol" : "LOC688708"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:683137"
+               },
+               {
+                  "id" : "RGD:1590429",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "1",
+                  "endPosition" : 67364353,
+                  "startPosition" : 67363424,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "1",
+                  "endPosition" : 67369934,
+                  "startPosition" : 67365581,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:1590429",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "similar to LYRIC",
+         "soTermId" : "SO:0000336",
+         "symbol" : "LOC683137"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:103693461"
+               },
+               {
+                  "id" : "RGD:9134622",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "10",
+                  "endPosition" : 92958112,
+                  "startPosition" : 92947682,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "10",
+                  "endPosition" : 92996088,
+                  "startPosition" : 92960398,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:9134622",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "troponin C, slow skeletal and cardiac muscles-like",
+         "soTermId" : "SO:0001217",
+         "symbol" : "LOC103693461"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:102552744"
+               },
+               {
+                  "id" : "RGD:7516902",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "8",
+                  "endPosition" : 107380957,
+                  "startPosition" : 107363448,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "8",
+                  "endPosition" : 107394104,
+                  "startPosition" : 107380991,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:7516902",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "twist-related protein 1-like",
+         "soTermId" : "SO:0001217",
+         "symbol" : "LOC102552744"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000020593"
+               },
+               {
+                  "id" : "NCBI_Gene:500789"
+               },
+               {
+                  "id" : "PANTHER:PTHR12259"
+               },
+               {
+                  "id" : "UniProtKB:D3ZEK6"
+               },
+               {
+                  "id" : "RGD:1563255",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "7",
+                  "endPosition" : 11253080,
+                  "startPosition" : 11245160,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:1563255",
+            "synonyms" : [
+               "LOC500789",
+               "PDZ domain-containing protein GIPC3",
+               "RGD1563255",
+               "similar to PDZ-domain protein Gipc3"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Human ortholog(s) of this gene implicated in autosomal recessive nonsyndromic deafness 15. Orthologous to human GIPC3 (GIPC PDZ domain containing family member 3); INTERACTS WITH bisphenol A; endosulfan; furan.",
+         "name" : "GIPC PDZ domain containing family, member 3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Gipc3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000029571"
+               },
+               {
+                  "id" : "NCBI_Gene:362810"
+               },
+               {
+                  "id" : "UniProtKB:D3ZX74"
+               },
+               {
+                  "id" : "UniProtKB:A0A0G2JYY6"
+               },
+               {
+                  "id" : "RGD:1562447",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "7",
+                  "endPosition" : 2788189,
+                  "startPosition" : 2780930,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:1562447",
+            "synonyms" : [
+               "LOC362810",
+               "RGD1562447",
+               "coenzyme Q-binding protein COQ10 homolog A, mitochondrial",
+               "coenzyme Q10 homolog A",
+               "coenzyme Q10 homolog A (S. cerevisiae)",
+               "coenzyme Q10 homolog A (yeast)",
+               "similar to Hypothetical protein FLJ32452"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to enable ubiquinone binding activity. Predicted to be involved in cellular respiration and ubiquinone biosynthetic process. Predicted to be active in mitochondrion. Orthologous to human COQ10A (coenzyme Q10A); INTERACTS WITH (+)-schisandrin B; 1-naphthyl isothiocyanate; 2,3,7,8-tetrachlorodibenzodioxine.",
+         "name" : "coenzyme Q10A",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Coq10a"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000016525"
+               },
+               {
+                  "id" : "NCBI_Gene:306810"
+               },
+               {
+                  "id" : "UniProtKB:D3Z8I2"
+               },
+               {
+                  "id" : "RGD:1310933",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "17",
+                  "endPosition" : 15830328,
+                  "startPosition" : 15814132,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:1310933",
+            "synonyms" : [
+               "LOC306810",
+               "sushi domain-containing protein 3"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to be integral component of membrane. Predicted to be active in plasma membrane. Orthologous to human SUSD3 (sushi domain containing 3); INTERACTS WITH 17alpha-ethynylestradiol; amphetamine; atrazine.",
+         "name" : "sushi domain containing 3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Susd3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000029627"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000030596"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000030345"
+               },
+               {
+                  "id" : "NCBI_Gene:100359951"
+               },
+               {
+                  "id" : "PANTHER:PTHR11700"
+               },
+               {
+                  "id" : "UniProtKB:P60868"
+               },
+               {
+                  "id" : "RGD:2323094",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "9",
+                  "endPosition" : 1012567,
+                  "startPosition" : 1012044,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "3",
+                  "endPosition" : 22964732,
+                  "startPosition" : 22964230,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:2323094",
+            "synonyms" : [
+               "40S ribosomal protein S20"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to enable RNA binding activity. Predicted to be involved in translation.",
+         "name" : "ribosomal protein S20-like",
+         "soTermId" : "SO:0001217",
+         "symbol" : "LOC100359951"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000047638"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000050541"
+               },
+               {
+                  "id" : "NCBI_Gene:104796629"
+               },
+               {
+                  "id" : "RGD:14398583",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "17",
+                  "endPosition" : 72066617,
+                  "startPosition" : 72066536,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "17",
+                  "endPosition" : 71809128,
+                  "startPosition" : 71809047,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:14398583",
+            "synonyms" : [
+               "rno-mir-466b-4"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "microRNAs (miRNAs) are short (20-24 nt) non-coding RNAs that are involved in post-transcriptional regulation of gene expression in multicellular organisms by affecting both the stability and translation of mRNAs. miRNAs are transcribed by RNA polymerase II as part of capped and polyadenylated primary transcripts (pri-miRNAs) that can be either protein-coding or non-coding. The primary transcript is cleaved by the Drosha ribonuclease III enzyme to produce an approximately 70-nt stem-loop precursor miRNA (pre-miRNA), which is further cleaved by the cytoplasmic Dicer ribonuclease to generate the mature miRNA and antisense miRNA star (miRNA*) products. The mature miRNA is incorporated into a RNA-induced silencing complex (RISC), which recognizes target mRNAs through imperfect base pairing with the miRNA and most commonly results in translational inhibition or destabilization of the target mRNA. The RefSeq represents the predicted microRNA stem-loop. [provided by RefSeq, Sep 2009]",
+         "name" : "microRNA mir-466b-4",
+         "soTermId" : "SO:0001263",
+         "symbol" : "Mir466b-4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000049991"
+               },
+               {
+                  "id" : "NCBI_Gene:54272"
+               },
+               {
+                  "id" : "UniProtKB:A0A0G2KAZ8"
+               },
+               {
+                  "id" : "UniProtKB:A0A0A0MY26"
+               },
+               {
+                  "id" : "UniProtKB:P97611"
+               },
+               {
+                  "id" : "UniProtKB:A0A0G2K4T4"
+               },
+               {
+                  "id" : "RGD:3068",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "15",
+                  "endPosition" : 35020842,
+                  "startPosition" : 35018087,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "15",
+                  "endPosition" : 34694244,
+                  "startPosition" : 34644464,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:3068",
+            "synonyms" : [
+               "granzyme J"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to enable serine-type endopeptidase activity. Predicted to be involved in proteolysis.",
+         "name" : "mast cell protease 9",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Mcpt9"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000058972"
+               },
+               {
+                  "id" : "RGD:15012198",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "X",
+                  "endPosition" : 152670217,
+                  "startPosition" : 152670075,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:15012198",
+            "synonyms" : [
+               "Gm24879",
+               "predicted gene, 24879"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "soTermId" : "SO:0001267",
+         "symbol" : "AABR07042321.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000054621"
+               },
+               {
+                  "id" : "RGD:15008818",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "6",
+                  "endPosition" : 70169608,
+                  "startPosition" : 70169481,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:15008818",
+            "synonyms" : [
+               "Gm25015",
+               "predicted gene, 25015"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "soTermId" : "SO:0001267",
+         "symbol" : "AABR07064228.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000059324"
+               },
+               {
+                  "id" : "RGD:15012482",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "8",
+                  "endPosition" : 95883667,
+                  "startPosition" : 95883543,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:15012482",
+            "synonyms" : [
+               "Gm22493",
+               "predicted gene, 22493"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "soTermId" : "SO:0001267",
+         "symbol" : "AABR07070999.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:100361154"
+               },
+               {
+                  "id" : "RGD:2320707",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "15",
+                  "endPosition" : 18231274,
+                  "startPosition" : 18222880,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:2320707",
+            "synonyms" : [
+               "LOC100360808"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "Smad nuclear interacting protein 1-like",
+         "soTermId" : "SO:0000336",
+         "symbol" : "LOC100361154"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:103691013"
+               },
+               {
+                  "id" : "RGD:9219688",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "1",
+                  "endPosition" : 55608076,
+                  "startPosition" : 55602545,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:9219688",
+            "synonyms" : [
+               "LOC100911439"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "neuronal tyrosine-phosphorylated phosphoinositide-3-kinase adapter 1-like",
+         "soTermId" : "SO:0001217",
+         "symbol" : "LOC103691013"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:102551143"
+               },
+               {
+                  "id" : "RGD:7624949",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "6",
+                  "endPosition" : 77192691,
+                  "startPosition" : 77132474,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:7624949",
+            "synonyms" : [
+               "uncharacterized protein LOC102551143"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "uncharacterized LOC102551143",
+         "soTermId" : "SO:0001217",
+         "symbol" : "LOC102551143"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000057591"
+               },
+               {
+                  "id" : "RGD:15011133",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "2",
+                  "endPosition" : 165814067,
+                  "startPosition" : 165813947,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:15011133",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "soTermId" : "SO:0001267",
+         "symbol" : "AABR07011679.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000053151"
+               },
+               {
+                  "id" : "RGD:15007698",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "12",
+                  "endPosition" : 43252840,
+                  "startPosition" : 43252140,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:15007698",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "soTermId" : "SO:0001641",
+         "symbol" : "AABR07036436.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000038427"
+               },
+               {
+                  "id" : "UniProtKB:F1LXM2"
+               },
+               {
+                  "id" : "RGD:15004303",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "14",
+                  "endPosition" : 78377825,
+                  "startPosition" : 78359682,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:15004303",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "AABR07015812.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000049743"
+               },
+               {
+                  "id" : "NCBI_Gene:108348148"
+               },
+               {
+                  "id" : "RGD:11402080",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "2",
+                  "endPosition" : 210688273,
+                  "startPosition" : 210685197,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:11402080",
+            "synonyms" : [
+               "NEWGENE_620381"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Enables glutathione transferase activity. Predicted to be involved in several processes, including cellular detoxification of nitrogen compound; nitrobenzene metabolic process; and response to estrogen. Predicted to act upstream of or within cellular response to drug; cellular response to organic cyclic compound; and response to bacterium. Predicted to be located in cytosol and intercellular bridge; PARTICIPATES IN glutathione conjugation pathway; glutathione metabolic pathway; phase I biotransformation pathway via cytochrome P450; INTERACTS WITH 1-chloro-2,4-dinitrobenzene (ortholog); 17beta-estradiol (ortholog); 2,3,7,8-tetrachlorodibenzodioxine (ortholog).",
+         "name" : "glutathione S-transferase mu 3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Gstm3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000028166"
+               },
+               {
+                  "id" : "NCBI_Gene:288527"
+               },
+               {
+                  "id" : "PANTHER:PTHR43213"
+               },
+               {
+                  "id" : "UniProtKB:D4AA35"
+               },
+               {
+                  "id" : "RGD:1306877",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "12",
+                  "endPosition" : 18534836,
+                  "startPosition" : 18531990,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:1306877",
+            "synonyms" : [
+               "LOC288527"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to enable nucleoside-triphosphate diphosphatase activity. Predicted to be located in cytosol. Orthologous to human ASMTL (acetylserotonin O-methyltransferase like); INTERACTS WITH amphetamine; bis(2-ethylhexyl) phthalate; bisphenol A.",
+         "name" : "acetylserotonin O-methyltransferase-like",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Asmtl"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:311241"
+               },
+               {
+                  "id" : "RGD:1560961",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "3",
+                  "endPosition" : 89745868,
+                  "startPosition" : 89743733,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:1560961",
+            "synonyms" : [
+               "LOC311241"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "INTERACTS WITH nefazodone",
+         "name" : "similar to RIKEN cDNA 0610038L10 gene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "RGD1560961"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000015707"
+               },
+               {
+                  "id" : "PANTHER:PTHR24061"
+               },
+               {
+                  "id" : "UniProtKB:F1M924"
+               },
+               {
+                  "id" : "RGD:15003431",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "1",
+                  "endPosition" : 69521420,
+                  "startPosition" : 69496522,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:15003431",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to be involved in adenylate cyclase-inhibiting G protein-coupled glutamate receptor signaling pathway.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "AABR07002241.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000029131"
+               },
+               {
+                  "id" : "PANTHER:PTHR19964"
+               },
+               {
+                  "id" : "UniProtKB:F1LVM9"
+               },
+               {
+                  "id" : "RGD:15003728",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "16",
+                  "endPosition" : 9847444,
+                  "startPosition" : 9772688,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:15003728",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to be involved in bicellular tight junction assembly. Predicted to be located in cytoskeleton.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "AABR07024637.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000014794"
+               },
+               {
+                  "id" : "PANTHER:PTHR47898"
+               },
+               {
+                  "id" : "UniProtKB:D4A0Q5"
+               },
+               {
+                  "id" : "RGD:15003420",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "3",
+                  "endPosition" : 161163720,
+                  "startPosition" : 161160920,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:15003420",
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to enable serine-type endopeptidase inhibitor activity. Predicted to be involved in negative regulation of endopeptidase activity.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "AC105815.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000029760"
+               },
+               {
+                  "id" : "UniProtKB:D3ZS07"
+               },
+               {
+                  "id" : "RGD:15003771",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "2",
+                  "endPosition" : 192381716,
+                  "startPosition" : 192305560,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:15003771",
+            "synonyms" : [
+               "Sprr2h",
+               "small proline-rich protein 2H"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to be involved in keratinization. Predicted to be located in cornified envelope.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "AABR07012291.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000040060"
+               },
+               {
+                  "id" : "PANTHER:PTHR31678"
+               },
+               {
+                  "id" : "UniProtKB:D3ZK86"
+               },
+               {
+                  "id" : "RGD:15004373",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "11",
+                  "endPosition" : 28979169,
+                  "startPosition" : 28973432,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:15004373",
+            "synonyms" : [
+               "1110025L11Rik",
+               "RIKEN cDNA 1110025L11 gene"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to be involved in keratinization.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "AABR07033580.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000020618"
+               },
+               {
+                  "id" : "PANTHER:PTHR11545"
+               },
+               {
+                  "id" : "UniProtKB:A0A1W2Q6L2"
+               },
+               {
+                  "id" : "RGD:15003495",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "1",
+                  "endPosition" : 101131193,
+                  "startPosition" : 101120711,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:15003495",
+            "synonyms" : [
+               "Gm45713",
+               "predicted gene 45713"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "geneSynopsis" : "Predicted to enable cytokine activity. Predicted to be involved in signal transduction and translation. Predicted to be integral component of membrane.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "AC099450.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000048456"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000032635"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000048523"
+               },
+               {
+                  "id" : "NCBI_Gene:100360117"
+               },
+               {
+                  "id" : "PANTHER:PTHR13691"
+               },
+               {
+                  "id" : "UniProtKB:P62919"
+               },
+               {
+                  "id" : "RGD:2322732",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "3",
+                  "endPosition" : 3390465,
+                  "startPosition" : 3389582,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "7",
+                  "endPosition" : 118509256,
+                  "startPosition" : 118507224,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "7",
+                  "endPosition" : 117969850,
+                  "startPosition" : 117967818,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:2322732",
+            "synonyms" : [
+               "60S ribosomal protein L8"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "ribosomal protein L8-like",
+         "soTermId" : "SO:0001217",
+         "symbol" : "LOC100360117"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000046576"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000049503"
+               },
+               {
+                  "id" : "NCBI_Gene:689479"
+               },
+               {
+                  "id" : "UniProtKB:F1LUV6"
+               },
+               {
+                  "id" : "RGD:1592283",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "9",
+                  "endPosition" : 464804,
+                  "startPosition" : 456647,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "16",
+                  "endPosition" : 66387794,
+                  "startPosition" : 66230011,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "RGD:1592283",
+            "synonyms" : [
+               "uncharacterized protein LOC689479"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "similar to Discs large homolog 5 (Placenta and prostate DLG) (Discs large protein P-dlg)",
+         "soTermId" : "SO:0001217",
+         "symbol" : "LOC689479"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000047938"
+               },
+               {
+                  "id" : "ENSEMBL:ENSRNOG00000049773"
+               },
+               {
+                  "id" : "NCBI_Gene:688340"
+               },
+               {
+                  "id" : "UniProtKB:M0R575"
+               },
+               {
+                  "id" : "RGD:11446160",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "15",
+                  "endPosition" : 30197379,
+                  "startPosition" : 30172982,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "Rnor_6.0",
+                  "chromosome" : "15",
+                  "endPosition" : 29360198,
+                  "startPosition" : 29359765,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "RGD:11446160",
+            "synonyms" : [
+               "uncharacterized protein LOC688340"
+            ],
+            "taxonId" : "NCBITaxon:10116"
+         },
+         "name" : "T-cell receptor alpha chain V region PHDS58-like",
+         "soTermId" : "SO:0000704",
+         "symbol" : "LOC688340"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000029714",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXII",
+                  "endPosition" : 460711,
+                  "startPosition" : 459797,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000029714",
+            "synonyms" : [
+               "NTS1",
+               "NTS1-2"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Non-transcribed region of the rDNA repeat between the 3' ETS and RDN5; required for rDNA repeat expansion",
+         "name" : "NonTranscribed Spacer",
+         "soTermId" : "SO:0000183",
+         "symbol" : "NTS1-2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000029706",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXII",
+                  "endPosition" : 468812,
+                  "startPosition" : 467570,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000029706",
+            "synonyms" : [
+               "NTS2",
+               "NTS2-2"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Non-transcribed region of the rDNA repeat; located between RDN5 and the 5' ETS",
+         "name" : "NonTranscribed Spacer",
+         "soTermId" : "SO:0000183",
+         "symbol" : "NTS2-2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000303803",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrII",
+                  "endPosition" : 378633,
+                  "startPosition" : 376610,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000303803",
+            "synonyms" : [
+               "XUT_2F-154",
+               "YNCB0014W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Antisense lncRNA XUT_2F-154 (TBRT); transcription mediates  repression of BAP2 and TAT1",
+         "name" : "TAT1 and BAP2 Regulatory Transcript",
+         "soTermId" : "SO:0001263",
+         "symbol" : "TBRT"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000006728",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:850697"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXII",
+                  "endPosition" : 168025,
+                  "startPosition" : 167944,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000006728",
+            "secondaryIds" : [
+               "SGD:L000003665"
+            ],
+            "synonyms" : [
+               "tS(AGA)L",
+               "tRNA-Ser",
+               "YNCL0002C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Serine tRNA (tRNA-Ser), predicted by tRNAscan-SE analysis",
+         "soTermId" : "SO:0001272",
+         "symbol" : "YNCL0002C"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000006556",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:854823"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrIX",
+                  "endPosition" : 370488,
+                  "startPosition" : 370417,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000006556",
+            "secondaryIds" : [
+               "SGD:L000003871"
+            ],
+            "synonyms" : [
+               "tE(UUC)I",
+               "tRNA-Glu",
+               "YNCI0011W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Glutamate tRNA (tRNA-Glu), predicted by tRNAscan-SE analysis; thiolation of uridine at wobble position (34) requires Ncs6p",
+         "soTermId" : "SO:0001272",
+         "symbol" : "YNCI0011W"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000003353",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:853019"
+               },
+               {
+                  "id" : "UniProtKB:P40260"
+               },
+               {
+                  "id" : "PANTHER:PTHR43029:SF4"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrVII",
+                  "endPosition" : 732927,
+                  "startPosition" : 731449,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000003353",
+            "secondaryIds" : [
+               "SGD:L000001073"
+            ],
+            "synonyms" : [
+               "AMT1",
+               "YGR121C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Ammonium permease; belongs to Mep-Amt-Rh family of well-conserved ammonium (NH4+) transporters that includes the human Rh factors; expression is under the nitrogen catabolite repression regulation; activity regulated by TORC1 effectors, Npr1p and Par32p; human homolog RHCG complements yeast null mutant; mutations in human homolog RHCG implicated in metabolic acidosis; MEP1 has a paralog, MEP3, that arose from the whole genome duplication",
+         "soTermId" : "SO:0001217",
+         "symbol" : "MEP1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000006108",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P01149"
+               },
+               {
+                  "id" : "NCBI_Gene:855914"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXVI",
+                  "endPosition" : 194145,
+                  "startPosition" : 193648,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000006108",
+            "secondaryIds" : [
+               "SGD:L000001094"
+            ],
+            "synonyms" : [
+               "YPL187W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Mating pheromone alpha-factor, made by alpha cells; interacts with mating type a cells to induce cell cycle arrest and other responses leading to mating; also encoded by MF(ALPHA)2, although MF(ALPHA)1 produces most alpha-factor; binds copper(II) ions",
+         "name" : "Mating Factor ALPHA",
+         "soTermId" : "SO:0001217",
+         "symbol" : "MF(ALPHA)1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000002319",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P39517"
+               },
+               {
+                  "id" : "NCBI_Gene:851394"
+               },
+               {
+                  "id" : "PANTHER:PTHR47960:SF17"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrIV",
+                  "endPosition" : 171930,
+                  "startPosition" : 170410,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000002319",
+            "secondaryIds" : [
+               "SGD:L000000504"
+            ],
+            "synonyms" : [
+               "YDL160C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Cytoplasmic DEAD-box helicase and mRNA decapping activator; interacts with decapping and deadenylase complexes to coordinate mRNA decapping and decay; regulates general translational repression; translational activator of select mRNAs during filamentous growth, mating and autophagy; cooperates with Ngr1p to promote specific mRNA decay; ATP- and RNA-bound form promotes processing body assembly, while ATPase stimulation by Not1p promotes disassembly; forms cytoplasmic foci on replication stress",
+         "name" : "DEAD box Helicase Homolog",
+         "soTermId" : "SO:0001217",
+         "symbol" : "DHH1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000000684",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P15891"
+               },
+               {
+                  "id" : "NCBI_Gene:850450"
+               },
+               {
+                  "id" : "PANTHER:PTHR10829:SF25"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrIII",
+                  "endPosition" : 266846,
+                  "startPosition" : 265068,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000000684",
+            "secondaryIds" : [
+               "SGD:L000000013"
+            ],
+            "synonyms" : [
+               "YCR088W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Actin-binding protein of the cortical actin cytoskeleton; important for activation of actin nucleation mediated by the Arp2/Arp3 complex; inhibits actin filament elongation at the barbed-end; phosphorylation within its proline-rich region, mediated by Cdc28p and Pho85p, protects Abp1p from PEST sequence-mediated proteolysis; mammalian homolog of HIP-55 (hematopoietic progenitor kinase 1 [HPK1]-interacting protein of 55 kDa)",
+         "name" : "Actin Binding Protein",
+         "soTermId" : "SO:0001217",
+         "symbol" : "ABP1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000001574",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P33324"
+               },
+               {
+                  "id" : "NCBI_Gene:853771"
+               },
+               {
+                  "id" : "PANTHER:PTHR45657:SF1"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXI",
+                  "endPosition" : 270650,
+                  "startPosition" : 269718,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000001574",
+            "synonyms" : [
+               "SFH1",
+               "YKL091C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Putative phosphatidylinositol/phosphatidylcholine transfer protein; possibly involved in lipid metabolism; localizes to the nucleus; contains a CRAL/TRIO domain and binds several lipids in a large-scale study; YKL091C has a paralog, SEC14, that arose from the whole genome duplication",
+         "soTermId" : "SO:0001217",
+         "symbol" : "YKL091C"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000000087",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P0CX90"
+               },
+               {
+                  "id" : "NCBI_Gene:1466531"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrI",
+                  "endPosition" : 219145,
+                  "startPosition" : 218140,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000000087",
+            "synonyms" : [
+               "YAR062W",
+               "YAR061W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Pseudogenic fragment with similarity to flocculins; YAR061W has a paralog, YHR212W-A, that arose from a segmental duplication",
+         "soTermId" : "SO:0000336",
+         "symbol" : "YAR061W"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000007599",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:Q3E774"
+               },
+               {
+                  "id" : "NCBI_Gene:851395"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrIV",
+                  "endPosition" : 172313,
+                  "startPosition" : 172182,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000007599",
+            "synonyms" : [
+               "YDL159W-B",
+               "YDL159W-A"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Putative protein of unknown function; identified by sequence comparison with hemiascomycetous yeast species",
+         "soTermId" : "SO:0001217",
+         "symbol" : "YDL159W-A"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000005176",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P53859"
+               },
+               {
+                  "id" : "NCBI_Gene:855489"
+               },
+               {
+                  "id" : "PANTHER:PTHR12686:SF8"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXIV",
+                  "endPosition" : 215801,
+                  "startPosition" : 214923,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000005176",
+            "secondaryIds" : [
+               "SGD:L000001905",
+               "SGD:L000004677"
+            ],
+            "synonyms" : [
+               "SKI4",
+               "YNL232W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Exosome non-catalytic core component; involved in 3'-5' RNA processing and degradation in both the nucleus and the cytoplasm; predicted to contain an S1 RNA binding domain; human homolog EXOSC1 partially complements yeast csl4 null mutant, and can complement inviability of strain in which expression of CSL4 is repressed",
+         "name" : "Cep1 Synthetic Lethal",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CSL4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000003694",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:853282"
+               },
+               {
+                  "id" : "UniProtKB:P47001"
+               },
+               {
+                  "id" : "PANTHER:PTHR47254:SF1"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrX",
+                  "endPosition" : 122948,
+                  "startPosition" : 122265,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000003694",
+            "secondaryIds" : [
+               "SGD:L000004569",
+               "SGD:S000029072",
+               "SGD:L000003951",
+               "SGD:L000004553",
+               "SGD:S000029439"
+            ],
+            "synonyms" : [
+               "PIR4",
+               "CCW11",
+               "CCW5",
+               "SCW8",
+               "YJL158C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Mannose-containing glycoprotein constituent of the cell wall; member of the PIR (proteins with internal repeats) family",
+         "name" : "CIk1 Suppressing",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CIS3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000000018",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P31386"
+               },
+               {
+                  "id" : "NCBI_Gene:851213"
+               },
+               {
+                  "id" : "PANTHER:PTHR45622:SF40"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrI",
+                  "endPosition" : 114615,
+                  "startPosition" : 113614,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000000018",
+            "secondaryIds" : [
+               "SGD:L000000644",
+               "SGD:L000000154"
+            ],
+            "synonyms" : [
+               "FUN28",
+               "KTI13",
+               "YAL020C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Protein required for modification of wobble nucleosides in tRNA; acts with Elongator complex, Kti11p, and Kti12p; has a potential role in regulatory interactions between microtubules and the cell cycle; forms a stable heterodimer with Kti11p",
+         "name" : "Alpha Tubulin Suppressor",
+         "soTermId" : "SO:0001217",
+         "symbol" : "ATS1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000006295",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:Q06833"
+               },
+               {
+                  "id" : "NCBI_Gene:856207"
+               },
+               {
+                  "id" : "PANTHER:PTHR13466:SF0"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXVI",
+                  "endPosition" : 718468,
+                  "startPosition" : 716156,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000006295",
+            "synonyms" : [
+               "YPR091C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Lipid-binding ER protein, enriched at nucleus-vacuolar junctions (NVJ); involved in nonvesicular transfer of ceramides from ER to Golgi; may be involved in sterol metabolism or signaling at the NVJ; contains a synaptotagmin-like-mitochondrial-lipid binding protein (SMP) domain; binds phosphatidylinositols and other lipids in a large-scale study; may interact with ribosomes, based on co-purification experiments",
+         "name" : "Nucleus-Vacuole Junction",
+         "soTermId" : "SO:0001217",
+         "symbol" : "NVJ2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000003596",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:853386"
+               },
+               {
+                  "id" : "UniProtKB:P47039"
+               },
+               {
+                  "id" : "PANTHER:PTHR43807:SF20"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrX",
+                  "endPosition" : 324720,
+                  "startPosition" : 323386,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000003596",
+            "synonyms" : [
+               "YJL060W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Kynurenine aminotransferase; catalyzes formation of kynurenic acid from kynurenine; potential Cdc28p substrate",
+         "name" : "Biosynthesis of Nicotinic Acid",
+         "soTermId" : "SO:0001217",
+         "symbol" : "BNA3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000004901",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/disease",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:855332"
+               },
+               {
+                  "id" : "UniProtKB:P49955"
+               },
+               {
+                  "id" : "PANTHER:PTHR12097:SF0"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXIII",
+                  "endPosition" : 848486,
+                  "startPosition" : 845571,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000004901",
+            "synonyms" : [
+               "YMR288W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "U2-snRNP associated splicing factor; forms extensive associations with the branch site-3' splice site-3' exon region upon prespliceosome formation; similarity to the mammalian U2 snRNP-associated splicing factor SAP155",
+         "name" : "Human Sap Homolog",
+         "soTermId" : "SO:0001217",
+         "symbol" : "HSH155"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000007272",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:Q9ZZW7"
+               },
+               {
+                  "id" : "NCBI_Gene:854605"
+               },
+               {
+                  "id" : "PANTHER:PTHR19271:SF16"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrMito",
+                  "endPosition" : 40265,
+                  "startPosition" : 36540,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000007272",
+            "secondaryIds" : [
+               "SGD:L000004936",
+               "SGD:L000000176"
+            ],
+            "synonyms" : [
+               "Q0115"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Mitochondrial mRNA maturase; forms a complex with Mrs1p to mediate splicing of the bI3 intron of the COB gene; encoded by both exon and intron sequences of partially processed COB mRNA",
+         "soTermId" : "SO:0001217",
+         "symbol" : "BI3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000002715",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:Q06644"
+               },
+               {
+                  "id" : "NCBI_Gene:851902"
+               },
+               {
+                  "id" : "PANTHER:PTHR10050:SF46"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrIV",
+                  "endPosition" : 1077853,
+                  "startPosition" : 1075865,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000002715",
+            "secondaryIds" : [
+               "SGD:L000004021",
+               "SGD:L000004010",
+               "SGD:S000029378"
+            ],
+            "synonyms" : [
+               "YDR307W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Putative protein mannosyltransferase similar to Pmt1p; has a potential role in protein O-glycosylation",
+         "soTermId" : "SO:0001217",
+         "symbol" : "PMT7"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000007271",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P03873"
+               },
+               {
+                  "id" : "NCBI_Gene:854604"
+               },
+               {
+                  "id" : "PANTHER:PTHR19271:SF16"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrMito",
+                  "endPosition" : 38579,
+                  "startPosition" : 36540,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000007271",
+            "secondaryIds" : [
+               "SGD:L000004935",
+               "SGD:L000004888"
+            ],
+            "synonyms" : [
+               "Q0110"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Mitochondrial mRNA maturase with a role in splicing; encoded by both exon and intron sequences of partially processed COB mRNA",
+         "soTermId" : "SO:0001217",
+         "symbol" : "BI2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000006438",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:O14455"
+               },
+               {
+                  "id" : "NCBI_Gene:855826"
+               },
+               {
+                  "id" : "PANTHER:PTHR10114:SF0"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXVI",
+                  "endPosition" : 76239,
+                  "startPosition" : 75699,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000006438",
+            "secondaryIds" : [
+               "SGD:L000004515"
+            ],
+            "synonyms" : [
+               "L36B",
+               "L39",
+               "YL39",
+               "L36e",
+               "eL36",
+               "YPL249C-A"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Ribosomal 60S subunit protein L36B; binds to 5.8 S rRNA; homologous to mammalian ribosomal protein L36, no bacterial homolog; RPL36B has a paralog, RPL36A, that arose from the whole genome duplication",
+         "name" : "Ribosomal Protein of the Large subunit",
+         "soTermId" : "SO:0001217",
+         "symbol" : "RPL36B"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000005711",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P32836"
+               },
+               {
+                  "id" : "NCBI_Gene:854357"
+               },
+               {
+                  "id" : "PANTHER:PTHR24071:SF0"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXV",
+                  "endPosition" : 682106,
+                  "startPosition" : 681444,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000005711",
+            "secondaryIds" : [
+               "SGD:L000000737"
+            ],
+            "synonyms" : [
+               "CNR2",
+               "YOR185C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "GTP binding protein (mammalian Ranp homolog); involved in the maintenance of nuclear organization, RNA processing and transport; interacts with Kap121p, Kap123p and Pdr6p (karyophilin betas); not required for viability; protein abundance increases in response to DNA replication stress; GSP2 has a paralog, GSP1, that arose from the whole genome duplication",
+         "name" : "Genetic Suppressor of Prp20-1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "GSP2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000007292",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:9164974"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXV",
+                  "endPosition" : 408134,
+                  "startPosition" : 407948,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000007292",
+            "secondaryIds" : [
+               "SGD:L000001964"
+            ],
+            "synonyms" : [
+               "snR9",
+               "YNCO0014C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "H/ACA box small nucleolar RNA (snoRNA); guides pseudouridylation of large subunit (LSU) rRNA at position U2340 and U2345",
+         "name" : "Small Nucleolar RNA",
+         "soTermId" : "SO:0001267",
+         "symbol" : "SNR9"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000303802",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrII",
+                  "endPosition" : 280645,
+                  "startPosition" : 276805,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000303802",
+            "synonyms" : [
+               "GAL10-ncRNA",
+               "GAL1ucut",
+               "YNCB0008W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "lncRNA antisense to GAL10 and overlapping GAL1 mRNAs; GAL10-ncRNA transcription recruits Set2p methyltransferase  and histone deacetylation activities in cis, leading to stable changes in chromatin structure; acts to enhance glucose repression of GAL1-10 induction at low environmental sugar concentrations; expression driven by Reb1p; does not appear to control GAL1 induction",
+         "soTermId" : "SO:0001263",
+         "symbol" : "YNCB0008W"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000303814",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXIII",
+                  "endPosition" : 26578,
+                  "startPosition" : 23564,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000303814",
+            "synonyms" : [
+               "PHO84 lncRNA",
+               "PHO84 AS RNA",
+               "YNCM0001W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Antisense to PHO84 and 5'-end of YML122C; represses transcription of PHO84 through histone deacetylation",
+         "soTermId" : "SO:0001263",
+         "symbol" : "YNCM0001W"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000303815",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXVI",
+                  "endPosition" : 82648,
+                  "startPosition" : 79562,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000303815",
+            "synonyms" : [
+               "GAL4 lncRNA",
+               "YNCP0002W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Antisense to GAL4/YPL248C; influences expression of GAL4 mRNA",
+         "soTermId" : "SO:0001263",
+         "symbol" : "YNCP0002W"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000005882",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:854537"
+               },
+               {
+                  "id" : "UniProtKB:P41913"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXV",
+                  "endPosition" : 1006705,
+                  "startPosition" : 1005137,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000005882",
+            "secondaryIds" : [
+               "SGD:L000002580"
+            ],
+            "synonyms" : [
+               "YOR355W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Protein of unknown function; required for growth on glycerol as a carbon source; the authentic, non-tagged protein is detected in highly purified mitochondria in high-throughput studies",
+         "soTermId" : "SO:0001217",
+         "symbol" : "GDS1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000003481",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P53050"
+               },
+               {
+                  "id" : "NCBI_Gene:853164"
+               },
+               {
+                  "id" : "PANTHER:PTHR10015:SF349"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrVII",
+                  "endPosition" : 989419,
+                  "startPosition" : 988049,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000003481",
+            "secondaryIds" : [
+               "SGD:L000001100"
+            ],
+            "synonyms" : [
+               "YGR249W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Protein similar to heat shock transcription factor; multicopy suppressor of pseudohyphal growth defects of ammonium permease mutants",
+         "soTermId" : "SO:0001217",
+         "symbol" : "MGA1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000003429",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:853111"
+               },
+               {
+                  "id" : "UniProtKB:P46950"
+               },
+               {
+                  "id" : "PANTHER:PTHR34814:SF1"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrVII",
+                  "endPosition" : 894140,
+                  "startPosition" : 892497,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000003429",
+            "secondaryIds" : [
+               "SGD:L000002747"
+            ],
+            "synonyms" : [
+               "YGR197C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Protein involved in resistance to nitrosoguanidine and 6-azauracil; expression is regulated by transcription factors involved in multidrug resistance; SNG1 has a paralog, YJR015W, that arose from the whole genome duplication",
+         "soTermId" : "SO:0001217",
+         "symbol" : "SNG1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000006682",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:856549"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrVIII",
+                  "endPosition" : 388995,
+                  "startPosition" : 388893,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000006682",
+            "secondaryIds" : [
+               "SGD:L000002156",
+               "SGD:L000003859"
+            ],
+            "synonyms" : [
+               "tP(UGG)H",
+               "tRNA-Pro",
+               "YNCH0013C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Proline tRNA (tRNA-Pro), predicted by tRNAscan-SE analysis; target of K. lactis zymocin; can mutate to suppress +1 frameshift mutations in proline codons",
+         "soTermId" : "SO:0001272",
+         "symbol" : "SUF8"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000007264",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P03878"
+               },
+               {
+                  "id" : "NCBI_Gene:854596"
+               },
+               {
+                  "id" : "PANTHER:PTHR10422:SF39"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrMito",
+                  "endPosition" : 21935,
+                  "startPosition" : 13818,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000007264",
+            "secondaryIds" : [
+               "SGD:L000004928",
+               "SGD:L000004885"
+            ],
+            "synonyms" : [
+               "I-SceII",
+               "Q0065"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Endonuclease I-SceII; encoded by a mobile group I intron within the mitochondrial COX1 gene; intron is normally spliced by the BI4p maturase but AI4p can mutate to acquire the same maturase activity",
+         "soTermId" : "SO:0001217",
+         "symbol" : "AI4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000006584",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:853511"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrX",
+                  "endPosition" : 531898,
+                  "startPosition" : 531828,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000006584",
+            "secondaryIds" : [
+               "SGD:L000002170",
+               "SGD:S000029541",
+               "SGD:L000003613"
+            ],
+            "synonyms" : [
+               "tG(GCC)J2",
+               "tRNA-Gly",
+               "YNCJ0024W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Glycine tRNA (tRNA-Gly); can mutate to suppress +1 frameshift mutations",
+         "soTermId" : "SO:0001272",
+         "symbol" : "SUF23"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000002421",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:Q99359"
+               },
+               {
+                  "id" : "NCBI_Gene:851577"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrIV",
+                  "endPosition" : 475989,
+                  "startPosition" : 474046,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000002421",
+            "synonyms" : [
+               "WPL1",
+               "YDR014W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Subunit of a complex that inhibits sister chromatid cohesion; also negatively regulates chromosome condensation; inhibited by Eco1p-acetylated cohesin subunits Smc3p and Mcd1p; binds Smc3p ATPase head of cohesin; related to the human Wapl protein that controls the association of cohesin with chromatin",
+         "name" : "RADiation sensitive",
+         "soTermId" : "SO:0001217",
+         "symbol" : "RAD61"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000005934",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:Q02608"
+               },
+               {
+                  "id" : "NCBI_Gene:856094"
+               },
+               {
+                  "id" : "PANTHER:PTHR12919:SF20"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXVI",
+                  "endPosition" : 529350,
+                  "startPosition" : 528985,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000005934",
+            "synonyms" : [
+               "bS16m",
+               "YPL013C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Mitochondrial ribosomal protein of the small subunit",
+         "name" : "Mitochondrial Ribosomal Protein, Small subunit",
+         "soTermId" : "SO:0001217",
+         "symbol" : "MRPS16"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000004027",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:Q07987"
+               },
+               {
+                  "id" : "NCBI_Gene:850726"
+               },
+               {
+                  "id" : "PANTHER:PTHR31002:SF34"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXII",
+                  "endPosition" : 223059,
+                  "startPosition" : 222685,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000004027",
+            "synonyms" : [
+               "DAN2",
+               "YLR037C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Cell wall mannoprotein; has similarity to Tir1p, Tir2p, Tir3p, and Tir4p; member of the seripauperin multigene family encoded mainly in subtelomeric regions; expressed under anaerobic conditions, completely repressed during aerobic growth",
+         "name" : "seriPAUperin family",
+         "soTermId" : "SO:0001217",
+         "symbol" : "PAU23"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000006385",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P15303"
+               },
+               {
+                  "id" : "NCBI_Gene:856311"
+               },
+               {
+                  "id" : "PANTHER:PTHR11141:SF0"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXVI",
+                  "endPosition" : 899667,
+                  "startPosition" : 897361,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000006385",
+            "secondaryIds" : [
+               "SGD:S000028412",
+               "SGD:L000001846"
+            ],
+            "synonyms" : [
+               "YPR181C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "GTPase-activating protein, stimulates the GTPase activity of Sar1p; component of the Sec23p-Sec24p heterodimer of the COPII vesicle coat, involved in ER to Golgi transport; substrate of Ubp3/Bre5 complex; ubiquitylated by Ub-ligase Rsp5p; proteasome-mediated degradation of Sec23p is regulated by Cdc48p",
+         "name" : "SECretory",
+         "soTermId" : "SO:0001217",
+         "symbol" : "SEC23"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000001236",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P38879"
+               },
+               {
+                  "id" : "NCBI_Gene:856600"
+               },
+               {
+                  "id" : "PANTHER:PTHR21713:SF4"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrVIII",
+                  "endPosition" : 488236,
+                  "startPosition" : 487712,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000001236",
+            "secondaryIds" : [
+               "SGD:L000000546",
+               "SGD:L000002606"
+            ],
+            "synonyms" : [
+               "YHR193C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Alpha subunit of the nascent polypeptide-associated complex (NAC); involved in protein sorting and translocation; associated with cytoplasmic ribosomes",
+         "name" : "Enhancer of Gal4 DNA binding",
+         "soTermId" : "SO:0001217",
+         "symbol" : "EGD2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000004104",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:Q12500"
+               },
+               {
+                  "id" : "NCBI_Gene:850805"
+               },
+               {
+                  "id" : "PANTHER:PTHR31017:SF1"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXII",
+                  "endPosition" : 377238,
+                  "startPosition" : 374944,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000004104",
+            "secondaryIds" : [
+               "SGD:S000029007",
+               "SGD:S000029049"
+            ],
+            "synonyms" : [
+               "YLR114C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Conserved protein involved in exocytic transport from the Golgi; mutation is synthetically lethal with apl2 vps1 double mutation; member of a protein superfamily with orthologs in diverse organisms; relocalizes from bud neck to cytoplasm upon DNA replication stress",
+         "name" : "Apl2 Vps1 Lethal",
+         "soTermId" : "SO:0001217",
+         "symbol" : "AVL9"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000029329",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXII",
+                  "endPosition" : 459675,
+                  "startPosition" : 458433,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000029329",
+            "secondaryIds" : [
+               "SGD:L000003944"
+            ],
+            "synonyms" : [
+               "NTS2-1"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Nontranscribed region of the rDNA repeat; located between RND5 and the 5'ETS; contains RNA polymerase I termination site",
+         "name" : "NonTranscribed Spacer",
+         "soTermId" : "SO:0000183",
+         "symbol" : "NTS2-1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000004867",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:Q04838"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXIII",
+                  "endPosition" : 777923,
+                  "startPosition" : 777615,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000004867",
+            "synonyms" : [
+               "YMR254C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Putative protein of unknown function; conserved across S. cerevisiae strains",
+         "soTermId" : "SO:0001217",
+         "symbol" : "YMR254C"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000005094",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P53902"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXIV",
+                  "endPosition" : 349658,
+                  "startPosition" : 349251,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "SGD:S000005094",
+            "synonyms" : [
+               "YNL150W"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Dubious open reading frame; unlikely to encode a functional protein, based on available experimental and comparative sequence data; extensive overlap with PGA2/YNL149C, an uncharacterized gene with a proposed role in protein trafficking",
+         "soTermId" : "SO:0001217",
+         "symbol" : "YNL150W"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "SGD:S000005064",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "homepage",
+                     "gene/expression",
+                     "gene/spell",
+                     "gene/interactions",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:P53922"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R64-2-1",
+                  "chromosome" : "chrXIV",
+                  "endPosition" : 401518,
+                  "startPosition" : 401033,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "SGD:S000005064",
+            "synonyms" : [
+               "YNL120C"
+            ],
+            "taxonId" : "NCBITaxon:559292"
+         },
+         "geneSynopsis" : "Dubious open reading frame; unlikely to encode a functional protein, based on available experimental and comparative sequence data; deletion enhances replication of Brome mosaic virus in S. cerevisiae, but likely due to effects on the overlapping gene",
+         "soTermId" : "SO:0001217",
+         "symbol" : "YNL120C"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00002859",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00002859",
+            "synonyms" : [
+               "mel-27"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "name" : "LEThal 725",
+         "soTermId" : "SO:0000704",
+         "symbol" : "let-725"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00004772",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00004772",
+            "synonyms" : [
+               "let-654"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "name" : "SEx Muscle abnormal 3",
+         "soTermId" : "SO:0000704",
+         "symbol" : "sem-3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00001011",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00001011",
+            "synonyms" : [
+               "mod-3"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "name" : "Defective MOrphogenesis (pka mod-) 3",
+         "soTermId" : "SO:0000704",
+         "symbol" : "dmo-3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00008371"
+               },
+               {
+                  "id" : "PANTHER:PTHR45862"
+               },
+               {
+                  "id" : "NCBI_Gene:179494"
+               },
+               {
+                  "id" : "UniProtKB:Q18949"
+               },
+               {
+                  "id" : "UniProtKB:J7RNI7"
+               },
+               {
+                  "id" : "WB:WBGene00008371",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:D1054.3",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "V",
+                  "endPosition" : 10772832,
+                  "startPosition" : 10771451,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00008371",
+            "synonyms" : [
+               "CELE_D1054.3"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is enriched in body wall muscle cell; germ line; germline precursor cell; intestine; and muscle cell based on tiling array; RNA-seq; and microarray studies. Is affected by several genes including daf-2; hsf-1; and let-7 based on microarray; proteomic; and RNA-seq studies. Is affected by eight chemicals including hydrogen sulfide; rotenone; and Zidovudine based on microarray and RNA-seq studies. Is predicted to encode a protein with the following domains: SGS domain and SGS domain. Is an ortholog of human SUGT1 (SGT1 homolog, MIS12 kinetochore complex assembly cochaperone).",
+         "name" : "SGS domain-containing protein",
+         "soTermId" : "SO:0001217",
+         "symbol" : "D1054.3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00010124"
+               },
+               {
+                  "id" : "PANTHER:PTHR47155"
+               },
+               {
+                  "id" : "NCBI_Gene:178248"
+               },
+               {
+                  "id" : "UniProtKB:G5EC22"
+               },
+               {
+                  "id" : "WB:WBGene00010124",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:F55G11.4",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 12975603,
+                  "startPosition" : 12973624,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00010124",
+            "synonyms" : [
+               "CELE_F55G11.4"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "F55G11.4 encodes a protein containing a CUB-like domain conserved amongst nematodes; F55G11.4 expression is increased in response to bacterial infection, suggesting that it plays a role in the defense response.",
+         "name" : "CUB_2 domain-containing protein",
+         "soTermId" : "SO:0001217",
+         "symbol" : "F55G11.4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00185089"
+               },
+               {
+                  "id" : "PANTHER:PTHR45646"
+               },
+               {
+                  "id" : "NCBI_Gene:13184588"
+               },
+               {
+                  "id" : "UniProtKB:C0Z1Y5"
+               },
+               {
+                  "id" : "WB:WBGene00185089",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:C16A11.10",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "II",
+                  "endPosition" : 4234620,
+                  "startPosition" : 4231385,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00185089",
+            "synonyms" : [
+               "CELE_C16A11.10"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is predicted to enable ATP binding activity and protein serine/threonine kinase activity.",
+         "name" : "Protein kinase domain-containing protein",
+         "soTermId" : "SO:0001217",
+         "symbol" : "C16A11.10"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00021342"
+               },
+               {
+                  "id" : "NCBI_Gene:189596"
+               },
+               {
+                  "id" : "WB:WBGene00021342",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:Y35H6.3",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "X",
+                  "endPosition" : 34439,
+                  "startPosition" : 16541,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00021342",
+            "secondaryIds" : [
+               "WB:WBGene00012160",
+               "WB:WBGene00012161"
+            ],
+            "synonyms" : [
+               "CELE_Y35H6.3"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is enriched in coelomocyte; germ line; germline precursor cell; and neurons based on tiling array and RNA-seq studies. Is affected by several genes including hsf-1; clk-1; and sek-1 based on tiling array; RNA-seq; and microarray studies. Is affected by seven chemicals including rotenone; D-glucose; and Psoralens based on RNA-seq studies.",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Y35H6.3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00018582"
+               },
+               {
+                  "id" : "NCBI_Gene:185958"
+               },
+               {
+                  "id" : "UniProtKB:O01567"
+               },
+               {
+                  "id" : "WB:WBGene00018582",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:F48A9.2",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "I",
+                  "endPosition" : 6598927,
+                  "startPosition" : 6592469,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00018582",
+            "secondaryIds" : [
+               "WB:WBGene00017067",
+               "WB:WBGene00018581"
+            ],
+            "synonyms" : [
+               "CELE_F48A9.2"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is enriched in head mesodermal cell; intestine; neurons; pharynx; and seam cell based on microarray; tiling array; and RNA-seq studies. Is affected by several genes including daf-2; rrf-3; and hsf-1 based on microarray; tiling array; and RNA-seq studies. Is affected by eleven chemicals including Mercuric Chloride; stavudine; and Psoralens based on microarray and RNA-seq studies.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "F48A9.2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00001495"
+               },
+               {
+                  "id" : "PANTHER:PTHR24180"
+               },
+               {
+                  "id" : "NCBI_Gene:266949"
+               },
+               {
+                  "id" : "UniProtKB:C6KRI0"
+               },
+               {
+                  "id" : "WB:WBGene00001495",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:F31B12.3",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "X",
+                  "endPosition" : 10820611,
+                  "startPosition" : 10819442,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00001495",
+            "secondaryIds" : [
+               "WB:WBGene00007318",
+               "WB:WBGene00009282"
+            ],
+            "synonyms" : [
+               "CELE_F31B12.3"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "frm-9 encodes a B41/ERM (ezrin/radixin/moesin) domain containing protein.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "F31B12.3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00014451"
+               },
+               {
+                  "id" : "WB:WBGene00014451",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:MTCE.2",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "MtDNA",
+                  "endPosition" : 111,
+                  "startPosition" : 58,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00014451",
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is affected by prg-1 based on RNA-seq studies.",
+         "soTermId" : "SO:0001272",
+         "symbol" : "MTCE.2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00014464"
+               },
+               {
+                  "id" : "WB:WBGene00014464",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:MTCE.20",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "MtDNA",
+                  "endPosition" : 4502,
+                  "startPosition" : 4447,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00014464",
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is affected by prg-1 based on RNA-seq studies.",
+         "soTermId" : "SO:0001272",
+         "symbol" : "MTCE.20"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00014462"
+               },
+               {
+                  "id" : "WB:WBGene00014462",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:MTCE.18",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "MtDNA",
+                  "endPosition" : 4383,
+                  "startPosition" : 4330,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00014462",
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is affected by prg-1 based on RNA-seq studies.",
+         "soTermId" : "SO:0001272",
+         "symbol" : "MTCE.18"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00016437"
+               },
+               {
+                  "id" : "NCBI_Gene:3565455"
+               },
+               {
+                  "id" : "UniProtKB:Q7YXG5"
+               },
+               {
+                  "id" : "WB:WBGene00016437",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:C35B1.8",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 4079001,
+                  "startPosition" : 4077642,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00016437",
+            "synonyms" : [
+               "C35B1.b",
+               "CELE_C35B1.8"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is affected by several genes including daf-2; rrf-3; and hsf-1 based on tiling array; microarray; and RNA-seq studies. Is affected by seven chemicals including Ethanol; Zidovudine; and Psoralens based on RNA-seq and microarray studies.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "C35B1.8"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00009881"
+               },
+               {
+                  "id" : "PANTHER:PTHR31733"
+               },
+               {
+                  "id" : "NCBI_Gene:177755"
+               },
+               {
+                  "id" : "UniProtKB:Q20589"
+               },
+               {
+                  "id" : "UniProtKB:X5LX67"
+               },
+               {
+                  "id" : "WB:WBGene00009881",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:F49C12.12",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 9321089,
+                  "startPosition" : 9320122,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00009881",
+            "synonyms" : [
+               "CELE_F49C12.12",
+               "phi-62"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is predicted to enable endoribonuclease activity. Is an ortholog of human RNASEK (ribonuclease K).",
+         "soTermId" : "SO:0001217",
+         "symbol" : "F49C12.12"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00045162"
+               },
+               {
+                  "id" : "NCBI_Gene:7040181"
+               },
+               {
+                  "id" : "RNAcentral:URS000045D58C"
+               },
+               {
+                  "id" : "WB:WBGene00045162",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:F25H2.15",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "I",
+                  "endPosition" : 10565443,
+                  "startPosition" : 10565266,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00045162",
+            "synonyms" : [
+               "CELE_F25H2.15",
+               "Ce1a"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is enriched in germ line based on RNA-seq studies. Is affected by several genes including cep-1; prg-1; and hpl-2 based on RNA-seq studies. Is affected by multi-walled carbon nanotube and bisphenol A based on RNA-seq studies.",
+         "soTermId" : "SO:0001267",
+         "symbol" : "F25H2.15"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00044071"
+               },
+               {
+                  "id" : "PANTHER:PTHR24161"
+               },
+               {
+                  "id" : "NCBI_Gene:181109"
+               },
+               {
+                  "id" : "UniProtKB:Q7Z127"
+               },
+               {
+                  "id" : "UniProtKB:H2KYE9"
+               },
+               {
+                  "id" : "WB:WBGene00044071",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:dhhc-14",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "X",
+                  "endPosition" : 8556360,
+                  "startPosition" : 8552277,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00044071",
+            "secondaryIds" : [
+               "WB:WBGene00017047",
+               "WB:WBGene00017049"
+            ],
+            "synonyms" : [
+               "CELE_D2021.2",
+               "D2021.2",
+               "tag-233"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is predicted to enable protein-cysteine S-palmitoyltransferase activity. Is expressed in body wall musculature and neurons. Is an ortholog of human ZDHHC17 (zinc finger DHHC-type palmitoyltransferase 17).",
+         "name" : "DHHC-types zinc finger protein 14",
+         "soTermId" : "SO:0001217",
+         "symbol" : "dhhc-14"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00022048"
+               },
+               {
+                  "id" : "PANTHER:PTHR38537"
+               },
+               {
+                  "id" : "NCBI_Gene:176855"
+               },
+               {
+                  "id" : "UniProtKB:U4PM04"
+               },
+               {
+                  "id" : "UniProtKB:U4PB53"
+               },
+               {
+                  "id" : "UniProtKB:U4PBJ9"
+               },
+               {
+                  "id" : "UniProtKB:U4PB58"
+               },
+               {
+                  "id" : "UniProtKB:D0IMZ8"
+               },
+               {
+                  "id" : "UniProtKB:D0IMZ5"
+               },
+               {
+                  "id" : "UniProtKB:U4PEE8"
+               },
+               {
+                  "id" : "UniProtKB:U4PR97"
+               },
+               {
+                  "id" : "UniProtKB:D0IMZ6"
+               },
+               {
+                  "id" : "UniProtKB:U4PBK4"
+               },
+               {
+                  "id" : "UniProtKB:U4PEF1"
+               },
+               {
+                  "id" : "UniProtKB:U4PRA0"
+               },
+               {
+                  "id" : "UniProtKB:U4PM09"
+               },
+               {
+                  "id" : "UniProtKB:Q9TYW4"
+               },
+               {
+                  "id" : "UniProtKB:D0IMZ7"
+               },
+               {
+                  "id" : "UniProtKB:U4PM01"
+               },
+               {
+                  "id" : "UniProtKB:U4PEE3"
+               },
+               {
+                  "id" : "UniProtKB:U4PR92"
+               },
+               {
+                  "id" : "WB:WBGene00022048",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:fln-1",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 376015,
+                  "startPosition" : 359223,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00022048",
+            "secondaryIds" : [
+               "WB:WBGene00022049",
+               "WB:WBGene00022050"
+            ],
+            "synonyms" : [
+               "CELE_Y66H1B.2",
+               "Y66H1B.2"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "fln-1 encodes three protein isoforms, a full length filamin (fln-1a) orthologous to human filamin A, alpha (FLNA; OMIM:300017), of 2257 amino acids containing a well conserved N-terminal ABD and 20 Ig-like repeats and  two trans-sliced versions with C- and N- terminal truncations are 1084 and 836 amino-acids respectively; expression of full-length filamin in hermaphrodites is required for normal brood size; depletion of fln-1 in the germline does not contribute to the brood size defects; in fln-1 mutants, misshapen embryos and embryonic lethality are resulted from maternal defect during ovulation; fln-1 is required for normal exit of embryos from spermatheca by maintaining its correct morphology; in fln-1 mutants spermatheca-uterine lariat is severely disorganized and lacks the characteristic branching filament; filamin is primarly required to maintain the F-actin cytoskeleton in response to stretching by the oocyte during ovulation; fln-1::GFP is expressed in early L4 stage, adults and in the uterus, spermatheca and proximal gonadal sheath and weakly expressed in the posterior intestinal cells, anal depressor muscle, unidentified neurons and pharynx.",
+         "name" : "FiLamiN (actin binding protein) homolog 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "fln-1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00006454"
+               },
+               {
+                  "id" : "PANTHER:PTHR19305"
+               },
+               {
+                  "id" : "NCBI_Gene:188509"
+               },
+               {
+                  "id" : "UniProtKB:G5EEN8"
+               },
+               {
+                  "id" : "WB:WBGene00006454",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:aex-4",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "X",
+                  "endPosition" : 3731961,
+                  "startPosition" : 3729281,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00006454",
+            "secondaryIds" : [
+               "WB:WBGene00000087",
+               "WB:WBGene00020513"
+            ],
+            "synonyms" : [
+               "CELE_T14G12.2",
+               "T14G12.2",
+               "tag-81"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is involved in positive regulation of defecation and positive regulation of protein secretion. Located in plasma membrane.",
+         "name" : "ABoc, EXpulsion (defecation) defective 4",
+         "soTermId" : "SO:0001217",
+         "symbol" : "aex-4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00014280"
+               },
+               {
+                  "id" : "NCBI_Gene:183282"
+               },
+               {
+                  "id" : "WB:WBGene00014280",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:C36F7.t2",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "I",
+                  "endPosition" : 9562437,
+                  "startPosition" : 9562353,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00014280",
+            "synonyms" : [
+               "CELE_C36F7.t2",
+               "CELUV05"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001272",
+         "symbol" : "C36F7.t2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00219820"
+               },
+               {
+                  "id" : "NCBI_Gene:24104217"
+               },
+               {
+                  "id" : "RNAcentral:URS000021AD5D"
+               },
+               {
+                  "id" : "WB:WBGene00219820",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:C17D12.17",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "I",
+                  "endPosition" : 11595198,
+                  "startPosition" : 11595127,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00219820",
+            "synonyms" : [
+               "CELE_C17D12.17",
+               "cel-inc84"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001263",
+         "symbol" : "C17D12.17"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00220127"
+               },
+               {
+                  "id" : "NCBI_Gene:24105009"
+               },
+               {
+                  "id" : "RNAcentral:URS000034A322"
+               },
+               {
+                  "id" : "WB:WBGene00220127",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes"
+                  ]
+               },
+               {
+                  "id" : "WB:W10D5.5",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "I",
+                  "endPosition" : 9106697,
+                  "startPosition" : 9106600,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00220127",
+            "synonyms" : [
+               "CELE_W10D5.5",
+               "cel-inc60"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001263",
+         "symbol" : "W10D5.5"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "RNAcentral:URS0001981266"
+               },
+               {
+                  "id" : "WB:WBGene00305401",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:F37E3.6",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00305401",
+            "synonyms" : [
+               "cel_circ_008372"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001263",
+         "symbol" : "F37E3.6"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "RNAcentral:URS00019810D3"
+               },
+               {
+                  "id" : "WB:WBGene00305783",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:Y50D7A.20",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00305783",
+            "synonyms" : [
+               "cel_circ_004591"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001263",
+         "symbol" : "Y50D7A.20"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "RNAcentral:URS0001980E24"
+               },
+               {
+                  "id" : "WB:WBGene00305835",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:Y56A3A.42",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00305835",
+            "synonyms" : [
+               "cel_circ_005714"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001263",
+         "symbol" : "Y56A3A.42"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00011456"
+               },
+               {
+                  "id" : "NCBI_Gene:188077"
+               },
+               {
+                  "id" : "UniProtKB:Q22189"
+               },
+               {
+                  "id" : "UniProtKB:Q2XN03"
+               },
+               {
+                  "id" : "WB:WBGene00011456",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:T05A1.5",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 9560446,
+                  "startPosition" : 9546286,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00011456",
+            "secondaryIds" : [
+               "WB:WBGene00011457"
+            ],
+            "synonyms" : [
+               "CELE_T05A1.5"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is predicted to enable transmembrane transporter activity. Is an ortholog of several human genes including SLC22A11 (solute carrier family 22 member 11); SLC22A24 (solute carrier family 22 member 24); and SLC22A25 (solute carrier family 22 member 25).",
+         "name" : "MFS domain-containing protein",
+         "soTermId" : "SO:0001217",
+         "symbol" : "T05A1.5"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00009521"
+               },
+               {
+                  "id" : "PANTHER:PTHR43134"
+               },
+               {
+                  "id" : "NCBI_Gene:185438"
+               },
+               {
+                  "id" : "UniProtKB:G4RYA5"
+               },
+               {
+                  "id" : "WB:WBGene00009521",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:F38A1.8",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 1239852,
+                  "startPosition" : 1232825,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00009521",
+            "secondaryIds" : [
+               "WB:WBGene00021119"
+            ],
+            "synonyms" : [
+               "CELE_F38A1.8"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is predicted to enable GTP binding activity; GTPase activity; and signal recognition particle binding activity. Is an ortholog of human SRPRA (SRP receptor subunit alpha).",
+         "name" : "SRP54 domain-containing protein",
+         "soTermId" : "SO:0001217",
+         "symbol" : "F38A1.8"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00009220"
+               },
+               {
+                  "id" : "PANTHER:PTHR13141"
+               },
+               {
+                  "id" : "NCBI_Gene:173012"
+               },
+               {
+                  "id" : "UniProtKB:D5MNM9"
+               },
+               {
+                  "id" : "WB:WBGene00009220",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:F28D9.4",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "I",
+                  "endPosition" : 11177728,
+                  "startPosition" : 11168511,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00009220",
+            "secondaryIds" : [
+               "WB:WBGene00013131"
+            ],
+            "synonyms" : [
+               "CELE_F28D9.4"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is enriched in OLL; PVD; germ line; and muscle cell based on microarray and RNA-seq studies. Is affected by several genes including daf-2; glp-1; and sir-2.1 based on microarray; proteomic; and RNA-seq studies. Is affected by bisphenol S and Sirolimus based on RNA-seq studies. Is predicted to encode a protein with the following domain: Transmembrane protein 242.",
+         "name" : "Transmembrane protein 242",
+         "soTermId" : "SO:0001217",
+         "symbol" : "F28D9.4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00003193",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00003193",
+            "synonyms" : [
+               "mel-6"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "mel-8 was identified in screens for maternal-effect lethal mutations on chromosome II; mel-8 is a highly mutable gene with multiple alleles that result in male-rescuable embryonic lethality.",
+         "name" : "Maternal Effect Lethal 8",
+         "soTermId" : "SO:0000704",
+         "symbol" : "mel-8"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00000127",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00000127",
+            "synonyms" : [
+               "arm-4"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "amo-4 is required maternally for embryonic viability.",
+         "name" : "Abnormal MOrphogenesis 4",
+         "soTermId" : "SO:0000704",
+         "symbol" : "amo-4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00001003",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00001003",
+            "synonyms" : [
+               "ccd-2"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Uncloned locus required for embryonic viability that regulates the timing of cell divisions; it particularly affects embryonic cell division in the P1 cell.",
+         "name" : "cell DIVision defective 2",
+         "soTermId" : "SO:0000704",
+         "symbol" : "div-2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00014458"
+               },
+               {
+                  "id" : "WB:WBGene00014458",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:MTCE.13",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "MtDNA",
+                  "endPosition" : 3305,
+                  "startPosition" : 3244,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00014458",
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001272",
+         "symbol" : "MTCE.13"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00014457"
+               },
+               {
+                  "id" : "WB:WBGene00014457",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:MTCE.10",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "MtDNA",
+                  "endPosition" : 1761,
+                  "startPosition" : 1707,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00014457",
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001272",
+         "symbol" : "MTCE.10"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00014473"
+               },
+               {
+                  "id" : "WB:WBGene00014473",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:MTCE.36",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "MtDNA",
+                  "endPosition" : 13327,
+                  "startPosition" : 13275,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00014473",
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001272",
+         "symbol" : "MTCE.36"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00021319"
+               },
+               {
+                  "id" : "PANTHER:PTHR15157"
+               },
+               {
+                  "id" : "NCBI_Gene:189585"
+               },
+               {
+                  "id" : "UniProtKB:A7DT33"
+               },
+               {
+                  "id" : "WB:WBGene00021319",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:Y34B4A.2",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "X",
+                  "endPosition" : 5283719,
+                  "startPosition" : 5279497,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00021319",
+            "secondaryIds" : [
+               "WB:WBGene00045435"
+            ],
+            "synonyms" : [
+               "CELE_Y34B4A.2",
+               "Y34B4A.f",
+               "Y34B4A.g"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is involved in regulation of endosome size. Is an ortholog of human UVRAG (UV radiation resistance associated).",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Y34B4A.2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00014312"
+               },
+               {
+                  "id" : "NCBI_Gene:260092"
+               },
+               {
+                  "id" : "RNAcentral:URS000035BC7B"
+               },
+               {
+                  "id" : "WB:WBGene00014312",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:F08G2.11",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "II",
+                  "endPosition" : 13852972,
+                  "startPosition" : 13852787,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00014312",
+            "secondaryIds" : [
+               "WB:WBGene00201144"
+            ],
+            "synonyms" : [
+               "CELE_F08G2.11",
+               "U2"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is affected by dlc-1 and sftb-1 based on RNA-seq studies.",
+         "soTermId" : "SO:0001268",
+         "symbol" : "F08G2.11"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00019847"
+               },
+               {
+                  "id" : "NCBI_Gene:187543"
+               },
+               {
+                  "id" : "UniProtKB:Q8MQ01"
+               },
+               {
+                  "id" : "WB:WBGene00019847",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:R03G5.6",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "X",
+                  "endPosition" : 7816924,
+                  "startPosition" : 7805624,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00019847",
+            "secondaryIds" : [
+               "WB:WBGene00019848"
+            ],
+            "synonyms" : [
+               "CELE_R03G5.6",
+               "R03G5.c"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is enriched in DA neuron; RIS; VA neuron; and dopaminergic neurons based on tiling array; RNA-seq; and microarray studies. Is affected by several genes including daf-2; daf-12; and hsf-1 based on microarray; tiling array; and RNA-seq studies. Is affected by five chemicals including stavudine; Diazinon; and Quercetin based on RNA-seq and microarray studies.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "R03G5.6"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00022693",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00022693",
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is affected by several genes including daf-16; eat-2; and sek-1 based on RNA-seq and microarray studies. Is affected by six chemicals including Sodium Chloride; Psoralens; and allantoin based on RNA-seq and microarray studies.",
+         "soTermId" : "SO:0000336",
+         "symbol" : "ZK250.10"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00013711"
+               },
+               {
+                  "id" : "PANTHER:PTHR10663"
+               },
+               {
+                  "id" : "NCBI_Gene:172898"
+               },
+               {
+                  "id" : "UniProtKB:O18093"
+               },
+               {
+                  "id" : "WB:WBGene00013711",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:Y106G6G.2",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "I",
+                  "endPosition" : 10327870,
+                  "startPosition" : 10300568,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00013711",
+            "secondaryIds" : [
+               "WB:WBGene00011866",
+               "WB:WBGene00013715"
+            ],
+            "synonyms" : [
+               "CELE_Y106G6G.2"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is predicted to enable guanyl-nucleotide exchange factor activity. Is an ortholog of human ARFGEF3 (ARFGEF family member 3).",
+         "name" : "SEC7 domain-containing protein",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Y106G6G.2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00045063"
+               },
+               {
+                  "id" : "PANTHER:PTHR15829"
+               },
+               {
+                  "id" : "NCBI_Gene:4927018"
+               },
+               {
+                  "id" : "UniProtKB:A0A061ADZ4"
+               },
+               {
+                  "id" : "UniProtKB:D1MN86"
+               },
+               {
+                  "id" : "UniProtKB:G5EE35"
+               },
+               {
+                  "id" : "UniProtKB:G5EDU9"
+               },
+               {
+                  "id" : "UniProtKB:O45268"
+               },
+               {
+                  "id" : "UniProtKB:B3GWD4"
+               },
+               {
+                  "id" : "UniProtKB:C6KRP1"
+               },
+               {
+                  "id" : "RNAcentral:URS000046097A"
+               },
+               {
+                  "id" : "WB:WBGene00045063",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:Y37A1A.4",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 13964008,
+                  "startPosition" : 13934386,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00045063",
+            "secondaryIds" : [
+               "WB:WBGene00007782",
+               "WB:WBGene00045064"
+            ],
+            "synonyms" : [
+               "CELE_Y37A1A.4"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is enriched in several structures, including Z1.p; excretory cell; male distal tip cell; neurons; and somatic gonad precursor based on microarray; tiling array; and RNA-seq studies. Is affected by several genes including let-60; hsf-1; and sek-1 based on microarray and RNA-seq studies. Is affected by eighteen chemicals including 1-methylnicotinamide; rotenone; and D-glucose based on RNA-seq and microarray studies. Human ortholog(s) of this gene are implicated in autosomal recessive nonsyndromic deafness 104. Is predicted to encode a protein with the following domains: Filopodia upregulated, FAM65; RIPOR family member 3; and FAM65, N-terminal. Is an ortholog of human RIPOR2 (RHO family interacting cell polarization regulator 2) and RIPOR3 (RIPOR family member 3).",
+         "name" : "PL48 domain-containing protein",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Y37A1A.4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00013639"
+               },
+               {
+                  "id" : "PANTHER:PTHR46169"
+               },
+               {
+                  "id" : "NCBI_Gene:178442"
+               },
+               {
+                  "id" : "UniProtKB:A0A078BS51"
+               },
+               {
+                  "id" : "UniProtKB:A0A078BPJ6"
+               },
+               {
+                  "id" : "UniProtKB:D3NQA6"
+               },
+               {
+                  "id" : "UniProtKB:Q9U323"
+               },
+               {
+                  "id" : "RNAcentral:URS00007B28C1"
+               },
+               {
+                  "id" : "WB:WBGene00013639",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:Y105C5A.15",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 15722553,
+                  "startPosition" : 15689201,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00013639",
+            "secondaryIds" : [
+               "WB:WBGene00044740",
+               "WB:WBGene00219211"
+            ],
+            "synonyms" : [
+               "CELE_Y105C5A.15"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is predicted to enable metal ion binding activity. Is expressed in pharynx.",
+         "name" : "BED-type domain-containing protein",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Y105C5A.15"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00048894"
+               },
+               {
+                  "id" : "NCBI_Gene:13209916"
+               },
+               {
+                  "id" : "RNAcentral:URS000041CD24"
+               },
+               {
+                  "id" : "WB:WBGene00048894",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:21ur-120",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 16707140,
+                  "startPosition" : 16707120,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00048894",
+            "secondaryIds" : [
+               "WB:WBGene00172005"
+            ],
+            "synonyms" : [
+               "21ur-10192",
+               "CELE_Y51H4A.259",
+               "Y51H4A.259"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "name" : "21U-RNA 120",
+         "soTermId" : "SO:0001638",
+         "symbol" : "21ur-120"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00048996"
+               },
+               {
+                  "id" : "NCBI_Gene:13209989"
+               },
+               {
+                  "id" : "RNAcentral:URS00003C189B"
+               },
+               {
+                  "id" : "WB:WBGene00048996",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:21ur-1262",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 16727378,
+                  "startPosition" : 16727358,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00048996",
+            "secondaryIds" : [
+               "WB:WBGene00171874"
+            ],
+            "synonyms" : [
+               "21ur-12999",
+               "CELE_Y51H4A.269",
+               "Y51H4A.269"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "name" : "21U-RNA 1262",
+         "soTermId" : "SO:0001638",
+         "symbol" : "21ur-1262"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00049530"
+               },
+               {
+                  "id" : "NCBI_Gene:13209183"
+               },
+               {
+                  "id" : "RNAcentral:URS00001B10EC"
+               },
+               {
+                  "id" : "WB:WBGene00049530",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:21ur-3946",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 16527002,
+                  "startPosition" : 16526982,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00049530",
+            "secondaryIds" : [
+               "WB:WBGene00169945"
+            ],
+            "synonyms" : [
+               "21ur-12088",
+               "CELE_Y51H4A.310",
+               "Y51H4A.310"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "name" : "21U-RNA 3946",
+         "soTermId" : "SO:0001638",
+         "symbol" : "21ur-3946"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00002892",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00002892",
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "name" : "LEThal 768",
+         "soTermId" : "SO:0000704",
+         "symbol" : "let-768"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00002932",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00002932",
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "name" : "LEThal 825",
+         "soTermId" : "SO:0000704",
+         "symbol" : "let-825"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00002905",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00002905",
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "name" : "LEThal 789",
+         "soTermId" : "SO:0000704",
+         "symbol" : "let-789"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00022099"
+               },
+               {
+                  "id" : "NCBI_Gene:177043"
+               },
+               {
+                  "id" : "UniProtKB:Q95XH0"
+               },
+               {
+                  "id" : "WB:WBGene00022099",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:Y69A2AR.28",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 2613061,
+                  "startPosition" : 2612432,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00022099",
+            "synonyms" : [
+               "CELE_Y69A2AR.28"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is enriched in several structures, including AFD; germ line; head mesodermal cell; intestine; and male distal tip cell based on RNA-seq and microarray studies. Is affected by several genes including daf-16; daf-2; and glp-1 based on RNA-seq and microarray studies. Is affected by eight chemicals including aldicarb; rotenone; and stavudine based on microarray and RNA-seq studies. Is predicted to encode a protein with the following domains: Spo12 family and Spo12.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Y69A2AR.28"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00016237"
+               },
+               {
+                  "id" : "NCBI_Gene:174021"
+               },
+               {
+                  "id" : "UniProtKB:Q18314"
+               },
+               {
+                  "id" : "WB:WBGene00016237",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:C29H12.6",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "II",
+                  "endPosition" : 6118263,
+                  "startPosition" : 6114426,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00016237",
+            "synonyms" : [
+               "CELE_C29H12.6"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is expressed in marginal cell.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "C29H12.6"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00200133"
+               },
+               {
+                  "id" : "NCBI_Gene:13189665"
+               },
+               {
+                  "id" : "RNAcentral:URS0000029581"
+               },
+               {
+                  "id" : "WB:WBGene00200133",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:R12B2.11",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "III",
+                  "endPosition" : 5823171,
+                  "startPosition" : 5823024,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00200133",
+            "synonyms" : [
+               "CELE_R12B2.11"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is affected by cep-1 based on RNA-seq studies.",
+         "soTermId" : "SO:0001263",
+         "symbol" : "R12B2.11"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00021681"
+               },
+               {
+                  "id" : "PANTHER:PTHR31824"
+               },
+               {
+                  "id" : "NCBI_Gene:3564797"
+               },
+               {
+                  "id" : "UniProtKB:V6CL97"
+               },
+               {
+                  "id" : "UniProtKB:V6CL71"
+               },
+               {
+                  "id" : "WB:WBGene00021681",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:Y48G1C.8",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "I",
+                  "endPosition" : 108223,
+                  "startPosition" : 96459,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00021681",
+            "secondaryIds" : [
+               "WB:WBGene00021680",
+               "WB:WBGene00206367"
+            ],
+            "synonyms" : [
+               "CELE_Y48G1C.8",
+               "Y48G1C.a",
+               "Y48G1C.b"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is enriched in NSM; OLL; PVD; and germ line based on microarray and RNA-seq studies. Is affected by several genes including daf-2; daf-12; and dpy-10 based on microarray; RNA-seq; tiling array; and proteomic studies. Is affected by seven chemicals including rotenone; Zidovudine; and paraquat based on RNA-seq and microarray studies. Is predicted to encode a protein with the following domain: .",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Y48G1C.8"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00020957"
+               },
+               {
+                  "id" : "PANTHER:PTHR15435"
+               },
+               {
+                  "id" : "NCBI_Gene:189134"
+               },
+               {
+                  "id" : "UniProtKB:A0A1I6CMB1"
+               },
+               {
+                  "id" : "WB:WBGene00020957",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:W02H5.2",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "V",
+                  "endPosition" : 2646594,
+                  "startPosition" : 2639335,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00020957",
+            "secondaryIds" : [
+               "WB:WBGene00020956",
+               "WB:WBGene00020963"
+            ],
+            "synonyms" : [
+               "CELE_W02H5.2",
+               "W02H5.j",
+               "W02H5.k",
+               "W02H5.l",
+               "W02H5.m"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is predicted to enable actin binding activity. Human ortholog(s) of this gene are implicated in autosomal recessive non-syndromic intellectual disability. Is an ortholog of human KPTN (kaptin, actin binding protein).",
+         "soTermId" : "SO:0001217",
+         "symbol" : "W02H5.2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00003296"
+               },
+               {
+                  "id" : "NCBI_Gene:260240"
+               },
+               {
+                  "id" : "RNAcentral:URS000000F862"
+               },
+               {
+                  "id" : "WB:WBGene00003296",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:Y51H4A.27",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 16717400,
+                  "startPosition" : 16717380,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00003296",
+            "secondaryIds" : [
+               "WB:WBGene00166056",
+               "WB:WBGene00169241"
+            ],
+            "synonyms" : [
+               "21ur-14297",
+               "21ur-14355",
+               "21ur-5527",
+               "CELE_Y51H4A.27",
+               "mir-68"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Y51H4A.27 was published as a microRNA but is now classified as an endogenous siRNA; the product of Y51H4A.27 could not be detected on Northern blots and neither it, nor its predicted precursor, appears to be conserved in other species; the precise function of Y51H4A.27 is not known.",
+         "soTermId" : "SO:0001263",
+         "symbol" : "Y51H4A.27"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00010249"
+               },
+               {
+                  "id" : "NCBI_Gene:186504"
+               },
+               {
+                  "id" : "UniProtKB:O02276"
+               },
+               {
+                  "id" : "WB:WBGene00010249",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:F58D12.1",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "V",
+                  "endPosition" : 14054663,
+                  "startPosition" : 14049574,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00010249",
+            "secondaryIds" : [
+               "WB:WBGene00050901"
+            ],
+            "synonyms" : [
+               "CELE_F58D12.1"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "F58D12.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00014321"
+               },
+               {
+                  "id" : "NCBI_Gene:184327"
+               },
+               {
+                  "id" : "WB:WBGene00014321",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:F11A1.t2",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "X",
+                  "endPosition" : 10667093,
+                  "startPosition" : 10667022,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00014321",
+            "secondaryIds" : [
+               "WB:WBGene00139735"
+            ],
+            "synonyms" : [
+               "CELE_F11A1.t2"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001272",
+         "symbol" : "F11A1.t2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00002856",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00002856",
+            "synonyms" : [
+               "let-744",
+               "let-772"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "name" : "LEThal 722",
+         "soTermId" : "SO:0000704",
+         "symbol" : "let-722"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00001478"
+               },
+               {
+                  "id" : "PANTHER:PTHR23023"
+               },
+               {
+                  "id" : "NCBI_Gene:176491"
+               },
+               {
+                  "id" : "UniProtKB:A0A1X7RC69"
+               },
+               {
+                  "id" : "UniProtKB:G5ECJ8"
+               },
+               {
+                  "id" : "WB:WBGene00001478",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:fmo-3",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "III",
+                  "endPosition" : 10698864,
+                  "startPosition" : 10694681,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00001478",
+            "synonyms" : [
+               "CELE_Y39A1A.19",
+               "Y39A1A.19",
+               "fmo-13"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "fmo-3 encodes a flavin-containing monoxygenase homologous to human FMO1, FMO2, and FMO3 (OMIM:602079, mutated in trimethylaminuria).",
+         "name" : "Flavin-containing MonoOxygenase family 3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "fmo-3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00005669"
+               },
+               {
+                  "id" : "PANTHER:PTHR46045"
+               },
+               {
+                  "id" : "NCBI_Gene:183142"
+               },
+               {
+                  "id" : "UniProtKB:Q18363"
+               },
+               {
+                  "id" : "WB:WBGene00005669",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:sru-6",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 9491991,
+                  "startPosition" : 9490620,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00005669",
+            "synonyms" : [
+               "C33A12.8",
+               "CELE_C33A12.8"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is enriched in NSM based on tiling array studies. Is affected by sir-2.1 based on microarray studies. Is affected by Diazinon; adsorbable organic bromine compound; and Sirolimus based on microarray studies. Is predicted to encode a protein with the following domains: Serpentine type 7TM GPCR chemoreceptor Sru and 7TM GPCR, serpentine receptor class u (Sru).",
+         "name" : "Serpentine Receptor, class U 6",
+         "soTermId" : "SO:0001217",
+         "symbol" : "sru-6"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00001592"
+               },
+               {
+                  "id" : "PANTHER:PTHR18945"
+               },
+               {
+                  "id" : "NCBI_Gene:172103"
+               },
+               {
+                  "id" : "UniProtKB:Q17328"
+               },
+               {
+                  "id" : "WB:WBGene00001592",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:glc-2",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "I",
+                  "endPosition" : 4888002,
+                  "startPosition" : 4885041,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00001592",
+            "synonyms" : [
+               "CELE_F25F8.2",
+               "F25F8.2",
+               "GluCl beta",
+               "avm-2"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "glc-2 encodes the beta subunit of a glutamate-gated chloride channel; in vivo, GLC-2 is capable of forming homomeric glutamate-activated channels, as well as heteromeric channels with GLC-1 that can be activated by glutamate and avermectins, antihelmintics that inhibit pharyngeal pumping; as loss of glc-2 activity via large-scale RNAi screens does not result in any obvious abnormalities, the precise role of GLC-2 in development and/or behavior is not yet known; however, GLC-2 expression is generally restricted to the pm4 pharyngeal muscles of larvae and adults, suggesting a role for GLC-2 in regulation of glutamatergic inhibition of pharyngeal pumping.",
+         "name" : "Glutamate-gated ChLoride channel 2",
+         "soTermId" : "SO:0001217",
+         "symbol" : "glc-2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00044542"
+               },
+               {
+                  "id" : "PANTHER:PTHR13678"
+               },
+               {
+                  "id" : "NCBI_Gene:183877"
+               },
+               {
+                  "id" : "UniProtKB:Q4R133"
+               },
+               {
+                  "id" : "WB:WBGene00044542",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:CD4.11",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "V",
+                  "endPosition" : 5591683,
+                  "startPosition" : 5585133,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00044542",
+            "secondaryIds" : [
+               "WB:WBGene00016991"
+            ],
+            "synonyms" : [
+               "CELE_CD4.11"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is enriched in body wall muscle cell based on tiling array studies. Is affected by several genes including glp-1; rrf-3; and daf-12 based on tiling array; microarray; and RNA-seq studies. Is affected by eight chemicals including Tunicamycin; Sodium Chloride; and Psoralens based on microarray and RNA-seq studies. Is predicted to encode a protein with the following domain: Concanavalin A-like lectin/glucanase domain superfamily.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CD4.11"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00045024"
+               },
+               {
+                  "id" : "NCBI_Gene:4926926"
+               },
+               {
+                  "id" : "UniProtKB:Q067X3"
+               },
+               {
+                  "id" : "UniProtKB:G5EGM8"
+               },
+               {
+                  "id" : "WB:WBGene00045024",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:C43F9.11",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 10600145,
+                  "startPosition" : 10596805,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00045024",
+            "secondaryIds" : [
+               "WB:WBGene00045070"
+            ],
+            "synonyms" : [
+               "CELE_C43F9.11"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is affected by several genes including daf-16; daf-2; and rrf-3 based on tiling array; RNA-seq; and microarray studies. Is affected by five chemicals including 1-methylnicotinamide; multi-walled carbon nanotube; and Sirolimus based on RNA-seq and microarray studies.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "C43F9.11"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00017805"
+               },
+               {
+                  "id" : "NCBI_Gene:184946"
+               },
+               {
+                  "id" : "WB:WBGene00017805",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:F26A1.7",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "III",
+                  "endPosition" : 4819943,
+                  "startPosition" : 4815820,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00017805",
+            "secondaryIds" : [
+               "WB:WBGene00017804"
+            ],
+            "synonyms" : [
+               "CELE_F26A1.7"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is enriched in head mesodermal cell based on RNA-seq studies. Is affected by several genes including let-60; eat-2; and pgl-1 based on microarray; tiling array; and RNA-seq studies. Is affected by eight chemicals including stavudine; Rifampin; and Atrazine based on RNA-seq and microarray studies. Is predicted to encode a protein with the following domains: Sulfite exporter TauE/SafE and Transmembrane protein TauE-like.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "F26A1.7"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00174113"
+               },
+               {
+                  "id" : "NCBI_Gene:13201929"
+               },
+               {
+                  "id" : "RNAcentral:URS00004EAC6D"
+               },
+               {
+                  "id" : "WB:WBGene00174113",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:21ur-7117",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 14501219,
+                  "startPosition" : 14501199,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00174113",
+            "synonyms" : [
+               "CELE_Y57G11A.214",
+               "Y57G11A.214"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "name" : "21U-RNA 7117",
+         "soTermId" : "SO:0001638",
+         "symbol" : "21ur-7117"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00048094"
+               },
+               {
+                  "id" : "NCBI_Gene:13202009"
+               },
+               {
+                  "id" : "RNAcentral:URS00005FDD59"
+               },
+               {
+                  "id" : "WB:WBGene00048094",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:21ur-1091",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 14526308,
+                  "startPosition" : 14526288,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00048094",
+            "synonyms" : [
+               "CELE_T27E7.25",
+               "T27E7.25"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "name" : "21U-RNA 1091",
+         "soTermId" : "SO:0001638",
+         "symbol" : "21ur-1091"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00165781"
+               },
+               {
+                  "id" : "NCBI_Gene:13207359"
+               },
+               {
+                  "id" : "RNAcentral:URS000042E34D"
+               },
+               {
+                  "id" : "WB:WBGene00165781",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:21ur-10825",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 15959024,
+                  "startPosition" : 15959004,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00165781",
+            "synonyms" : [
+               "CELE_Y105C5B.668",
+               "Y105C5B.668"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "name" : "21U-RNA 10825",
+         "soTermId" : "SO:0001638",
+         "symbol" : "21ur-10825"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00000825",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00000825",
+            "synonyms" : [
+               "dmo-4",
+               "mod-4"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Uncloned locus that is required maternally for embryonic viability and affects the distribution of yolk granules in the cytoplasm.",
+         "name" : "CyToplasmic Appearance 2",
+         "soTermId" : "SO:0000704",
+         "symbol" : "cta-2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00004362",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00004362",
+            "synonyms" : [
+               "lan-5",
+               "osm-13",
+               "ric-5"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "ric-1 was identified in screens for mutations that confer resistance to acetylcholinesterase inhibitors; ric-1 mutations confer resistance to aldicarb and result in jerky, uncoordinated movement which phenotypic analyses suggest may be due to defects in acetycholine release; ric-1 is defined by at least 19 alleles.",
+         "name" : "Resistance to Inhibitors of Cholinesterase 1",
+         "soTermId" : "SO:0000704",
+         "symbol" : "ric-1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00003502",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00003502",
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Uncloned locus that affects germlline transposition and excision of Tc1 in a Bergerac strain.",
+         "name" : "MUTator 5",
+         "soTermId" : "SO:0000704",
+         "symbol" : "mut-5"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00077743",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00077743",
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is involved in embryo development and regulation of centrosome duplication.",
+         "name" : "Suppressor of ZYg-1 15",
+         "soTermId" : "SO:0000704",
+         "symbol" : "szy-15"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "WB:WBGene00001257",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00001257",
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Uncloned locus required for embryonic viability that affects the rate and sequence of early embryonic divisions, spindle structure, and chromosome pairing during meiosis I.",
+         "name" : "abnormal EMBroygenesis 3",
+         "soTermId" : "SO:0000704",
+         "symbol" : "emb-3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00012769"
+               },
+               {
+                  "id" : "PANTHER:PTHR12381"
+               },
+               {
+                  "id" : "NCBI_Gene:178421"
+               },
+               {
+                  "id" : "UniProtKB:F5GUI4"
+               },
+               {
+                  "id" : "UniProtKB:F5GUI5"
+               },
+               {
+                  "id" : "UniProtKB:Q9U2H8"
+               },
+               {
+                  "id" : "UniProtKB:B9WRU1"
+               },
+               {
+                  "id" : "RNAcentral:URS00007A9FDC"
+               },
+               {
+                  "id" : "WB:WBGene00012769",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:hrpu-1",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 15049333,
+                  "startPosition" : 15039616,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00012769",
+            "secondaryIds" : [
+               "WB:WBGene00012774"
+            ],
+            "synonyms" : [
+               "CELE_Y41E3.11",
+               "Y41E3.11"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is enriched in AVE; OLL; PLM; PVD; and germ line based on microarray; tiling array; and RNA-seq studies. Is affected by several genes including daf-16; daf-2; and eat-2 based on microarray and RNA-seq studies. Is affected by eight chemicals including aldicarb; rotenone; and Cry5B based on microarray and RNA-seq studies. Human ortholog(s) of this gene are implicated in colorectal cancer and early infantile epileptic encephalopathy 54. Is predicted to encode a protein with the following domains: AAA domain; SPRY domain; SPRY domain; Concanavalin A-like lectin/glucanase domain superfamily; P-loop containing nucleoside triphosphate hydrolase; and B30.2/SPRY domain superfamily. Is an ortholog of human HNRNPUL1 (heterogeneous nuclear ribonucleoprotein U like 1).",
+         "name" : "Heterogeneous nuclear RibonucleoProtein U 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "hrpu-1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00004884"
+               },
+               {
+                  "id" : "PANTHER:PTHR15696"
+               },
+               {
+                  "id" : "NCBI_Gene:175367"
+               },
+               {
+                  "id" : "UniProtKB:Q9BL69"
+               },
+               {
+                  "id" : "UniProtKB:Q1T6W7"
+               },
+               {
+                  "id" : "UniProtKB:Q9BL68"
+               },
+               {
+                  "id" : "WB:WBGene00004884",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:smg-6",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "III",
+                  "endPosition" : 2486622,
+                  "startPosition" : 2473854,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00004884",
+            "secondaryIds" : [
+               "WB:WBGene00001339"
+            ],
+            "synonyms" : [
+               "CELE_Y54F10AL.2",
+               "NM_001047420",
+               "NM_065164",
+               "NM_065165",
+               "Y54F10AL.2",
+               "Y54F10AL.a",
+               "est-1",
+               "mab-16",
+               "spr-8"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is involved in RNA interference; embryonic genitalia morphogenesis; and nuclear-transcribed mRNA catabolic process, nonsense-mediated decay. Is an ortholog of human SMG6 (SMG6 nonsense mediated mRNA decay factor).",
+         "name" : "Suppressor with Morphological effect on Genitalia 6",
+         "soTermId" : "SO:0001217",
+         "symbol" : "smg-6"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00010341"
+               },
+               {
+                  "id" : "NCBI_Gene:186637"
+               },
+               {
+                  "id" : "UniProtKB:G5EBW0"
+               },
+               {
+                  "id" : "RNAcentral:URS0000850849"
+               },
+               {
+                  "id" : "WB:WBGene00010341",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references",
+                     "gene/phenotypes",
+                     "gene/expression_images"
+                  ]
+               },
+               {
+                  "id" : "WB:glo-3",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "X",
+                  "endPosition" : 10537131,
+                  "startPosition" : 10533699,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00010341",
+            "secondaryIds" : [
+               "WB:WBGene00010346"
+            ],
+            "synonyms" : [
+               "CELE_F59F5.2",
+               "F59F5.2",
+               "XL153"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "geneSynopsis" : "Is involved in gastrulation. Located in gut granule membrane. Is expressed in intestine.",
+         "name" : "Gut granule LOss 3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "glo-3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "RNAcentral:URS0001980EC9"
+               },
+               {
+                  "id" : "WB:WBGene00305820",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:Y54G11A.24",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "primaryId" : "WB:WBGene00305820",
+            "synonyms" : [
+               "cel_circ_008125",
+               "cel_circ_008394"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001263",
+         "symbol" : "Y54G11A.24"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00197922"
+               },
+               {
+                  "id" : "NCBI_Gene:13221334"
+               },
+               {
+                  "id" : "RNAcentral:URS000020B8C2"
+               },
+               {
+                  "id" : "WB:WBGene00197922",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:F43E12.3",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "X",
+                  "endPosition" : 7175863,
+                  "startPosition" : 7175661,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00197922",
+            "synonyms" : [
+               "CELE_F43E12.3"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001263",
+         "symbol" : "F43E12.3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00197472"
+               },
+               {
+                  "id" : "NCBI_Gene:13192966"
+               },
+               {
+                  "id" : "RNAcentral:URS000057442F"
+               },
+               {
+                  "id" : "WB:WBGene00197472",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:F28E10.11",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "IV",
+                  "endPosition" : 4570957,
+                  "startPosition" : 4570693,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "WB:WBGene00197472",
+            "synonyms" : [
+               "CELE_F28E10.11"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001263",
+         "symbol" : "F28E10.11"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:WBGene00200773"
+               },
+               {
+                  "id" : "NCBI_Gene:13180617"
+               },
+               {
+                  "id" : "RNAcentral:URS00004CA010"
+               },
+               {
+                  "id" : "WB:WBGene00200773",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "WB:T10E9.13",
+                  "pages" : [
+                     "gene/spell"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "WBcel235",
+                  "chromosome" : "I",
+                  "endPosition" : 6535436,
+                  "startPosition" : 6535367,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "WB:WBGene00200773",
+            "synonyms" : [
+               "CELE_T10E9.13"
+            ],
+            "taxonId" : "NCBITaxon:6239"
+         },
+         "soTermId" : "SO:0001263",
+         "symbol" : "T10E9.13"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0027934",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 7528068,
+                  "startPosition" : 7526369,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0027934",
+            "secondaryIds" : [
+               "FB:CR31511",
+               "FB:FBgn0020769",
+               "FB:FBgn0051511"
+            ],
+            "synonyms" : [
+               "CR31511",
+               "aE4a",
+               "DmalphaE4a-Psi",
+               "alphaEPsi",
+               "alphaE4",
+               "alphaE4a-Psi",
+               "alphaEsterase 4a-Psi",
+               "alpha-EstPsi"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "alpha-Est4aPsi",
+         "soTermId" : "SO:0000336",
+         "symbol" : "α-Est4aΨ"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0016974",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 6363310,
+                  "startPosition" : 6361496,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0016974",
+            "secondaryIds" : [
+               "FB:CR32747",
+               "FB:FBgn0052747"
+            ],
+            "synonyms" : [
+               "CG3429",
+               "swaPsi",
+               "CR32747",
+               "Swallow Psi"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "swallow pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "swaΨ"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0267494",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "Y",
+                  "endPosition" : 3332699,
+                  "startPosition" : 3331980,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0267494",
+            "secondaryIds" : [
+               "FB:CR45774",
+               "FB:FBgn0262757",
+               "FB:FBgn0267421"
+            ],
+            "synonyms" : [
+               "Male-specific transcript 77Y 8",
+               "CR45774",
+               "Mst77Y-8"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Male-specific pseudogene 77Y 8",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Mst77Y-8Ψ"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0005584",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0005584",
+            "secondaryIds" : [
+               "FB:FBgn0004489",
+               "FB:FBgn0004909"
+            ],
+            "synonyms" : [
+               "F7D6"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "MabF7D6",
+         "soTermId" : "SO:0000704",
+         "symbol" : "MabF7D6"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0283709",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0283709",
+            "secondaryIds" : [
+               "FB:CG6451",
+               "FB:FBgn0036404",
+               "FB:FBgn0041161"
+            ],
+            "synonyms" : [
+               "bls"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "bluestreak",
+         "soTermId" : "SO:0000704",
+         "symbol" : "blue"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:32597"
+               },
+               {
+                  "id" : "UniProtKB:Q9VXH6"
+               },
+               {
+                  "id" : "FB:FBgn0260450",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR10183"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 16328523,
+                  "startPosition" : 16325763,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0260450",
+            "secondaryIds" : [
+               "FB:CG3692",
+               "FB:FBgn0030741"
+            ],
+            "synonyms" : [
+               "CG3692"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "Calpain C (CalpC) encodes one of four calcium-dependent cysteine proteases, but lack of conservation in the catalytic domain suggests it lacks proteolytic activity.",
+         "name" : "Calpain C",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CalpC"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:318105"
+               },
+               {
+                  "id" : "UniProtKB:Q8IR47"
+               },
+               {
+                  "id" : "FB:FBgn0266710",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 14718942,
+                  "startPosition" : 14718273,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0266710",
+            "secondaryIds" : [
+               "FB:CG32595",
+               "FB:FBgn0052595",
+               "FB:FBgn0266546"
+            ],
+            "synonyms" : [
+               "CG32595"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "hog (hog) encodes a short protein required for centripetal follicle cell migration and eggshell formation. It may play a role in modulating transcriptional fidelity in the early embryo.",
+         "name" : "hog",
+         "soTermId" : "SO:0001217",
+         "symbol" : "hog"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:33334"
+               },
+               {
+                  "id" : "UniProtKB:B7YZU6"
+               },
+               {
+                  "id" : "UniProtKB:Q8SYZ9"
+               },
+               {
+                  "id" : "FB:FBgn0001174",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 1518148,
+                  "startPosition" : 1517533,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0001174",
+            "secondaryIds" : [
+               "FB:CG7428",
+               "FB:FBgn0031346"
+            ],
+            "synonyms" : [
+               "CG7428"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "halo (halo) encodes a protein that acts as cofactor of the molecular motor kinesin-1 and controls travel distances of moving lipid droplets. It determines the intracellular distribution of lipid droplets.",
+         "name" : "halo",
+         "soTermId" : "SO:0001217",
+         "symbol" : "halo"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:19836060"
+               },
+               {
+                  "id" : "RNAcentral:URS0000755823_7227"
+               },
+               {
+                  "id" : "FB:FBgn0265737",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3L",
+                  "endPosition" : 10785360,
+                  "startPosition" : 10784590,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0265737",
+            "secondaryIds" : [
+               "FB:CR44544"
+            ],
+            "synonyms" : [
+               "lincRNA.494",
+               "incRNA.494",
+               "CR44544"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "long non-coding RNA:CR44544",
+         "soTermId" : "SO:0002127",
+         "symbol" : "lncRNA:CR44544"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:34351"
+               },
+               {
+                  "id" : "UniProtKB:Q9VL31"
+               },
+               {
+                  "id" : "FB:FBgn0032189",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR31742"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 10200974,
+                  "startPosition" : 10199401,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0032189",
+            "secondaryIds" : [
+               "FB:CG18145"
+            ],
+            "synonyms" : [
+               "CG18145",
+               "dRIPalpha",
+               "Ripalpha",
+               "Tes83"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "RPA-interacting protein alpha",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Ripα"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:41473"
+               },
+               {
+                  "id" : "UniProtKB:Q9VGD0"
+               },
+               {
+                  "id" : "UniProtKB:Q8MQZ9"
+               },
+               {
+                  "id" : "FB:FBgn0037993",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR23279"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 12158595,
+                  "startPosition" : 12138833,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0037993",
+            "secondaryIds" : [
+               "FB:CG10095"
+            ],
+            "synonyms" : [
+               "CG10095",
+               "Dpr15",
+               "CT28423",
+               "Dpr-15",
+               "dpr15"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "defective proboscis extension response 15",
+         "soTermId" : "SO:0001217",
+         "symbol" : "dpr15"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:19836045"
+               },
+               {
+                  "id" : "FB:FBgn0267016",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0267016",
+            "secondaryIds" : [
+               "FB:CR45460"
+            ],
+            "synonyms" : [
+               "CR45460"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "long non-coding RNA:CR45460",
+         "soTermId" : "SO:0001263",
+         "symbol" : "lncRNA:CR45460"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:19835011"
+               },
+               {
+                  "id" : "FB:FBgn0267015",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0267015",
+            "secondaryIds" : [
+               "FB:CR45459"
+            ],
+            "synonyms" : [
+               "CR45459"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "long non-coding RNA:CR45459",
+         "soTermId" : "SO:0001263",
+         "symbol" : "lncRNA:CR45459"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:O96509"
+               },
+               {
+                  "id" : "UniProtKB:Q5BHW5"
+               },
+               {
+                  "id" : "UniProtKB:Q7KPH5"
+               },
+               {
+                  "id" : "FB:FBgn0261516",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0261516",
+            "secondaryIds" : [
+               "FB:FBgn0025801"
+            ],
+            "synonyms" : [
+               "sperm-specific dynein intermediate polypeptide chain"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Sperm-specific dynein intermediate chain",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Sdic"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0027200",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0027200",
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (1) H21",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(1)H21"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0013618",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0013618",
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (3) L5150",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(3)L5150"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0003225",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0003225",
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "rearranged tergites",
+         "soTermId" : "SO:0000704",
+         "symbol" : "rea"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0263263",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0263263",
+            "synonyms" : [
+               "SGP cluster fusion defects 2"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000704",
+         "symbol" : "fus2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0264407",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0264407",
+            "synonyms" : [
+               "FC G-J"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000704",
+         "symbol" : "FCG-J"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0259308",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0259308",
+            "synonyms" : [
+               "EP-(19)"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000704",
+         "symbol" : "EP-19"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:36698"
+               },
+               {
+                  "id" : "UniProtKB:Q5BI03"
+               },
+               {
+                  "id" : "UniProtKB:Q960U5"
+               },
+               {
+                  "id" : "FB:FBgn0034009",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR22957"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 15322171,
+                  "startPosition" : 15317817,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0034009",
+            "secondaryIds" : [
+               "FB:CG8155",
+               "FB:CG8155-RA",
+               "FB:CG8155-PA"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG8155 encodes a Rab GTPase activator of the Rab signaling pathway. It's involved in border follicle cell migration, regulation of GTPase activity, intracellular trafficking of vesicles and determination of lifespan.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG8155"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:34965"
+               },
+               {
+                  "id" : "UniProtKB:Q9V3I6"
+               },
+               {
+                  "id" : "FB:FBgn0015338",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR12869"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 16307298,
+                  "startPosition" : 16305801,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0015338",
+            "secondaryIds" : [
+               "FB:CG5861",
+               "FB:FBgn0020603"
+            ],
+            "synonyms" : [
+               "anon-35Fa",
+               "III",
+               "BG:DS02740.11",
+               "anon-35Fc"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG5861 encodes a transmembrane protein involved in phagocytosis.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG5861"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:33910"
+               },
+               {
+                  "id" : "UniProtKB:Q9VMC7"
+               },
+               {
+                  "id" : "UniProtKB:A8DYW1"
+               },
+               {
+                  "id" : "FB:FBgn0051638",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR46292"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 6496988,
+                  "startPosition" : 6491061,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0051638",
+            "secondaryIds" : [
+               "FB:CG31638",
+               "FB:FBgn0031823",
+               "FB:FBgn0031825"
+            ],
+            "synonyms" : [
+               "CG13764",
+               "CG9545"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG31638 is expressed in the mesoderm and is regulated by the RNA-binding protein encoded by how.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG31638"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:3771732"
+               },
+               {
+                  "id" : "UniProtKB:Q8MTA6"
+               },
+               {
+                  "id" : "UniProtKB:A0A0B4LFL0"
+               },
+               {
+                  "id" : "FB:FBgn0050461",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 16998594,
+                  "startPosition" : 16995991,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0050461",
+            "secondaryIds" : [
+               "FB:CG33142",
+               "FB:CG30461",
+               "FB:FBgn0053142",
+               "FB:FBgn0063335"
+            ],
+            "synonyms" : [
+               "CG33142",
+               "CG30461",
+               "BcDNA:AT13932",
+               "CR30461"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG30461 encodes a protein that is likely a recent partial duplicate of the type I prenyl protease encoded by ste24c.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG30461"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0084049",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 4732343,
+                  "startPosition" : 4731514,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0084049",
+            "secondaryIds" : [
+               "FB:CR41440",
+               "FB:FBgn0058287"
+            ],
+            "synonyms" : [
+               "CG40287"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR41440"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0262565",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 15375702,
+                  "startPosition" : 15374846,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0262565",
+            "secondaryIds" : [
+               "FB:CR43105",
+               "FB:CG43105"
+            ],
+            "synonyms" : [
+               "CG43105"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR43105"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0030116",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 9260522,
+                  "startPosition" : 9259218,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0030116",
+            "secondaryIds" : [
+               "FB:CR17438",
+               "FB:CG17438"
+            ],
+            "synonyms" : [
+               "CG17438"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR17438"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:36043"
+               },
+               {
+                  "id" : "UniProtKB:Q7K2V5"
+               },
+               {
+                  "id" : "UniProtKB:A1Z833"
+               },
+               {
+                  "id" : "UniProtKB:E2QCN5"
+               },
+               {
+                  "id" : "UniProtKB:Q960T3"
+               },
+               {
+                  "id" : "UniProtKB:A0A0B4LEL6"
+               },
+               {
+                  "id" : "UniProtKB:A0A0B4KF56"
+               },
+               {
+                  "id" : "UniProtKB:A0A0B4LF16"
+               },
+               {
+                  "id" : "UniProtKB:A0A0B4LF00"
+               },
+               {
+                  "id" : "FB:FBgn0033474",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 10032893,
+                  "startPosition" : 10028443,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0033474",
+            "secondaryIds" : [
+               "FB:CG1407"
+            ],
+            "synonyms" : [
+               "ZDHHC15"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG1407"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:49952"
+               },
+               {
+                  "id" : "UniProtKB:Q8IRZ1"
+               },
+               {
+                  "id" : "UniProtKB:Q8I044"
+               },
+               {
+                  "id" : "FB:FBgn0040028",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 21608920,
+                  "startPosition" : 21605884,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0040028",
+            "secondaryIds" : [
+               "FB:CG17450"
+            ],
+            "synonyms" : [
+               "tektin"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG17450"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:40098"
+               },
+               {
+                  "id" : "UniProtKB:Q9VVX9"
+               },
+               {
+                  "id" : "FB:FBgn0036858",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR24260"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3L",
+                  "endPosition" : 19270642,
+                  "startPosition" : 19269772,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0036858",
+            "secondaryIds" : [
+               "FB:CG14088"
+            ],
+            "synonyms" : [
+               "SPH199"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG14088"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0028705",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0028705",
+            "synonyms" : [
+               "DmMTR1",
+               "Drosophila melanogaster CpG MTase-related protein 1"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Methyltransferase-related protein 1",
+         "soTermId" : "SO:0000704",
+         "symbol" : "Mtr1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0004527",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0004527",
+            "synonyms" : [
+               "l(4)MW-1",
+               "l(4)CDj",
+               "lethal(4) Solway, Tennessee-4",
+               "l(4)ST-4",
+               "l(4)SLC-1",
+               "lethal(4) Salt Lake City-1",
+               "l(4)15"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (4) 102CDj",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(4)102CDj"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0002271",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0002271",
+            "synonyms" : [
+               "l(3)rsg33",
+               "rsg33",
+               "rose-gespleten region interval 33"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (3) 69Bc",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(3)69Bc"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:37301"
+               },
+               {
+                  "id" : "UniProtKB:Q7K0F7"
+               },
+               {
+                  "id" : "FB:FBgn0034500",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR24320"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 20308671,
+                  "startPosition" : 20304517,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0034500",
+            "secondaryIds" : [
+               "FB:CG11200"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Carbonyl reductase",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG11200"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:43395"
+               },
+               {
+                  "id" : "UniProtKB:Q9VAT8"
+               },
+               {
+                  "id" : "FB:FBgn0039597",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 28756979,
+                  "startPosition" : 28755484,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0039597",
+            "secondaryIds" : [
+               "FB:CG9997"
+            ],
+            "synonyms" : [
+               "SPH252"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG9997 encodes a protein with homology to serine-type endopeptidases, but is not predicted to have catalytic activity due to mutations in its active site. It is produced in the male accessory gland and transferred to females during mating. In males, it is required for other seminal proteins to be transferred to mated females. In mated females, it is required for the binding of the product of SP to sperm and for the maintenance of long-term post-mating responses.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG9997"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:34357"
+               },
+               {
+                  "id" : "UniProtKB:Q9VL25"
+               },
+               {
+                  "id" : "FB:FBgn0032194",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR18934"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 10213721,
+                  "startPosition" : 10211143,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0032194",
+            "secondaryIds" : [
+               "FB:CG4901"
+            ],
+            "synonyms" : [
+               "cg4901"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG4901 encodes an ATP-dependent RNA helicase involved in neurogenesis and spliceosomal complex disassembly.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG4901"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:41000"
+               },
+               {
+                  "id" : "UniProtKB:Q9VHR5"
+               },
+               {
+                  "id" : "UniProtKB:Q8MRT0"
+               },
+               {
+                  "id" : "FB:FBgn0037583",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 8362554,
+                  "startPosition" : 8359958,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0037583",
+            "secondaryIds" : [
+               "FB:CG9684"
+            ],
+            "synonyms" : [
+               "cg9684"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG9684 encodes a protein belonging to the TDRD1 family that is predicted to have a role in the piRNA pathway.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG9684"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0262852",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 11589173,
+                  "startPosition" : 11587283,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0262852",
+            "secondaryIds" : [
+               "FB:CR43216"
+            ],
+            "synonyms" : [
+               "noncoding_23159",
+               "noncoding_23161"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR43216"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0262849",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 11595452,
+                  "startPosition" : 11593562,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0262849",
+            "secondaryIds" : [
+               "FB:CR43213"
+            ],
+            "synonyms" : [
+               "noncoding_23159",
+               "noncoding_23161"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR43213"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0262853",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 11586944,
+                  "startPosition" : 11586228,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0262853",
+            "secondaryIds" : [
+               "FB:CR43217"
+            ],
+            "synonyms" : [
+               "noncoding_23159",
+               "noncoding_23161"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR43217"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0286011",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0286011",
+            "secondaryIds" : [
+               "FB:FBgn0062683"
+            ],
+            "synonyms" : [
+               "EP(X)1565"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000704",
+         "symbol" : "EP1565"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:317855"
+               },
+               {
+                  "id" : "UniProtKB:Q8IQI2"
+               },
+               {
+                  "id" : "UniProtKB:M9ND83"
+               },
+               {
+                  "id" : "UniProtKB:Q86NN4"
+               },
+               {
+                  "id" : "FB:FBgn0052106",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3L",
+                  "endPosition" : 12778716,
+                  "startPosition" : 12773951,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0052106",
+            "secondaryIds" : [
+               "FB:CG32106",
+               "FB:FBgn0064958"
+            ],
+            "synonyms" : [
+               "mlncRNA69E2",
+               "BcDNA:GH24302",
+               "FBgn0052106"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG32106"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:35519"
+               },
+               {
+                  "id" : "UniProtKB:A1Z6I3"
+               },
+               {
+                  "id" : "FB:FBgn0263109",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR11461"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 5931363,
+                  "startPosition" : 5893895,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0263109",
+            "secondaryIds" : [
+               "FB:CG43366",
+               "FB:CG12551",
+               "FB:CG14470",
+               "FB:FBgn0033045",
+               "FB:FBgn0033046"
+            ],
+            "synonyms" : [
+               "CG14470",
+               "CG12551"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG43366"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:38367"
+               },
+               {
+                  "id" : "UniProtKB:Q9VZV5"
+               },
+               {
+                  "id" : "FB:FBgn0266918",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR23059"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3L",
+                  "endPosition" : 3070839,
+                  "startPosition" : 3055908,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0266918",
+            "secondaryIds" : [
+               "FB:CG32486",
+               "FB:FBgn0035394",
+               "FB:FBgn0035395",
+               "FB:FBgn0052486",
+               "FB:FBgn0062132",
+               "FB:FBgn0065142"
+            ],
+            "synonyms" : [
+               "CG16745",
+               "l(3)SH095",
+               "l(2)SH3 095",
+               "CG14954",
+               "lethal (3) SH095",
+               "anon-WO0118547.267"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG32486"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:O62532"
+               },
+               {
+                  "id" : "FB:FBgn0020850",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0020850",
+            "synonyms" : [
+               "#098"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "indora",
+         "soTermId" : "SO:0001217",
+         "symbol" : "idr"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0011150",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0011150",
+            "secondaryIds" : [
+               "FB:FBgn0010210"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (1) Q226",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(1)Q226"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0011053",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0011053",
+            "secondaryIds" : [
+               "FB:FBgn0010210"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (1) Q6",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(1)Q6"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0011084",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0011084",
+            "secondaryIds" : [
+               "FB:FBgn0010210"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (1) Q42",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(1)Q42"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0267520",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 23271158,
+                  "startPosition" : 23270802,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0267520",
+            "secondaryIds" : [
+               "FB:CR45860"
+            ],
+            "synonyms" : [
+               "CR45860"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "28S ribosomal RNA pseudogene:CR45860",
+         "soTermId" : "SO:0000336",
+         "symbol" : "28SrRNA-Ψ:CR45860"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0267510",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "rDNA",
+                  "endPosition" : 16555,
+                  "startPosition" : 16526,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0267510",
+            "secondaryIds" : [
+               "FB:CR45850"
+            ],
+            "synonyms" : [
+               "CR45850"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "2S ribosomal RNA pseudogene:CR45850",
+         "soTermId" : "SO:0000336",
+         "symbol" : "2SrRNA-Ψ:CR45850"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0267509",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "rDNA",
+                  "endPosition" : 16497,
+                  "startPosition" : 16375,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0267509",
+            "secondaryIds" : [
+               "FB:CR45849"
+            ],
+            "synonyms" : [
+               "CR45849"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "5.8S ribosomal RNA pseudogene:CR45849",
+         "soTermId" : "SO:0000336",
+         "symbol" : "5.8SrRNA-Ψ:CR45849"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0011042",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0011042",
+            "secondaryIds" : [
+               "FB:FBgn0010212"
+            ],
+            "synonyms" : [
+               "l(1)Sa",
+               "lethal (1) Sa"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (1) of Stark a",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(1)Stark-a"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0028119",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0028119",
+            "secondaryIds" : [
+               "FB:FBgn0060444"
+            ],
+            "synonyms" : [
+               "0671/10",
+               "1226/12",
+               "0612/07",
+               "l(3)S122612a"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (3) S061207",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(3)S061207"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0015317",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0015317",
+            "secondaryIds" : [
+               "FB:FBgn0012029"
+            ],
+            "synonyms" : [
+               "U2AF[35]",
+               "U2AF",
+               "U2AF-35kDa"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "U2 small nuclear riboprotein auxiliary factor 35",
+         "soTermId" : "SO:0000704",
+         "symbol" : "U2af35"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:31170"
+               },
+               {
+                  "id" : "UniProtKB:Q9W532"
+               },
+               {
+                  "id" : "UniProtKB:O77268"
+               },
+               {
+                  "id" : "FB:FBgn0025625",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR24343"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 2061915,
+                  "startPosition" : 2055310,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0025625",
+            "secondaryIds" : [
+               "FB:CG4290"
+            ],
+            "synonyms" : [
+               "EG:22E5.8",
+               "CG4290",
+               "Salt-induced kinase 2",
+               "SIK2",
+               "SIK"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "Salt-inducible kinase 2 (Sik2) encodes a serine/threonine kinase that is activated by the product of Lkb1. It regulates lipid storage and energy homeostasis by controlling the activity of cAMP-response element-binding protein (CREB)-regulated transcription coactivator (CRTC).",
+         "name" : "Salt-inducible kinase 2",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Sik2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:41414"
+               },
+               {
+                  "id" : "UniProtKB:Q9VGJ2"
+               },
+               {
+                  "id" : "UniProtKB:O96723"
+               },
+               {
+                  "id" : "FB:FBgn0025821",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 11704916,
+                  "startPosition" : 11704030,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0025821",
+            "secondaryIds" : [
+               "FB:CG14719"
+            ],
+            "synonyms" : [
+               "CG14719",
+               "pp1d6",
+               "Inhibitor-t"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "inhibitor-t (I-t) encodes a protein phosphatase inhibitor.",
+         "name" : "inhibitor-t",
+         "soTermId" : "SO:0001217",
+         "symbol" : "I-t"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:35104"
+               },
+               {
+                  "id" : "UniProtKB:Q9VJ82"
+               },
+               {
+                  "id" : "UniProtKB:Q960X3"
+               },
+               {
+                  "id" : "FB:FBgn0032683",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR15036"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 18503978,
+                  "startPosition" : 18487747,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0032683",
+            "secondaryIds" : [
+               "FB:CG10275"
+            ],
+            "synonyms" : [
+               "perd",
+               "CT28869",
+               "Kon",
+               "Kon-tiki",
+               "kontiki",
+               "perdido",
+               "CG10275",
+               "Kon-Tiki",
+               "NG2-like"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "kon-tiki (kon) (also known as perdido) encodes a single transmembrane protein required to initiate muscle-tendon attachment in a group of embryonic and adult body muscles. kon mutants are embryonic lethal with rounded ventral longitudinal muscles. It concentrates at muscle attachment sites and genetically interacts with integrins.",
+         "name" : "kon-tiki",
+         "soTermId" : "SO:0001217",
+         "symbol" : "kon"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:41174"
+               },
+               {
+                  "id" : "UniProtKB:Q9VH94"
+               },
+               {
+                  "id" : "UniProtKB:Q8SZV8"
+               },
+               {
+                  "id" : "UniProtKB:Q9U462"
+               },
+               {
+                  "id" : "FB:FBgn0028997",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR43109"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 9681502,
+                  "startPosition" : 9679939,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0028997",
+            "secondaryIds" : [
+               "FB:CG8362",
+               "FB:FBgn0037729"
+            ],
+            "synonyms" : [
+               "CG8362"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "nmdyn-D7",
+         "soTermId" : "SO:0001217",
+         "symbol" : "nmdyn-D7"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:3772672"
+               },
+               {
+                  "id" : "RNAcentral:URS00002398EB_7227"
+               },
+               {
+                  "id" : "FB:FBgn0044508",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 1482590,
+                  "startPosition" : 1482492,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0044508",
+            "secondaryIds" : [
+               "FB:CR32807",
+               "FB:FBgn0052807"
+            ],
+            "synonyms" : [
+               "CR32807"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "snoRNA:M",
+         "soTermId" : "SO:0001267",
+         "symbol" : "snoRNA:M"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:41973"
+               },
+               {
+                  "id" : "UniProtKB:Q8IH00"
+               },
+               {
+                  "id" : "FB:FBgn0261286",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR17972"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 16272415,
+                  "startPosition" : 16268329,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0261286",
+            "secondaryIds" : [
+               "FB:CG12785",
+               "FB:FBgn0020408",
+               "FB:FBgn0038410"
+            ],
+            "synonyms" : [
+               "CG12785"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Maternal transcript 89Ba",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Mat89Ba"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:44057"
+               },
+               {
+                  "id" : "FB:FBgn0265195",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0265195",
+            "secondaryIds" : [
+               "FB:CG6657",
+               "FB:FBgn0015562"
+            ],
+            "synonyms" : [
+               "CG6657",
+               "lethal (2) k01206",
+               "l(2)k01206"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "vegetable",
+         "soTermId" : "SO:0000704",
+         "symbol" : "veg"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:Q24437"
+               },
+               {
+                  "id" : "FB:FBgn0011667",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0011667",
+            "secondaryIds" : [
+               "FB:FBgn0045090",
+               "FB:FBgn0045255"
+            ],
+            "synonyms" : [
+               "Male-specific transcript 40",
+               "mst40",
+               "NEST:bs18c05",
+               "NEST:bs35e07",
+               "bs35e07.y1",
+               "ORF1",
+               "bs18c05.y1"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Male-specific RNA 40",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Mst40"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:Q8MSE1"
+               },
+               {
+                  "id" : "UniProtKB:Q7KV12"
+               },
+               {
+                  "id" : "FB:FBgn0003523",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0003523",
+            "secondaryIds" : [
+               "FB:CG32605",
+               "FB:FBgn0063181"
+            ],
+            "synonyms" : [
+               "euchromatic Ste",
+               "Ste eu",
+               "stellate",
+               "euchromatic Stellate",
+               "BcDNA:GM31840",
+               "ste",
+               "CG32605",
+               "euSte",
+               "eSte"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Stellate",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Ste"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:35354"
+               },
+               {
+                  "id" : "UniProtKB:Q9VII2"
+               },
+               {
+                  "id" : "FB:FBgn0032896",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 20857891,
+                  "startPosition" : 20856987,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0032896",
+            "secondaryIds" : [
+               "FB:CG14400",
+               "FB:CG14400-RA",
+               "FB:CG14400-PA"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG14400"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:38212"
+               },
+               {
+                  "id" : "UniProtKB:Q4V4Q7"
+               },
+               {
+                  "id" : "FB:FBgn0035258",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3L",
+                  "endPosition" : 1702407,
+                  "startPosition" : 1700956,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0035258",
+            "secondaryIds" : [
+               "FB:CG13931",
+               "FB:CG13931-RA",
+               "FB:CG13931-PA"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG13931"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:34042"
+               },
+               {
+                  "id" : "UniProtKB:Q9VLZ1"
+               },
+               {
+                  "id" : "UniProtKB:Q5BI80"
+               },
+               {
+                  "id" : "FB:FBgn0031930",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR11705"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 7692683,
+                  "startPosition" : 7691109,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0031930",
+            "secondaryIds" : [
+               "FB:CG7025-RA",
+               "FB:CG7025-PA",
+               "FB:CG7025"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG7025"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0263212",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 19944417,
+                  "startPosition" : 19944198,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0263212",
+            "secondaryIds" : [
+               "FB:CR43382"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR43382"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0286920",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 11123389,
+                  "startPosition" : 11122387,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0286920",
+            "secondaryIds" : [
+               "FB:CR46420"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR46420"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0263092",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 5082431,
+                  "startPosition" : 5081884,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0263092",
+            "secondaryIds" : [
+               "FB:CR43360"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR43360"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0003005",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0003005",
+            "synonyms" : [
+               "ophthalmoptera"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "opthalmoptera",
+         "soTermId" : "SO:0000704",
+         "symbol" : "opht"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0060615",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0060615",
+            "synonyms" : [
+               "0898/14"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (3) S089814b",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(3)S089814b"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0060365",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0060365",
+            "synonyms" : [
+               "1383/07"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (3) S138307",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(3)S138307"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0005431",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0005431",
+            "secondaryIds" : [
+               "FB:FBgn0001506",
+               "FB:FBgn0001864"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (1) 10Ea",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(1)10Ea"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:50050"
+               },
+               {
+                  "id" : "UniProtKB:Q9VDG1"
+               },
+               {
+                  "id" : "FB:FBgn0046763",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 21024163,
+                  "startPosition" : 21021044,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0046763",
+            "secondaryIds" : [
+               "FB:CG17278",
+               "FB:FBgn0040577"
+            ],
+            "synonyms" : [
+               "BcDNA:SD04019"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG17278 encodes a secreted Kazal-type serine protease whose expression is induced by bacterial infection. RNAi results in lethality and wing adhesion defects.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG17278"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:36414"
+               },
+               {
+                  "id" : "UniProtKB:A1Z957"
+               },
+               {
+                  "id" : "UniProtKB:Q8T499"
+               },
+               {
+                  "id" : "UniProtKB:A0A0B4JCT2"
+               },
+               {
+                  "id" : "FB:FBgn0250842",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 12846596,
+                  "startPosition" : 12845544,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0250842",
+            "secondaryIds" : [
+               "FB:CG17575",
+               "FB:FBgn0033776",
+               "FB:FBgn0066885"
+            ],
+            "synonyms" : [
+               "anon-SAGE:Wang-113"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG17575 encodes a cysteine-rich secretory protein produced in the male accessory glands and transferred to females during mating. In mated females, it is required for the binding of the product of SP to sperm and for the consequent maintenance of long-term post-mating responses.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG17575"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:40788"
+               },
+               {
+                  "id" : "UniProtKB:Q9VI17"
+               },
+               {
+                  "id" : "FB:FBgn0260766",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR10334"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 6377348,
+                  "startPosition" : 6374475,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0260766",
+            "secondaryIds" : [
+               "FB:CG42564",
+               "FB:CG10284",
+               "FB:FBgn0037441"
+            ],
+            "synonyms" : [
+               "CG10284"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG42564 encodes a predicted cysteine-rich secretory protein that is produced in the male accessory gland and transferred to females during mating.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG42564"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0032898",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 20863775,
+                  "startPosition" : 20862547,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0032898",
+            "secondaryIds" : [
+               "FB:CG9337",
+               "FB:CG9337-PA",
+               "FB:CR9337",
+               "FB:FBgn0063270"
+            ],
+            "synonyms" : [
+               "cg9337",
+               "BcDNA:GH05725",
+               "CG9337"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR9337"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0260469",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3L",
+                  "endPosition" : 27850751,
+                  "startPosition" : 27849226,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0260469",
+            "secondaryIds" : [
+               "FB:CR14578",
+               "FB:CG14578",
+               "FB:FBgn0040059",
+               "FB:FBgn0058105"
+            ],
+            "synonyms" : [
+               "CG14578",
+               "CG40105"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR14578"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0263745",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 16703197,
+                  "startPosition" : 16700940,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0263745",
+            "secondaryIds" : [
+               "FB:CR43670",
+               "FB:FBgn0051782",
+               "FB:FBgn0062488"
+            ],
+            "synonyms" : [
+               "BcDNA:GM06363",
+               "CG31782"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR43670"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0259330",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0259330",
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000704",
+         "symbol" : "C371"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0259531",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0259531",
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000704",
+         "symbol" : "B2005"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0287801",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0287801",
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000704",
+         "symbol" : "d00123"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:37541"
+               },
+               {
+                  "id" : "UniProtKB:Q9W272"
+               },
+               {
+                  "id" : "UniProtKB:Q8T436"
+               },
+               {
+                  "id" : "FB:FBgn0034713",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR19288"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 22212704,
+                  "startPosition" : 22211371,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0034713",
+            "secondaryIds" : [
+               "FB:CG11291"
+            ],
+            "synonyms" : [
+               "22026920",
+               "Phos11291"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG11291"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:42593"
+               },
+               {
+                  "id" : "UniProtKB:Q9VD52"
+               },
+               {
+                  "id" : "FB:FBgn0038927",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR43979"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 22034286,
+                  "startPosition" : 22032150,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0038927",
+            "secondaryIds" : [
+               "FB:CG6015"
+            ],
+            "synonyms" : [
+               "CDC40",
+               "prp17"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG6015"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:12798442"
+               },
+               {
+                  "id" : "UniProtKB:A0A0B4K7P2"
+               },
+               {
+                  "id" : "FB:FBgn0262821",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 13478079,
+                  "startPosition" : 13477342,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0262821",
+            "secondaryIds" : [
+               "FB:CG43192"
+            ],
+            "synonyms" : [
+               "noncoding_6907",
+               "noncoding_6564"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG43192"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:32460"
+               },
+               {
+                  "id" : "UniProtKB:Q9VXW5"
+               },
+               {
+                  "id" : "FB:FBgn0030628",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 15333154,
+                  "startPosition" : 15330784,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0030628",
+            "secondaryIds" : [
+               "FB:CG9114"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG9114"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:42923"
+               },
+               {
+                  "id" : "UniProtKB:Q9VC68"
+               },
+               {
+                  "id" : "FB:FBgn0039202",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 24523678,
+                  "startPosition" : 24522478,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0039202",
+            "secondaryIds" : [
+               "FB:CG13622"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG13622"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:40099"
+               },
+               {
+                  "id" : "UniProtKB:Q9VVY0"
+               },
+               {
+                  "id" : "FB:FBgn0036859",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR33960"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3L",
+                  "endPosition" : 19274168,
+                  "startPosition" : 19269351,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0036859",
+            "secondaryIds" : [
+               "FB:CG14085"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG14085"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0259751",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0259751",
+            "synonyms" : [
+               "ms(3)168-112",
+               "ms(3)127-109",
+               "127-109",
+               "168-112"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000704",
+         "symbol" : "ms(3)Z3741"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0259758",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0259758",
+            "synonyms" : [
+               "ms(3)150-16",
+               "150-016"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000704",
+         "symbol" : "ms(3)Z1190"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0261296",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0261296",
+            "synonyms" : [
+               "HSF",
+               "heat-shock factor"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "GJ20676"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0004421",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0004421",
+            "secondaryIds" : [
+               "FB:FBgn0001154",
+               "FB:FBgn0001158"
+            ],
+            "synonyms" : [
+               "gust[x1]",
+               "gust[x2]",
+               "gust-A"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "gustatory-defective A",
+         "soTermId" : "SO:0000704",
+         "symbol" : "gustA"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0000164",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0000164",
+            "secondaryIds" : [
+               "FB:FBgn0003454",
+               "FB:FBgn0010322",
+               "FB:FBgn0014124",
+               "FB:FBgn0014125",
+               "FB:FBgn0025282"
+            ],
+            "synonyms" : [
+               "ITS1",
+               "rDNA unit",
+               "snRNA-a",
+               "small nuclear RNA a",
+               "female-specific lethal on X",
+               "rRNA",
+               "ribosomal RNA",
+               "anon-EST:Posey92",
+               "rDNA repeat",
+               "Xbb",
+               "NO",
+               "flex",
+               "35S rRNA",
+               "clone 1.69",
+               "l(1)20Fa",
+               "anon-EST:Liang-1.69",
+               "rDNA"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "bobbed",
+         "soTermId" : "SO:0001637",
+         "symbol" : "bb"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0060752",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0060752",
+            "secondaryIds" : [
+               "FB:FBgn0060488",
+               "FB:FBgn0060489"
+            ],
+            "synonyms" : [
+               "1103/03",
+               "l(3)S110303",
+               "1103/05",
+               "0644/11",
+               "l(3)S110305a"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (3) S064411a",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(3)S064411a"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0067407",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 27845414,
+                  "startPosition" : 27845089,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0067407",
+            "secondaryIds" : [
+               "FB:CR33345",
+               "FB:FBgn0053345"
+            ],
+            "synonyms" : [
+               "CR33345"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Odorant receptor 98a pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Or98P"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:37575"
+               },
+               {
+                  "id" : "UniProtKB:Q8SWW8"
+               },
+               {
+                  "id" : "UniProtKB:A0A0B4KFY0"
+               },
+               {
+                  "id" : "FB:FBgn0260866",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 22592964,
+                  "startPosition" : 22563152,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0260866",
+            "secondaryIds" : [
+               "FB:CG12489",
+               "FB:FBgn0034738",
+               "FB:FBgn0084288"
+            ],
+            "synonyms" : [
+               "DNR1",
+               "Dnr1",
+               "CG12489",
+               "Defense repressor I",
+               "dnr1",
+               "defense repressor 1",
+               "dNR1",
+               "Dnr-1",
+               "Defense repressor 1"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "defense repressor 1 (dnr1) encodes a protein that interacts with the caspase encoded by Dredd. The product of dnr1 is involved in attenuation of innate immune response and neuro-inflammation.",
+         "name" : "defense repressor 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "dnr1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:32009"
+               },
+               {
+                  "id" : "UniProtKB:M9NF14"
+               },
+               {
+                  "id" : "UniProtKB:Q8IR99"
+               },
+               {
+                  "id" : "UniProtKB:Q9VZ69"
+               },
+               {
+                  "id" : "UniProtKB:Q0KHU2"
+               },
+               {
+                  "id" : "UniProtKB:E1JJM0"
+               },
+               {
+                  "id" : "UniProtKB:Q8IGK4"
+               },
+               {
+                  "id" : "UniProtKB:Q95S41"
+               },
+               {
+                  "id" : "FB:FBgn0285926",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR10288"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 10824277,
+                  "startPosition" : 10787869,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0285926",
+            "secondaryIds" : [
+               "FB:CG1691",
+               "FB:FBgn0025229",
+               "FB:FBgn0026687",
+               "FB:FBgn0030235",
+               "FB:FBgn0044592",
+               "FB:FBgn0086345",
+               "FB:FBgn0086543",
+               "FB:FBgn0262735"
+            ],
+            "synonyms" : [
+               "IGF-II messenger RNA binding protein",
+               "cg1691",
+               "KH-domain protein",
+               "l(1)G0072",
+               "IMP",
+               "anon-EST:fe2B3",
+               "imp",
+               "IGF2BP1",
+               "IGF2BP",
+               "ORE-9",
+               "insulin-like growth factor II",
+               "FGC026A04",
+               "mRNA-like ncRNA in embryogenesis 11",
+               "IMP-1",
+               "MRE11",
+               "anon-WO0140519.39",
+               "dIMP",
+               "mre11",
+               "IGF-II",
+               "Insulin-like Growth Factor 2 mRNA Binding Protein 1",
+               "CG1691",
+               "anon-fast-evolving-2B3"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "IGF-II mRNA-binding protein (Imp) encodes a protein that regulates the stability, translation and/or transport of its associated mRNAs, a large number of them encoding F-actin regulators. It is an essential protein required for neural and germline stem cell maturation, neuronal remodeling, as well as the expression modulation of asymmetrically localized maternal mRNAs.",
+         "name" : "IGF-II mRNA-binding protein",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Imp"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:39014"
+               },
+               {
+                  "id" : "UniProtKB:Q9XYU0"
+               },
+               {
+                  "id" : "UniProtKB:Q8T025"
+               },
+               {
+                  "id" : "UniProtKB:Q7JNE3"
+               },
+               {
+                  "id" : "FB:FBgn0020633",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR11630"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3L",
+                  "endPosition" : 8894310,
+                  "startPosition" : 8891596,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0020633",
+            "secondaryIds" : [
+               "FB:CG4978",
+               "FB:FBgn0025980"
+            ],
+            "synonyms" : [
+               "mcm7",
+               "Mcp-PCR1",
+               "DmMCM7",
+               "CG4978",
+               "MCM7",
+               "clone 1.66",
+               "minichromosome maintenance 7",
+               "PCR1",
+               "anon-EST:Liang-1.66",
+               "dMcm7",
+               "McM7",
+               "DmeMCM7",
+               "Minichromosome maintenance-PCR1"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "Minichromosome maintenance 7 (Mcm7) encodes a component of the MCM2-7 hexamer, which forms part of the CMG complex, together with CDC45L and GINS proteins. CMG complex is the main DNA helicase that functions during DNA replication.",
+         "name" : "Minichromosome maintenance 7",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Mcm7"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:P02283"
+               },
+               {
+                  "id" : "FB:FBgn0001198",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR23428"
+               }
+            ],
+            "primaryId" : "FB:FBgn0001198",
+            "secondaryIds" : [
+               "FB:FBgn0039974"
+            ],
+            "synonyms" : [
+               "HisC",
+               "H2[[B]]",
+               "histone H2B",
+               "HistoneH2B",
+               "H2b",
+               "histone 2B",
+               "dH2b",
+               "DmeH2b",
+               "Histone",
+               "histone",
+               "His2b",
+               "histone H2b",
+               "core histone",
+               "Histone 2B",
+               "his",
+               "dH2B",
+               "histone H3",
+               "histone h2b",
+               "Histone2B",
+               "H2B"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Histone H2B",
+         "soTermId" : "SO:0001217",
+         "symbol" : "His2B"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:P02299"
+               },
+               {
+                  "id" : "FB:FBgn0001199",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR11426"
+               }
+            ],
+            "primaryId" : "FB:FBgn0001199",
+            "secondaryIds" : [
+               "FB:FBgn0062243"
+            ],
+            "synonyms" : [
+               "histone 3",
+               "DmH3",
+               "HisC",
+               "phospho-Histone H3",
+               "histoneH3",
+               "H3/H3.2",
+               "P~H3",
+               "Ph3",
+               "phosphohistone H3",
+               "h3",
+               "Histone H3",
+               "H3K9",
+               "His",
+               "HistoneH3",
+               "Histone-3",
+               "phospho-histone H3",
+               "HH3",
+               "his3",
+               "H3 histone",
+               "H3K27ac",
+               "histone-3",
+               "phosphorylated histone H3",
+               "Phospho histone 3",
+               "pHistone3",
+               "dH3",
+               "histone",
+               "phosph-H3",
+               "anon-WO0118547.10",
+               "Histone",
+               "phosphorylated histone-H3",
+               "H3 Histone",
+               "H3.1",
+               "core histone",
+               "H3",
+               "his",
+               "H[[3]]",
+               "histone-H3",
+               "Histone3",
+               "histone H3",
+               "replication-dependent histone 3",
+               "His3.2",
+               "Histone-H3",
+               "PH3",
+               "H3.3",
+               "pH3",
+               "DmeH3",
+               "Histone 3"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Histone H3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "His3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:14462711"
+               },
+               {
+                  "id" : "FB:FBgn0261699",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0261699",
+            "secondaryIds" : [
+               "FB:CR42735"
+            ],
+            "synonyms" : [
+               "CR42735",
+               "CG42735",
+               "HDC01070"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "long non-coding RNA:CR42735",
+         "soTermId" : "SO:0001263",
+         "symbol" : "lncRNA:CR42735"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:26067229"
+               },
+               {
+                  "id" : "RNAcentral:URS00009FCA92_7227"
+               },
+               {
+                  "id" : "RNAcentral:URS0000A477EC_7227"
+               },
+               {
+                  "id" : "FB:FBgn0267561",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 6834247,
+                  "startPosition" : 6833363,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0267561",
+            "secondaryIds" : [
+               "FB:CR45901"
+            ],
+            "synonyms" : [
+               "CR45901"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "long non-coding RNA:CR45901",
+         "soTermId" : "SO:0002127",
+         "symbol" : "lncRNA:CR45901"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:3771947"
+               },
+               {
+                  "id" : "UniProtKB:P84040"
+               },
+               {
+                  "id" : "FB:FBgn0053883",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 21499736,
+                  "startPosition" : 21499324,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0053883",
+            "secondaryIds" : [
+               "FB:CG33883"
+            ],
+            "synonyms" : [
+               "CG33883"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "His4:CG33883",
+         "soTermId" : "SO:0001217",
+         "symbol" : "His4:CG33883"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:19834973"
+               },
+               {
+                  "id" : "RNAcentral:URS00007395C8_7227"
+               },
+               {
+                  "id" : "FB:FBgn0267174",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 11066377,
+                  "startPosition" : 11065860,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0267174",
+            "secondaryIds" : [
+               "FB:CR45614"
+            ],
+            "synonyms" : [
+               "CR45614"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "long non-coding RNA:CR45614",
+         "soTermId" : "SO:0002127",
+         "symbol" : "lncRNA:CR45614"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:36652"
+               },
+               {
+                  "id" : "UniProtKB:Q7K3Q3"
+               },
+               {
+                  "id" : "UniProtKB:A0A0B4KEQ7"
+               },
+               {
+                  "id" : "FB:FBgn0033971",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 14848366,
+                  "startPosition" : 14846064,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0033971",
+            "secondaryIds" : [
+               "FB:CG10209"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG10209 encodes a DNA binding nuclear apoptosis-inducing factor involved in the apoptotic process.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG10209"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:33815"
+               },
+               {
+                  "id" : "UniProtKB:Q9VML7"
+               },
+               {
+                  "id" : "UniProtKB:X2JDB2"
+               },
+               {
+                  "id" : "FB:FBgn0031746",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 5886609,
+                  "startPosition" : 5886002,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0031746",
+            "secondaryIds" : [
+               "FB:CG9029"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG9029 encodes a peptide that is produced by the male accessory gland and transferred to females during mating.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG9029"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:35123"
+               },
+               {
+                  "id" : "UniProtKB:Q9VJ64"
+               },
+               {
+                  "id" : "UniProtKB:Q961H4"
+               },
+               {
+                  "id" : "FB:FBgn0032699",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR48187"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 18695602,
+                  "startPosition" : 18690904,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0032699",
+            "secondaryIds" : [
+               "FB:CG10383"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG10383 encodes a hydrolase involved in the regulation of glycosylphosphatidylinositol metabolism, determination of lifespan and sleep.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG10383"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0013716",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0013716",
+            "secondaryIds" : [
+               "FB:FBgn0020266"
+            ],
+            "synonyms" : [
+               "neo44"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (3) neo44",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(3)neo44"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0022227",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0022227",
+            "secondaryIds" : [
+               "FB:FBgn0022243"
+            ],
+            "synonyms" : [
+               "l(2)k02203"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (2) k03110",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(2)k03110"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0015458",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0015458",
+            "secondaryIds" : [
+               "FB:FBgn0013293"
+            ],
+            "synonyms" : [
+               "l(2)E151"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (2) 37CDc",
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(2)37CDc"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0033997",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 15206334,
+                  "startPosition" : 15204654,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0033997",
+            "secondaryIds" : [
+               "FB:CR12953"
+            ],
+            "synonyms" : [
+               "CR12953",
+               "DmelIR51a",
+               "CG12953",
+               "IR51a",
+               "ionotropic receptor 51a"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Ionotropic receptor 51a",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Ir51a"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0262163",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 15576964,
+                  "startPosition" : 15576355,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0262163",
+            "secondaryIds" : [
+               "FB:CR42877"
+            ],
+            "synonyms" : [
+               "CR42877",
+               "beta-subunit of nascent polypeptide-associated complex"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Nascent-associated complex beta-subunit-like, testis 5",
+         "soTermId" : "SO:0000336",
+         "symbol" : "βNACtes5"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0265142",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 19652826,
+                  "startPosition" : 19652295,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0265142",
+            "secondaryIds" : [
+               "FB:CR44211"
+            ],
+            "synonyms" : [
+               "CR44211",
+               "DmelIR56e"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Ionotropic receptor 56e",
+         "soTermId" : "SO:0000336",
+         "symbol" : "Ir56e"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:Q65ZF1"
+               },
+               {
+                  "id" : "FB:FBgn0017428",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0017428",
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "anon-67Ea",
+         "soTermId" : "SO:0001217",
+         "symbol" : "anon-67Ea"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:43842"
+               },
+               {
+                  "id" : "UniProtKB:Q7KQM6"
+               },
+               {
+                  "id" : "FB:FBgn0039936",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR14445"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "4",
+                  "endPosition" : 867025,
+                  "startPosition" : 853557,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0039936",
+            "secondaryIds" : [
+               "FB:CG11148"
+            ],
+            "synonyms" : [
+               "CG11148"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "Gigyf (Gyf) encodes a protein that is necessary for maintenance of neuromuscular homeostasis. It regulates protein translation, insulin/IGF signaling pathway and autophagy.",
+         "name" : "Gigyf",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Gyf"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:35437"
+               },
+               {
+                  "id" : "UniProtKB:Q9V9P3"
+               },
+               {
+                  "id" : "FB:FBgn0032971",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR12210"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 22080738,
+                  "startPosition" : 22079632,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0032971",
+            "secondaryIds" : [
+               "FB:CG6691"
+            ],
+            "synonyms" : [
+               "CG6691"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "tiny tim 3 (ttm3) encodes a mitochondrial inner membrane protein that is involved in mitochondrial protein translocation and maintenance of mitochondrial membrane potential.",
+         "name" : "tiny tim 3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "ttm3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:32679"
+               },
+               {
+                  "id" : "UniProtKB:Q9VX98"
+               },
+               {
+                  "id" : "FB:FBgn0030802",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR12789"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 16886560,
+                  "startPosition" : 16885546,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0030802",
+            "secondaryIds" : [
+               "FB:CG9099"
+            ],
+            "synonyms" : [
+               "CG9099"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "Density regulated protein (DENR) encodes a non-canonical translation initiation factor together with its binding partner encoded by MCTS1. It associates with ribosomes and it promotes translation reinitiation.",
+         "name" : "Density regulated protein",
+         "soTermId" : "SO:0001217",
+         "symbol" : "DENR"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:42802"
+               },
+               {
+                  "id" : "UniProtKB:Q7KMP8"
+               },
+               {
+                  "id" : "FB:FBgn0028691",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR10539"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 23733462,
+                  "startPosition" : 23731375,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0028691",
+            "secondaryIds" : [
+               "FB:CG10230",
+               "FB:FBgn0028103"
+            ],
+            "synonyms" : [
+               "718/06",
+               "Rpn4",
+               "0718/06",
+               "Nobody",
+               "PSMD13",
+               "S11",
+               "CG10230",
+               "l(3)S071806",
+               "l(3)S071806b",
+               "Rpn9",
+               "CT28749",
+               "Rpn94",
+               "p39A",
+               "rpn9"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Regulatory particle non-ATPase 9",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Rpn9"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:3772433"
+               },
+               {
+                  "id" : "RNAcentral:URS00001B18EA_7227"
+               },
+               {
+                  "id" : "FB:FBgn0011935",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 6190202,
+                  "startPosition" : 6190129,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0011935",
+            "secondaryIds" : [
+               "FB:CR30519",
+               "FB:FBgn0003759",
+               "FB:FBgn0050318",
+               "FB:FBgn0050519",
+               "FB:FBgn0060133"
+            ],
+            "synonyms" : [
+               "chr2R.trna92-AsnGTT",
+               "tRNA:asn5:42Ae",
+               "tRNA:N5:42Ae",
+               "AAC",
+               "tRNA-Asn-GTT-1-7",
+               "transfer RNA:asn5:42Ae",
+               "tRNA:N:GTT:AE002769-a",
+               "CR30318",
+               "AE002769.trna1-AsnGTT",
+               "CR30519"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "transfer RNA:Asparagine-GTT 1-7",
+         "soTermId" : "SO:0001272",
+         "symbol" : "tRNA:Asn-GTT-1-7"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:32518"
+               },
+               {
+                  "id" : "UniProtKB:Q9VXQ5"
+               },
+               {
+                  "id" : "FB:FBgn0027329",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR11353"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "X",
+                  "endPosition" : 15748971,
+                  "startPosition" : 15746648,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0027329",
+            "secondaryIds" : [
+               "FB:CG8231",
+               "FB:FBgn0026695",
+               "FB:FBgn0027326",
+               "FB:FBgn0030681"
+            ],
+            "synonyms" : [
+               "CCT6",
+               "TCPzeta",
+               "l(1)G0022",
+               "TCP1-zeta",
+               "TCP-1zeta",
+               "l(1)G0027",
+               "Rcd3",
+               "lethal (1) G0022",
+               "T-cp1zeta",
+               "Reduction in Cnn Dots 3",
+               "l(1)G0057",
+               "Lethal (1) G0022",
+               "Q9VXQ5_DROME",
+               "CG8231",
+               "Tcp-1-zeta",
+               "TCP1zeta",
+               "L(1)g0022",
+               "TCP-1-zeta",
+               "Tcp-1zeta",
+               "cct6",
+               "Cct6"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Chaperonin containing TCP1 subunit 6",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CCT6"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:P84051"
+               },
+               {
+                  "id" : "FB:FBgn0001196",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR23430"
+               }
+            ],
+            "primaryId" : "FB:FBgn0001196",
+            "synonyms" : [
+               "HisC",
+               "H2A",
+               "histone H2A",
+               "HistoneH2A",
+               "DmeH2a",
+               "Histone2A",
+               "dH2a",
+               "Histone 2A",
+               "Histone",
+               "H2a",
+               "histone",
+               "His2a",
+               "histone H2a",
+               "core histone",
+               "his",
+               "H2A1",
+               "H2A.1",
+               "hist",
+               "H2[[A]]",
+               "dH2A"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Histone H2A",
+         "soTermId" : "SO:0001217",
+         "symbol" : "His2A"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:V9H127"
+               },
+               {
+                  "id" : "UniProtKB:Q65ZD0"
+               },
+               {
+                  "id" : "UniProtKB:V9H1D8"
+               },
+               {
+                  "id" : "FB:FBgn0011623",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0011623",
+            "synonyms" : [
+               "1(2)rot",
+               "relative of 1(2)tid",
+               "lethal(2)relative of tid"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "lethal (2) relative of tid",
+         "soTermId" : "SO:0001217",
+         "symbol" : "l(2)rot"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:P84040"
+               },
+               {
+                  "id" : "FB:FBgn0001200",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR10484"
+               }
+            ],
+            "primaryId" : "FB:FBgn0001200",
+            "synonyms" : [
+               "HisC",
+               "core histone",
+               "Bicoid interacting protein 2",
+               "H4Ac16",
+               "H4",
+               "dH4",
+               "his",
+               "Bin2",
+               "his4",
+               "H4K20",
+               "H4_DROME",
+               "histone 4",
+               "DmeH4",
+               "Histone",
+               "histone",
+               "histone H4",
+               "4"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "name" : "Histone H4",
+         "soTermId" : "SO:0001217",
+         "symbol" : "His4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:35906"
+               },
+               {
+                  "id" : "UniProtKB:A1Z7M5"
+               },
+               {
+                  "id" : "FB:FBgn0033363",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR24253"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 9017195,
+                  "startPosition" : 9014368,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0033363",
+            "secondaryIds" : [
+               "FB:CG13744"
+            ],
+            "synonyms" : [
+               "SP67",
+               "cSP67",
+               "c-SP67"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG13744 encodes a CLIP-domain-containing serine protease.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG13744"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:37428"
+               },
+               {
+                  "id" : "UniProtKB:Q9W2I5"
+               },
+               {
+                  "id" : "FB:FBgn0034612",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR24223"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 21290343,
+                  "startPosition" : 21285248,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0034612",
+            "secondaryIds" : [
+               "FB:CG10505"
+            ],
+            "synonyms" : [
+               "ABC transporter",
+               "Dme_CG10505",
+               "DmCG10505"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG10505 encodes an ABC transporter whose expression is induced by excess copper, zinc, and cadmium. It is a target of the metal-responsive transcription factor encoded by MTF-1.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG10505"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:42368"
+               },
+               {
+                  "id" : "UniProtKB:Q9I7J1"
+               },
+               {
+                  "id" : "UniProtKB:A0A0B4LHF0"
+               },
+               {
+                  "id" : "FB:FBgn0038744",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR14095"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "3R",
+                  "endPosition" : 19898738,
+                  "startPosition" : 19890689,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0038744",
+            "secondaryIds" : [
+               "FB:CG4733"
+            ],
+            "synonyms" : [
+               "PP2A like",
+               "B''",
+               "PR72",
+               "pr72",
+               "PR-72",
+               "dPR72",
+               "PP2A-B''",
+               "dPP2A-PR72"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "geneSynopsis" : "CG4733 encodes a protein that is predicted to be the B\"/PR72 subunit of Protein Phosphatase 2A (PP2A) regulatory B unit. The B subunits determine the substrate specificity of the enzyme.",
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG4733"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0260636",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0260636",
+            "secondaryIds" : [
+               "FB:FBgn0016902"
+            ],
+            "synonyms" : [
+               "l(3)72CDd",
+               "72CDd"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000704",
+         "symbol" : "l(3)72-73a"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0285964",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "FB:FBgn0285964",
+            "secondaryIds" : [
+               "FB:FBgn0011241"
+            ],
+            "synonyms" : [
+               "ms(2)46C",
+               "crossbronx",
+               "Crossbronx",
+               "male sterile(2)46C",
+               "cbx"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000704",
+         "symbol" : "ms(2)05704"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0261856",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2R",
+                  "endPosition" : 7001696,
+                  "startPosition" : 7000154,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0261856",
+            "secondaryIds" : [
+               "FB:CR42785"
+            ],
+            "synonyms" : [
+               "noncoding_4773"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR42785"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0283435",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "Y",
+                  "endPosition" : 3251252,
+                  "startPosition" : 3250355,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0283435",
+            "secondaryIds" : [
+               "FB:CR46279"
+            ],
+            "synonyms" : [
+               "CG12717-related"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR46279"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "FB:FBgn0267426",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "Y",
+                  "endPosition" : 3371602,
+                  "startPosition" : 3370887,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0267426",
+            "secondaryIds" : [
+               "FB:CR45779"
+            ],
+            "synonyms" : [
+               "Mst77Y"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0000336",
+         "symbol" : "CR45779"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:34986"
+               },
+               {
+                  "id" : "UniProtKB:Q9VJK3"
+               },
+               {
+                  "id" : "FB:FBgn0032588",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 16549959,
+                  "startPosition" : 16549181,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "FB:FBgn0032588",
+            "secondaryIds" : [
+               "FB:CG5968",
+               "FB:FBgn0063297"
+            ],
+            "synonyms" : [
+               "BcDNA:AT27976"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG5968"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:34253"
+               },
+               {
+                  "id" : "UniProtKB:Q9VLC8"
+               },
+               {
+                  "id" : "FB:FBgn0032111",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 9350996,
+                  "startPosition" : 9350470,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0032111",
+            "secondaryIds" : [
+               "FB:CG13110",
+               "FB:FBgn0047341"
+            ],
+            "synonyms" : [
+               "BcDNA:AT19071"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG13110"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:318946"
+               },
+               {
+                  "id" : "UniProtKB:Q8INW8"
+               },
+               {
+                  "id" : "FB:FBgn0051798",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "R6",
+                  "chromosome" : "2L",
+                  "endPosition" : 19396190,
+                  "startPosition" : 19394160,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "FB:FBgn0051798",
+            "secondaryIds" : [
+               "FB:CG31798",
+               "FB:FBgn0044689"
+            ],
+            "synonyms" : [
+               "anon-WO0140519.187"
+            ],
+            "taxonId" : "NCBITaxon:7227"
+         },
+         "soTermId" : "SO:0001217",
+         "symbol" : "CG31798"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:Q9DDE2",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4INF8",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR13683",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000099824",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:114367",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q5PR42",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IA33",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-010620-1",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:B5DDQ0",
+                  "pages" : []
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-010620-1",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-041212-20",
+               "ZFIN:ZDB-GENE-030903-4"
+            ],
+            "synonyms" : [
+               "ctsel",
+               "LAP",
+               "zgc:103608"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "nothepsin",
+         "soTermId" : "SO:0001217",
+         "symbol" : "nots"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000104155",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-MIRNAG-050609-18",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-MIRNAG-050609-18",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-050609-18",
+               "ZFIN:ZDB-GENE-080926-1"
+            ],
+            "synonyms" : [
+               "miR-17",
+               "mirn17a-1",
+               "miR17a-1",
+               "mirn17a1",
+               "mirn17",
+               "miR-17-5p",
+               "dre-mir-17a-1",
+               "miR-17a-1"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "microRNA 17a-1",
+         "soTermId" : "SO:0001265",
+         "symbol" : "mir17a-1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-MIRNAG-090929-152",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000082467.2",
+                  "pages" : []
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-MIRNAG-090929-152",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-090929-152",
+               "ZFIN:ZDB-LINCRNAG-090929-152"
+            ],
+            "synonyms" : [
+               "dre-mir-142b",
+               "miR-142b",
+               "miR142b"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "microRNA 142b",
+         "soTermId" : "SO:0001265",
+         "symbol" : "mir142b"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000092870",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-LINCRNAG-070912-346",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-LINCRNAG-070912-346",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-070912-346",
+               "ZFIN:ZDB-GENE-030131-7308"
+            ],
+            "synonyms" : [
+               "wu:fj05h12"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:dkey-100n23.4",
+         "soTermId" : "SO:0001641",
+         "symbol" : "si:dkey-100n23.4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "PANTHER:PTHR16675",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-140820-13",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:X1WFJ5",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000096977",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0G2KIH5",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "25",
+                  "endPosition" : 10983432,
+                  "startPosition" : 10972288
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-140820-13",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-131120-129",
+               "ZFIN:ZDB-GENE-140820-12"
+            ],
+            "synonyms" : [
+               "si:dkey-52p2.4"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "major histocompatibility complex class I LLA",
+         "soTermId" : "SO:0001217",
+         "symbol" : "mhc1lla"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000034178",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q5EB13",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IC37",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A4IGB2",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q6DRG0",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-040709-2",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:Q6DRG2",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A8WFR1",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IH63",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:432372",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F6NXE7",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR10644",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "19",
+                  "endPosition" : 11975164,
+                  "startPosition" : 11897631
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-040709-2",
+            "secondaryIds" : [
+               "ZFIN:ZDB-LOCUS-040709-1",
+               "ZFIN:ZDB-GENE-030131-359"
+            ],
+            "synonyms" : [
+               "wu:fb24c01"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "cleavage and polyadenylation specific factor 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "cpsf1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-141216-476",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000102967",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-141216-476",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:dkey-245f22.5",
+         "soTermId" : "SO:0001217",
+         "symbol" : "si:dkey-245f22.5"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000102358",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR24106",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4I9J5",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-141211-1",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "4",
+                  "endPosition" : 39448829,
+                  "startPosition" : 39428602
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-141211-1",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:dkey-261o4.9",
+         "soTermId" : "SO:0001217",
+         "symbol" : "si:dkey-261o4.9"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-131121-400",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000098011",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-131121-400",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:ch211-209m20.7",
+         "soTermId" : "SO:0001217",
+         "symbol" : "si:ch211-209m20.7"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-070117-2507",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-070117-2507",
+            "secondaryIds" : [
+               "ZFIN:ZDB-LOCUS-990215-87"
+            ],
+            "synonyms" : [
+               "casper",
+               "unm b286"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "un-named b286",
+         "soTermId" : "SO:0001217",
+         "symbol" : "unm_b286"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-MIRNAG-081203-26",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-MIRNAG-081203-26",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-081203-26"
+            ],
+            "synonyms" : [
+               "dre-miR-139",
+               "mirn139",
+               "miR139",
+               "miR-139"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "microRNA 139",
+         "soTermId" : "SO:0001265",
+         "symbol" : "mir139"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENEP-060404-1",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENEP-060404-1",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-060403-14"
+            ],
+            "synonyms" : [
+               "v2rb3",
+               "B03"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "vomeronasal 2 receptor, b3 pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "v2rb3p"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-MIRNAG-150109-11",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-MIRNAG-150109-11",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-150109-11"
+            ],
+            "synonyms" : [
+               "dre-mir-7552bOS"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "microRNA 7552b, opposite strand",
+         "soTermId" : "SO:0001265",
+         "symbol" : "mir7552bos"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-170601-33",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-170601-33",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-141212-157"
+            ],
+            "synonyms" : [
+               "si:dkey-161l11.40"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "T-cell receptor alpha joining 25",
+         "soTermId" : "SO:0001217",
+         "symbol" : "traj25"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-170601-60",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-170601-60",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-141212-120"
+            ],
+            "synonyms" : [
+               "si:dkey-161l11.14"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "T-cell receptor alpha joining 52",
+         "soTermId" : "SO:0001217",
+         "symbol" : "traj52"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "PANTHER:PTHR11711",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000103858",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000045989",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A9JT20",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IGT1",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:445196",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-040801-109",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:Q6DC20",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "11",
+                  "endPosition" : 42492660,
+                  "startPosition" : 42482920
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "11",
+                  "endPosition" : 42502940,
+                  "startPosition" : 42494531
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-040801-109",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-080215-24"
+            ],
+            "synonyms" : [
+               "zgc:101030",
+               "zgc:174360"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "ADP-ribosylation factor 4a",
+         "soTermId" : "SO:0001217",
+         "symbol" : "arf4a"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-090313-42",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000100949",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000093053",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F1QJ30",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:E9QEG5",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "1",
+                  "endPosition" : 9109699,
+                  "startPosition" : 9105039
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "1",
+                  "endPosition" : 9115034,
+                  "startPosition" : 9113630
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-090313-42",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-090313-41"
+            ],
+            "synonyms" : [
+               "si:ch211-14k19.7",
+               "si:ch211-14k19.6"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "vascular associated protein",
+         "soTermId" : "SO:0001217",
+         "symbol" : "vap"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:F1QZW6",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A1L1QZS9",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR24300",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q0VG65",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-060818-12",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:F1RAB2",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0PGL6",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000068283",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q503N5",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F1QMK3",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000006501",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A1L1QZG6",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:E7F103",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "7",
+                  "endPosition" : 51953850,
+                  "startPosition" : 51950614
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "7",
+                  "endPosition" : 52096498,
+                  "startPosition" : 52093291
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-060818-12",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-030131-1265"
+            ],
+            "synonyms" : [
+               "wu:fb64f09",
+               "zgc:136371"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "cytochrome P450, family 2, subfamily X, polypeptide 10.2",
+         "soTermId" : "SO:0001217",
+         "symbol" : "cyp2x10.2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-070117-2403",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-070117-2403",
+            "secondaryIds" : [
+               "ZFIN:ZDB-LOCUS-990215-573"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "stop it",
+         "soTermId" : "SO:0001217",
+         "symbol" : "sit"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-070117-2221",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-070117-2221",
+            "secondaryIds" : [
+               "ZFIN:ZDB-LOCUS-990215-368"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "neil",
+         "soTermId" : "SO:0001217",
+         "symbol" : "nel"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-070117-889",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-070117-889",
+            "secondaryIds" : [
+               "ZFIN:ZDB-LOCUS-060417-3"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "minime",
+         "soTermId" : "SO:0001217",
+         "symbol" : "mnm"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:386918",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-031118-34",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-031118-34",
+            "synonyms" : [
+               "fi70g07"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "wu:fi70g07",
+         "soTermId" : "SO:0001217",
+         "symbol" : "wu:fi70g07"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000081322",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-140106-174",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-140106-174",
+            "synonyms" : [
+               "zmp:0000001214"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "ring finger protein 125, E3 ubiquitin protein ligase",
+         "soTermId" : "SO:0001217",
+         "symbol" : "rnf125"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:321971",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-030131-690",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-030131-690",
+            "synonyms" : [
+               "fb39g12"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "wu:fb39g12",
+         "soTermId" : "SO:0001217",
+         "symbol" : "wu:fb39g12"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:393588",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:E7EXN0",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000042671",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR33966",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F8W627",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-080502-1",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "2",
+                  "endPosition" : 20879820,
+                  "startPosition" : 20866898
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-080502-1",
+            "synonyms" : [
+               "c2h1orf27",
+               "c1orf27"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "odr-4 GPCR localization factor homolog",
+         "soTermId" : "SO:0001217",
+         "symbol" : "odr4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:A0A2R8Q5Y8",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-060929-1210",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8PUN1",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000061773",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR12429",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:767739",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q08CE8",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F1QZ44",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "17",
+                  "endPosition" : 20518626,
+                  "startPosition" : 20500229
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-060929-1210",
+            "synonyms" : [
+               "neurlb",
+               "zgc:153175"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "neuralized E3 ubiquitin protein ligase 1Ab",
+         "soTermId" : "SO:0001217",
+         "symbol" : "neurl1ab"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:797943",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A3KNJ7",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000069135",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-030131-4408",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR16489",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-030131-4408",
+            "synonyms" : [
+               "wu:fd02c11",
+               "zgc:162126"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "protein phosphatase 1, regulatory subunit 15A",
+         "soTermId" : "SO:0001217",
+         "symbol" : "ppp1r15a"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-080220-14",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:A8WGQ9",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000096528",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000093157",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "1",
+                  "endPosition" : 58601636,
+                  "startPosition" : 58593247
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "1",
+                  "endPosition" : 58613487,
+                  "startPosition" : 58608978
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-080220-14",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "zgc:174928",
+         "soTermId" : "SO:0001217",
+         "symbol" : "zgc:174928"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:B8JKV1",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-081104-259",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:F1QX64",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR22826",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000058835",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000096613",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "20",
+                  "endPosition" : 3166168,
+                  "startPosition" : 3162423
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "20",
+                  "endPosition" : 3160687,
+                  "startPosition" : 3145497
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-081104-259",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:ch73-212j7.3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "si:ch73-212j7.3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:A0A2R8Q005",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8Q4V8",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QC37",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QP82",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A1L1QZD9",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:K7DYP0",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IAQ6",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4ILB3",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4ICT2",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:H0WFI2",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IWJ2",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F1QU47",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QIG0",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4ISN2",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IJ46",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F1R0P8",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F8W5Z8",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F1R906",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IT83",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QE06",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:E9QD65",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QLP4",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QP01",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8Q3J6",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QL81",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000100164",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QB35",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:E9QJG9",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IYU5",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000105266",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QE61",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QT21",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:L7N0X1",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QBZ5",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8Q7B7",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IJZ8",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-081103-43",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:E7F524",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:E7EYZ8",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IPW3",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QEN8",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IJJ3",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:K7DYH6",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8RQG7",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QQS2",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IHB9",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IUL2",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000099825",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8Q1B4",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QR58",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IMJ6",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QQ45",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4ISH0",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QJL5",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IER6",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IDM7",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IFP7",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F1QF37",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F1QBP8",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IGB3",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0G2KV92",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F1R5Y0",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QR61",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8Q7I7",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8RYJ7",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F1R995",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QIE1",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QRN8",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4ILQ6",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "4",
+                  "endPosition" : 58259734,
+                  "startPosition" : 58240829
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "4",
+                  "endPosition" : 76450637,
+                  "startPosition" : 76440462
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "4",
+                  "endPosition" : 54381329,
+                  "startPosition" : 54355719
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-081103-43",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:dkey-16p6.1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "si:dkey-16p6.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:Q5XLR3",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:B3DGT7",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-050131-1",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:494449",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-050131-1",
+            "secondaryIds" : [
+               "ZFIN:ZDB-LOCUS-050805-3"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "nicastrin",
+         "soTermId" : "SO:0001217",
+         "symbol" : "ncstn"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-LINCRNAG-060526-56",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000095282",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-LINCRNAG-060526-56",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-060526-56"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:ch211-15o14.2",
+         "soTermId" : "SO:0001641",
+         "symbol" : "si:ch211-15o14.2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000092980",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-LINCRNAG-041014-343",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-LINCRNAG-041014-343",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-041014-343"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:dkey-166k9.2",
+         "soTermId" : "SO:0001641",
+         "symbol" : "si:dkey-166k9.2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-131125-15",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-131125-15",
+            "synonyms" : [
+               "gpr103b",
+               "qrfpr2",
+               "QRFPR3a"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "pyroglutamylated RFamide peptide receptor b",
+         "soTermId" : "SO:0001217",
+         "symbol" : "qrfprb"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-180320-3",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-180320-3",
+            "synonyms" : [
+               "rephaim",
+               "unm_dmh22",
+               "unm_mh22",
+               "reph"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "un-named mh22",
+         "soTermId" : "SO:0001217",
+         "symbol" : "unm_mh22"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-051013-1",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-051013-1",
+            "synonyms" : [
+               "iglc3",
+               "LC1-7"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "immunoglobulin light iota variable 1, s1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "igiv1s1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENEP-121011-2",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENEP-121011-2",
+            "synonyms" : [
+               "CXCL-chr5phi2"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "chemokine (C-X-C motif) ligand, pseudogene 2",
+         "soTermId" : "SO:0000336",
+         "symbol" : "cxclp2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-030131-752",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-030131-752",
+            "synonyms" : [
+               "fb44g06"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "wu:fb44g06",
+         "soTermId" : "SO:0001217",
+         "symbol" : "wu:fb44g06"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-101102-14",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-101102-14",
+            "synonyms" : [
+               "TCR Vbeta.13"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "T cell receptor beta variable 13",
+         "soTermId" : "SO:0001217",
+         "symbol" : "trbv13"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-091116-40",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-091116-40",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:dkey-93m18.5",
+         "soTermId" : "SO:0001217",
+         "symbol" : "si:dkey-93m18.5"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-120214-37",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-120214-37",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:dkey-260c8.5",
+         "soTermId" : "SO:0001217",
+         "symbol" : "si:dkey-260c8.5"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-171115-42",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-171115-42",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "un-named zko1175a",
+         "soTermId" : "SO:0001217",
+         "symbol" : "unm_zko1175a"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000097714",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-LINCRNAG-131121-345",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-LINCRNAG-131121-345",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-131121-345"
+            ],
+            "synonyms" : [
+               "slincR"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:ch1073-384e4.1",
+         "soTermId" : "SO:0001641",
+         "symbol" : "si:ch1073-384e4.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-MIRNAG-091023-6",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000082246",
+                  "pages" : []
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-MIRNAG-091023-6",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-091023-6"
+            ],
+            "synonyms" : [
+               "dre-mir-1388"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "microRNA 1388",
+         "soTermId" : "SO:0001265",
+         "symbol" : "mir1388"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:Q566T7",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q501X1",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-050522-261",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:A8KBL8",
+                  "pages" : []
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-050522-261",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-050417-144"
+            ],
+            "synonyms" : [
+               "zgc:112491"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "zgc:112490",
+         "soTermId" : "SO:0001217",
+         "symbol" : "zgc:112490"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-MIRNAG-081208-10",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000080168",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-MIRNAG-081208-10",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-081208-10"
+            ],
+            "synonyms" : [
+               "miR-15a-1",
+               "dre-mir-15a-1",
+               "miR15a-1",
+               "mirn15a-1"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "microRNA 15a-1",
+         "soTermId" : "SO:0001265",
+         "symbol" : "mir15a-1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:A7MCA2",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR11599",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-050913-120",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:Q4V918",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:564370",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000086618",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "17",
+                  "endPosition" : 11439815,
+                  "startPosition" : 11421712
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-050913-120",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-040914-29"
+            ],
+            "synonyms" : [
+               "im:6909944",
+               "zgc:114044"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "proteasome 20S subunit alpha 3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "psma3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:Q90461",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:B8A5N9",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR24339",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-990415-75",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:30260",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000021201",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "13",
+                  "endPosition" : 14978104,
+                  "startPosition" : 14976108
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-990415-75",
+            "secondaryIds" : [
+               "ZFIN:ZDB-LOCUS-990215-186"
+            ],
+            "synonyms" : [
+               "flh",
+               "floating head",
+               "Znot"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "notochord homeobox",
+         "soTermId" : "SO:0001217",
+         "symbol" : "noto"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-LINCRNAG-160114-10",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-LINCRNAG-160114-10",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-160114-10",
+               "ZFIN:ZDB-GENE-140106-54"
+            ],
+            "synonyms" : [
+               "zmp:0000001094"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:ch73-106k19.8",
+         "soTermId" : "SO:0001641",
+         "symbol" : "si:ch73-106k19.8"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENEP-090511-3",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENEP-090511-3",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-090511-3",
+               "ZFIN:ZDB-GENE-141216-8"
+            ],
+            "synonyms" : [
+               "btr03",
+               "si:ch73-367j5.6"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "bloodthirsty-related gene family, member 3, pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "btr03p"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENEP-041011-1",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENEP-041011-1",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENEP-030616-376",
+               "ZFIN:ZDB-GENE-030616-120",
+               "ZFIN:ZDB-GENEP-030616-120",
+               "ZFIN:ZDB-GENE-041004-1",
+               "ZFIN:ZDB-GENE-030616-376",
+               "ZFIN:ZDB-GENEP-041001-6",
+               "ZFIN:ZDB-GENEP-030616-229",
+               "ZFIN:ZDB-GENE-030616-238",
+               "ZFIN:ZDB-GENE-030616-229",
+               "ZFIN:ZDB-GENEP-041001-3"
+            ],
+            "synonyms" : [
+               "si:busm1-173m20.17, pseudogene",
+               "si:busm1-219h16.2, pseudogene",
+               "si:busm1-139e19.2p",
+               "nitr1.48",
+               "si:busm1-219h16.2p",
+               "nitr1.35",
+               "nitr1.57",
+               "nitr1.56",
+               "nitr1.66",
+               "si:busm1-116c14.10, pseudogene",
+               "si:busm1-173m20.17p",
+               "si:dz219h16.2p",
+               "si:dz116c14.10p",
+               "si:busm1-116c14.10p",
+               "si:dz175p12.4",
+               "si:busm1-175p12.4",
+               "nitr1e",
+               "nitr1.56p",
+               "si:dz173m20.17p"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "novel immune-type receptor 1e, pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "nitr1ep"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-020225-10",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-020225-10",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-041001-56",
+               "ZFIN:ZDB-GENE-020225-25"
+            ],
+            "synonyms" : [
+               "nitr1.14",
+               "nitr1.29",
+               "nitr1.61"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "novel immune-type receptor 1g",
+         "soTermId" : "SO:0001217",
+         "symbol" : "nitr1g"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:E7EXM4",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000061272",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:564564",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR12137",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000004018",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-030131-738",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "23",
+                  "endPosition" : 35069805,
+                  "startPosition" : 35027177
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "23",
+                  "endPosition" : 35025117,
+                  "startPosition" : 34990693
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-030131-738",
+            "synonyms" : [
+               "wu:fb44a12",
+               "fb44a12"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:ch211-236h17.3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "si:ch211-236h17.3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:K7DYB0",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q5RGV8",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000096473",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000016613",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A3KNQ6",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:564111",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-041111-231",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "4",
+                  "endPosition" : 18851365,
+                  "startPosition" : 18846624
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "4",
+                  "endPosition" : 18850799,
+                  "startPosition" : 18839856
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-041111-231",
+            "synonyms" : [
+               "si:dkey-31f5.5",
+               "im:7145278"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "malonyl CoA:ACP acyltransferase (mitochondrial)",
+         "soTermId" : "SO:0001217",
+         "symbol" : "mcat"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000096720",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000005185",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q6NY94",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000096728",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR11532",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-030131-9116",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:A8WGN2",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:337172",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:U3JB00",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "12",
+                  "endPosition" : 31612987,
+                  "startPosition" : 31608905
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "12",
+                  "endPosition" : 31631132,
+                  "startPosition" : 31608908
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "12",
+                  "endPosition" : 31631297,
+                  "startPosition" : 31616412
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-030131-9116",
+            "synonyms" : [
+               "fa99g08",
+               "cb1037",
+               "wu:fa99g08"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "carboxypeptidase N, polypeptide 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "cpn1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-070117-2329",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-070117-2329",
+            "secondaryIds" : [
+               "ZFIN:ZDB-LOCUS-990215-487"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "sallow",
+         "soTermId" : "SO:0001217",
+         "symbol" : "sll"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-070117-43",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-070117-43",
+            "secondaryIds" : [
+               "ZFIN:ZDB-LOCUS-000609-5"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "stuffy",
+         "soTermId" : "SO:0001217",
+         "symbol" : "sfy"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-MIRNAG-150109-10",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-MIRNAG-150109-10",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-150109-10"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "microRNA 7552b",
+         "soTermId" : "SO:0001265",
+         "symbol" : "mir7552b"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "PANTHER:PTHR18884",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F1QKY9",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F1QVB3",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A4FUM1",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-070424-3",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000014233",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:571702",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "14",
+                  "endPosition" : 49063157,
+                  "startPosition" : 49040190
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-070424-3",
+            "synonyms" : [
+               "zgc:136574"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "septin 8b",
+         "soTermId" : "SO:0001217",
+         "symbol" : "sept8b"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:100330004",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0G2KCM8",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR13140",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F8W510",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-110411-270",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000027381",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8Q0L6",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "23",
+                  "endPosition" : 45339439,
+                  "startPosition" : 45307726
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-110411-270",
+            "synonyms" : [
+               "si:ch211-116m6.4"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "coiled-coil domain containing 171",
+         "soTermId" : "SO:0001217",
+         "symbol" : "ccdc171"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000025824",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q6DG03",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:H2L2P5",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8Q8Q4",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR10641",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-040718-413",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:436938",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:B2GT69",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:H0WF14",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "4",
+                  "endPosition" : 9667410,
+                  "startPosition" : 9653423
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-040718-413",
+            "synonyms" : [
+               "zgc:92448"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "cyclin D binding myb-like transcription factor 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "dmtf1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-040106-1",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:399660",
+                  "pages" : []
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-040106-1",
+            "synonyms" : [
+               "cb466",
+               "sb:cb466"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "ATPase Na+/K+ transporting alpha subunit 3a, like",
+         "soTermId" : "SO:0001217",
+         "symbol" : "atp1a3al"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:Q5RL11",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q6PBS3",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000100954",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F1QI32",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:393745",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-040426-1742",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:B2GS19",
+                  "pages" : []
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-040426-1742",
+            "synonyms" : [
+               "wars",
+               "zgc:73274",
+               "TrpRS"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "tryptophanyl-tRNA synthetase 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "wars1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:Q24JV7",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000100513",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IYD0",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:677743",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-060331-65",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-060331-65",
+            "synonyms" : [
+               "rps27l",
+               "zgc:136826"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "ribosomal protein S27 like",
+         "soTermId" : "SO:0001217",
+         "symbol" : "rps27l"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:Q6NV44",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q90448",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q7SZR7",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-990415-223",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:Q98SI2",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:30369",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR11309",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000060004",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q90ZT3",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "9",
+                  "endPosition" : 13355071,
+                  "startPosition" : 13352308
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-990415-223",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-030131-2766",
+               "ZFIN:ZDB-GENE-010319-19"
+            ],
+            "synonyms" : [
+               "fz7",
+               "id:ibd2735",
+               "wu:fc17e10",
+               "zg07"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "frizzled class receptor 7a",
+         "soTermId" : "SO:0001217",
+         "symbol" : "fzd7a"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-040426-2933",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR15491",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q7SXB6",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000089461",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:406846",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:F1QSS8",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A8KC21",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "5",
+                  "endPosition" : 63663811,
+                  "startPosition" : 63648164
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-040426-2933",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-030131-5674",
+               "ZFIN:ZDB-GENE-030131-5957"
+            ],
+            "synonyms" : [
+               "wu:fi27d02",
+               "ciz1",
+               "zgc:66467",
+               "wu:fi12g11"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "cdkn1a interacting zinc finger protein 1b",
+         "soTermId" : "SO:0001217",
+         "symbol" : "ciz1b"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:B0S5J7",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-031112-5",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:B0S5J6",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A286YAB4",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000055945",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:323659",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q502M7",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "2",
+                  "endPosition" : 26682182,
+                  "startPosition" : 26656283
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-031112-5",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-030131-2379",
+               "ZFIN:ZDB-GENE-030131-4365",
+               "ZFIN:ZDB-GENE-030131-1384"
+            ],
+            "synonyms" : [
+               "wu:fb69e10",
+               "junctin",
+               "wu:fc06d04",
+               "wu:fc95a08",
+               "cb971",
+               "fc95a08",
+               "fc06d04",
+               "fb69e10"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "aspartate beta-hydroxylase",
+         "soTermId" : "SO:0001217",
+         "symbol" : "asph"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000088741",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-LINCRNAG-100922-90",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-LINCRNAG-100922-90",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-100922-151",
+               "ZFIN:ZDB-GENE-100922-90"
+            ],
+            "synonyms" : [
+               "si:dkey-85k15.10"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:dkey-19n13.5",
+         "soTermId" : "SO:0001641",
+         "symbol" : "si:dkey-19n13.5"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000104698",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-LINCRNAG-070424-191",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000093331",
+                  "pages" : []
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-LINCRNAG-070424-191",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-070424-191",
+               "ZFIN:ZDB-GENE-070424-217"
+            ],
+            "synonyms" : [
+               "si:dkey-190c14.9"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:ch211-69i3.3",
+         "soTermId" : "SO:0001641",
+         "symbol" : "si:ch211-69i3.3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000087306",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-LINCRNAG-170802-1",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-LINCRNAG-170802-1",
+            "secondaryIds" : [
+               "ZFIN:ZDB-LINCRNAG-131127-502",
+               "ZFIN:ZDB-GENE-131127-502"
+            ],
+            "synonyms" : [
+               "si:ch73-281f12.1"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "linc RNA nlrp12",
+         "soTermId" : "SO:0001641",
+         "symbol" : "linc-nlrp12"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000079298",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-140106-163",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-140106-163",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "zmp:0000001203",
+         "soTermId" : "SO:0001217",
+         "symbol" : "zmp:0000001203"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-130530-928",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000088233",
+                  "pages" : []
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-130530-928",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "zmp:0000000925",
+         "soTermId" : "SO:0001217",
+         "symbol" : "zmp:0000000925"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:553045",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-050506-126",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-050506-126",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "im:7145019",
+         "soTermId" : "SO:0001217",
+         "symbol" : "im:7145019"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-170601-117",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-170601-117",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-030616-204"
+            ],
+            "synonyms" : [
+               "si:dz172d23.29",
+               "TCR-alpha",
+               "si:busm1-172d23.29",
+               "J segment"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "T-cell receptor alpha joining 110",
+         "soTermId" : "SO:0001217",
+         "symbol" : "traj110"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-TRNAG-011205-32",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-TRNAG-011205-32",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-011205-32"
+            ],
+            "synonyms" : [
+               "mttg",
+               "AC024175.12",
+               "tRNA<sup>gly</sup>"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "tRNA glycine, mitochondrial",
+         "soTermId" : "SO:0001272",
+         "symbol" : "mt-tg"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENEP-030616-281",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENEP-030616-281",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-030616-281"
+            ],
+            "synonyms" : [
+               "si:busm1-18f12.11, pseudogene",
+               "si:dz18f12.11p"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:busm1-18f12.11, pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "si:busm1-18f12.11p"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-070117-1753",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-070117-1753",
+            "secondaryIds" : [
+               "ZFIN:ZDB-LOCUS-061101-229"
+            ],
+            "synonyms" : [
+               "unm t31407"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "un-named t31407",
+         "soTermId" : "SO:0001217",
+         "symbol" : "unm_t31407"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-070117-975",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-070117-975",
+            "secondaryIds" : [
+               "ZFIN:ZDB-LOCUS-060608-170"
+            ],
+            "synonyms" : [
+               "unm t30189"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "un-named t30189",
+         "soTermId" : "SO:0001217",
+         "symbol" : "unm_t30189"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-070117-1619",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-070117-1619",
+            "secondaryIds" : [
+               "ZFIN:ZDB-LOCUS-061101-108"
+            ],
+            "synonyms" : [
+               "unm t31443"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "un-named t31443",
+         "soTermId" : "SO:0001217",
+         "symbol" : "unm_t31443"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:A5WUU8",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000094854",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-070705-365",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "PANTHER:PTHR23320",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000043802",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:100002785",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "4",
+                  "endPosition" : 76655373,
+                  "startPosition" : 76637548
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "4",
+                  "endPosition" : 76633286,
+                  "startPosition" : 76608282
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-070705-365",
+            "synonyms" : [
+               "si:dkey-204h11.11"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "membrane-spanning 4-domains, subfamily A, member 17A.8",
+         "soTermId" : "SO:0001217",
+         "symbol" : "ms4a17a.8"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000096299",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000096278",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000013174",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A7E2G4",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:E7EZ18",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:E7FEL9",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A8E593",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:E7F1Y9",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000086218",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:566577",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-060503-63",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000069984",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:I3ITM9",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "19",
+                  "endPosition" : 44036792,
+                  "startPosition" : 44009473
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "19",
+                  "endPosition" : 43998061,
+                  "startPosition" : 43995936
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "19",
+                  "endPosition" : 43980876,
+                  "startPosition" : 43978814
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "19",
+                  "endPosition" : 43989462,
+                  "startPosition" : 43987389
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "19",
+                  "endPosition" : 44006445,
+                  "startPosition" : 44004348
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-060503-63",
+            "synonyms" : [
+               "si:dkey-231l1.4"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "NKD inhibitor of WNT signaling pathway 3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "nkd3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000101028",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000096367",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8QBK7",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:H0WEW1",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IPU0",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR43990",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8PVL4",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8PYK7",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A0R4IPN9",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-091117-6",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "21",
+                  "endPosition" : 6377890,
+                  "startPosition" : 6328801
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "21",
+                  "endPosition" : 6307573,
+                  "startPosition" : 6212844
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-091117-6",
+            "synonyms" : [
+               "si:ch211-225g23.2"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "formin binding protein 1b",
+         "soTermId" : "SO:0001217",
+         "symbol" : "fnbp1b"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-060503-131",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-060503-131",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:ch211-255l14.5",
+         "soTermId" : "SO:0001217",
+         "symbol" : "si:ch211-255l14.5"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-010323-3",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-010323-3",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "id:ibd1034",
+         "soTermId" : "SO:0001217",
+         "symbol" : "id:ibd1034"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-060503-455",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-060503-455",
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:dkey-59l11.4",
+         "soTermId" : "SO:0001217",
+         "symbol" : "si:dkey-59l11.4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:B0CLY5",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-040724-207",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:A8DZ56",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR21063",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000043198",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:554678",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q5BJ07",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "22",
+                  "endPosition" : 6404906,
+                  "startPosition" : 6393227
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-040724-207",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-050320-53"
+            ],
+            "synonyms" : [
+               "zgc:113457"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:rp71-1i20.2",
+         "soTermId" : "SO:0001217",
+         "symbol" : "si:rp71-1i20.2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:E7F704",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR19232",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:A0A2R8RPE7",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000037359",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-101203-4",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:101886304",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "12",
+                  "endPosition" : 1010416,
+                  "startPosition" : 1000323
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-101203-4",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-121214-325"
+            ],
+            "synonyms" : [
+               "si:ch1073-272o11.3"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "cerebellar degeneration-related protein 2b",
+         "soTermId" : "SO:0001217",
+         "symbol" : "cdr2b"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:H0WF30",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-040611-4",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000024681",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:402852",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:B8JLC6",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q7ZZC6",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR34436",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "1",
+                  "endPosition" : 55166611,
+                  "startPosition" : 55161083
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-040611-4",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-051030-66"
+            ],
+            "synonyms" : [
+               "zgc:123137"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "proliferation associated nuclear element",
+         "soTermId" : "SO:0001217",
+         "symbol" : "pane1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000105128",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-MIRNAG-090929-172",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-MIRNAG-090929-172",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-090929-172"
+            ],
+            "synonyms" : [
+               "miR-193a-2",
+               "dre-mir-193a-2",
+               "miR193a-2"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "microRNA 193a-2",
+         "soTermId" : "SO:0001265",
+         "symbol" : "mir193a-2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-MIRNAG-090929-176",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000088287",
+                  "pages" : []
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-MIRNAG-090929-176",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-090929-176"
+            ],
+            "synonyms" : [
+               "miR-194b",
+               "dre-mir-194b",
+               "miR194b"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "microRNA 194b",
+         "soTermId" : "SO:0001265",
+         "symbol" : "mir194b"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-MIRNAG-090929-170",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000082377",
+                  "pages" : []
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-MIRNAG-090929-170",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-090929-170"
+            ],
+            "synonyms" : [
+               "dre-mir-462",
+               "miR-462",
+               "miR462"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "microRNA 462",
+         "soTermId" : "SO:0001265",
+         "symbol" : "mir462"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-070117-724",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-070117-724",
+            "secondaryIds" : [
+               "ZFIN:ZDB-LOCUS-050919-28",
+               "ZFIN:ZDB-LOCUS-040720-20",
+               "ZFIN:ZDB-GENE-070117-847"
+            ],
+            "synonyms" : [
+               "unm s275"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "daredevil",
+         "soTermId" : "SO:0001217",
+         "symbol" : "ddl"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-LINCRNAG-050420-4",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-LINCRNAG-050420-4",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-041210-16",
+               "ZFIN:ZDB-GENE-050420-4"
+            ],
+            "synonyms" : [
+               "si:dkey-61f9.3"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:dkey-3n7.6",
+         "soTermId" : "SO:0001641",
+         "symbol" : "si:dkey-3n7.6"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-180305-4",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-180305-4",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-180305-6",
+               "ZFIN:ZDB-GENE-180305-5"
+            ],
+            "synonyms" : [
+               "escapist",
+               "escpst",
+               "unm_p406",
+               "unm_p405"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "un-named p404",
+         "soTermId" : "SO:0001217",
+         "symbol" : "unm_p404"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000096837",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-LINCRNAG-131125-29",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-LINCRNAG-131125-29",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-131125-29"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:dkey-167o9.3",
+         "soTermId" : "SO:0001641",
+         "symbol" : "si:dkey-167o9.3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-LINCRNAG-110411-192",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000095801",
+                  "pages" : []
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-LINCRNAG-110411-192",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-110411-192"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:dkey-119g10.4",
+         "soTermId" : "SO:0001641",
+         "symbol" : "si:dkey-119g10.4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-LINCRNAG-131121-164",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000097778",
+                  "pages" : []
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-LINCRNAG-131121-164",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-131121-164"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:dkey-273g18.4",
+         "soTermId" : "SO:0001641",
+         "symbol" : "si:dkey-273g18.4"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-030616-196",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-030616-196",
+            "synonyms" : [
+               "si:dz172d23.21",
+               "TCR-alpha",
+               "V segment"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:busm1-172d23.21",
+         "soTermId" : "SO:0001217",
+         "symbol" : "si:busm1-172d23.21"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-070301-1",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-070301-1",
+            "synonyms" : [
+               "ccr5.1",
+               "CCR5-26.1-EK21526"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "chemokine (C-C motif) receptor 12b, tandem duplicate 3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "ccr12b.3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-030616-287",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [],
+            "primaryId" : "ZFIN:ZDB-GENE-030616-287",
+            "synonyms" : [
+               "TCR-alpha",
+               "V segment",
+               "si:dz18f12.17"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "si:busm1-18f12.17",
+         "soTermId" : "SO:0001217",
+         "symbol" : "si:busm1-18f12.17"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-030131-1283",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-030131-1283",
+            "synonyms" : [
+               "fb65c06"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "wu:fb65c06",
+         "soTermId" : "SO:0001217",
+         "symbol" : "wu:fb65c06"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-111221-3",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-111221-3",
+            "synonyms" : [
+               "gb:al917659"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "junctional cadherin 5 associated b",
+         "soTermId" : "SO:0001217",
+         "symbol" : "jcadb"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ZFIN:ZDB-GENE-031118-94",
+                  "pages" : [
+                     "gene",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-031118-94",
+            "synonyms" : [
+               "fq40e10"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "wu:fq40e10",
+         "soTermId" : "SO:0001217",
+         "symbol" : "wu:fq40e10"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "UniProtKB:Q801U3",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000100815",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-030616-631",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "NCBI_Gene:368925",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000025397",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q801U4",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR23147",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "6",
+                  "endPosition" : 41085457,
+                  "startPosition" : 41080003
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "6",
+                  "endPosition" : 41091238,
+                  "startPosition" : 41080207
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-030616-631",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-040625-13",
+               "ZFIN:ZDB-GENE-030131-750"
+            ],
+            "synonyms" : [
+               "sfrs3a",
+               "sfrs3",
+               "si:zc263a23.9",
+               "zgc:86626",
+               "wu:fb44e08"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "serine and arginine rich splicing factor 3a",
+         "soTermId" : "SO:0001217",
+         "symbol" : "srsf3a"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000089475",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000089124",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q7ZT21",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-980526-80",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "3",
+                  "endPosition" : 55121125,
+                  "startPosition" : 55120330
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "3",
+                  "endPosition" : 55139127,
+                  "startPosition" : 55138413
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-980526-80",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-030616-6",
+               "ZFIN:ZDB-GENE-030616-8",
+               "ZFIN:ZDB-GENE-040625-58",
+               "ZFIN:ZDB-GENE-030131-6970",
+               "ZFIN:ZDB-GENE-030131-1560",
+               "ZFIN:ZDB-GENE-990603-3"
+            ],
+            "synonyms" : [
+               "globin alphae1",
+               "HBAA1",
+               "etID40432.3",
+               "hbae1a",
+               "HbA",
+               "si:by119c3.3",
+               "si:by119c3.1",
+               "HBA2r",
+               "wu:fb74f06",
+               "wu:fa12a11",
+               "hbae1",
+               "ae1a",
+               "si:xx-119c3.3",
+               "hba2",
+               "zgc:86936",
+               "alphae1globin"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "hemoglobin, alpha embryonic 1.1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "hbae1.1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSDARG00000096389",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q6A3P6",
+                  "pages" : []
+               },
+               {
+                  "id" : "NCBI_Gene:336346",
+                  "pages" : []
+               },
+               {
+                  "id" : "PANTHER:PTHR10270",
+                  "pages" : []
+               },
+               {
+                  "id" : "ZFIN:ZDB-GENE-030131-8290",
+                  "pages" : [
+                     "gene",
+                     "gene/expression",
+                     "gene/wild_type_expression",
+                     "gene/expression_images",
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "UniProtKB:I3IT46",
+                  "pages" : []
+               },
+               {
+                  "id" : "UniProtKB:Q6P0Z4",
+                  "pages" : []
+               },
+               {
+                  "id" : "ENSEMBL:ENSDARG00000004588",
+                  "pages" : []
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "19",
+                  "endPosition" : 28789409,
+                  "startPosition" : 28786149
+               },
+               {
+                  "assembly" : "GRCz11",
+                  "chromosome" : "19",
+                  "endPosition" : 28788466,
+                  "startPosition" : 28734048
+               }
+            ],
+            "primaryId" : "ZFIN:ZDB-GENE-030131-8290",
+            "secondaryIds" : [
+               "ZFIN:ZDB-GENE-040426-2130",
+               "ZFIN:ZDB-GENE-030131-1849",
+               "ZFIN:ZDB-GENE-040426-2424"
+            ],
+            "synonyms" : [
+               "wu:fq41g10",
+               "zgc:77392",
+               "zgc:65850",
+               "sox4",
+               "wu:fb82f08"
+            ],
+            "taxonId" : "NCBITaxon:7955"
+         },
+         "name" : "SRY-box transcription factor 4a",
+         "soTermId" : "SO:0001217",
+         "symbol" : "sox4a"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000223179"
+               },
+               {
+                  "id" : "NCBI_Gene:106480391"
+               },
+               {
+                  "id" : "RGD:10413330",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:47336",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:10413330"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "2",
+                  "endPosition" : 39393618,
+                  "startPosition" : 39393522,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "5",
+                  "endPosition" : 119007668,
+                  "startPosition" : 119007571,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "HGNC:47336",
+            "secondaryIds" : [
+               "RGD:10413330"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "RNA, U6 small nuclear 373, pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "RNU6-373P"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000225661"
+               },
+               {
+                  "id" : "NCBI_Gene:442442"
+               },
+               {
+                  "id" : "RGD:3277915",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:37720",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:3277915"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "Y",
+                  "endPosition" : 1010100,
+                  "startPosition" : 1009720,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "X",
+                  "endPosition" : 1010101,
+                  "startPosition" : 1008503,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:37720",
+            "secondaryIds" : [
+               "RGD:3277915"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "ribosomal protein L14 pseudogene 5",
+         "soTermId" : "SO:0000336",
+         "symbol" : "RPL14P5"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000237040"
+               },
+               {
+                  "id" : "NCBI_Gene:106478926"
+               },
+               {
+                  "id" : "RGD:10412387",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:38719",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:10412387"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "Y",
+                  "endPosition" : 57062405,
+                  "startPosition" : 57062156,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "X",
+                  "endPosition" : 155875885,
+                  "startPosition" : 155875636,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "HGNC:38719",
+            "secondaryIds" : [
+               "RGD:10412387"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "diphthamide biosynthesis 3 pseudogene 2",
+         "soTermId" : "SO:0000336",
+         "symbol" : "DPH3P2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000162714"
+               },
+               {
+                  "id" : "NCBI_Gene:84838"
+               },
+               {
+                  "id" : "PANTHER:PTHR23226"
+               },
+               {
+                  "id" : "UniProtKB:Q96IT1"
+               },
+               {
+                  "id" : "RGD:1312150",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:23713",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1312150"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "1",
+                  "endPosition" : 247331867,
+                  "startPosition" : 247297412,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:23713",
+            "secondaryIds" : [
+               "RGD:1312150"
+            ],
+            "synonyms" : [
+               "MGC15548",
+               "NIZP1",
+               "NSD1 (nuclear receptor binding SET-domain containing 1)-interacting zinc finger protein 1",
+               "ZFP496",
+               "ZKSCAN17",
+               "ZSCAN49",
+               "zinc finger protein with KRAB and SCAN domains 17"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "ENCODES a protein that exhibits DNA binding (ortholog); protein self-association (ortholog); INVOLVED IN negative regulation of transcription by RNA polymerase II (ortholog); positive regulation of transcription, DNA-templated (ortholog); ASSOCIATED WITH Gastrointestinal stroma tumor; gastrointestinal stromal tumor; Parathyroid carcinoma; FOUND IN nuclear body (ortholog); nucleus (ortholog); INTERACTS WITH 5-aza-2'-deoxycytidine; acrylamide; arsenite(3-)",
+         "name" : "zinc finger protein 496",
+         "soTermId" : "SO:0001217",
+         "symbol" : "ZNF496"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000223979"
+               },
+               {
+                  "id" : "NCBI_Gene:105371564"
+               },
+               {
+                  "id" : "RGD:1345469",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:17914",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1345469"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "17",
+                  "endPosition" : 17677688,
+                  "startPosition" : 17674026,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:17914",
+            "secondaryIds" : [
+               "RGD:1345469"
+            ],
+            "synonyms" : [
+               "Smith-Magenis syndrome chromosome region, candidate 2 (non-protein coding)",
+               "TCONS_00025215"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "ASSOCIATED WITH autistic disorder",
+         "name" : "Smith-Magenis syndrome chromosome region, candidate 2",
+         "soTermId" : "SO:0001263",
+         "symbol" : "SMCR2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000242086"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000215837"
+               },
+               {
+                  "id" : "NCBI_Gene:727956"
+               },
+               {
+                  "id" : "RGD:1351623",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:27408",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1351623"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "3",
+                  "endPosition" : 195688871,
+                  "startPosition" : 195658039,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "HGNC:27408",
+            "secondaryIds" : [
+               "RGD:1351623"
+            ],
+            "synonyms" : [
+               "AC069513.3",
+               "SDHAL2",
+               "SDHALP2"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "INTERACTS WITH antirheumatic drug; benzo[a]pyrene; cisplatin",
+         "name" : "succinate dehydrogenase complex flavoprotein subunit A pseudogene 2",
+         "soTermId" : "SO:0000336",
+         "symbol" : "SDHAP2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000231049"
+               },
+               {
+                  "id" : "NCBI_Gene:81270"
+               },
+               {
+                  "id" : "RGD:1350568",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:15210",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1350568"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "11",
+                  "endPosition" : 5564327,
+                  "startPosition" : 5557096,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "HGNC:15210",
+            "secondaryIds" : [
+               "RGD:1350568"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "Olfactory receptors interact with odorant molecules in the nose, to initiate a neuronal response that triggers the perception of a smell. The olfactory receptor proteins are members of a large family of G-protein-coupled receptors (GPCR) arising from single coding-exon genes. Olfactory receptors share a 7-transmembrane domain structure with many neurotransmitter and hormone receptors and are responsible for the recognition and G protein-mediated transduction of odorant signals. The olfactory receptor gene family is the largest in the genome. The nomenclature assigned to the olfactory receptor genes and proteins for this organism is independent of other organisms. [provided by RefSeq, Jul 2008]",
+         "name" : "olfactory receptor family 52 subfamily B member 5 pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "OR52B5P"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000199363"
+               },
+               {
+                  "id" : "NCBI_Gene:109617007"
+               },
+               {
+                  "id" : "RGD:12738314",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:52212",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:12738314"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "3",
+                  "endPosition" : 183453946,
+                  "startPosition" : 183453814,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "HGNC:52212",
+            "secondaryIds" : [
+               "RGD:12738314"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "ASSOCIATED WITH Currarino syndrome",
+         "name" : "small nucleolar RNA, H/ACA box 63E",
+         "soTermId" : "SO:0001267",
+         "symbol" : "SNORA63E"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:146880"
+               },
+               {
+                  "id" : "RGD:11571013",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:28630",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:11571013"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "17",
+                  "endPosition" : 64781504,
+                  "startPosition" : 64778139,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:28630",
+            "secondaryIds" : [
+               "RGD:11571013"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "INTERACTS WITH leflunomide; valproic acid",
+         "name" : "Rho GTPase activating protein 27 pseudogene 1",
+         "soTermId" : "SO:0000336",
+         "symbol" : "ARHGAP27P1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:100189411"
+               },
+               {
+                  "id" : "RGD:2300566",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:34980",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:2300566"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "6",
+                  "endPosition" : 26796281,
+                  "startPosition" : 26796209,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "6",
+                  "endPosition" : 26705449,
+                  "startPosition" : 26705377,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "HGNC:34980",
+            "secondaryIds" : [
+               "RGD:2300566"
+            ],
+            "synonyms" : [
+               "TRNAA41",
+               "tRNA-Ala (AGC) 13-1",
+               "transfer RNA-Ala (AGC) 13-1"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "tRNA-Ala (anticodon AGC) 13-1",
+         "soTermId" : "SO:0001272",
+         "symbol" : "TRA-AGC13-1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000261834"
+               },
+               {
+                  "id" : "NCBI_Gene:28301"
+               },
+               {
+                  "id" : "RGD:1349167",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:5639",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1349167"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "16",
+                  "endPosition" : 33950462,
+                  "startPosition" : 33949898,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "16",
+                  "endPosition" : 32903894,
+                  "startPosition" : 32903442,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "HGNC:5639",
+            "secondaryIds" : [
+               "RGD:1349167"
+            ],
+            "synonyms" : [
+               "IGHV3OR16-15",
+               "IGHV3OR1615",
+               "immunoglobulin heavy variable 3/OR16-15 (pseudogene)"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "immunoglobulin heavy variable 3/OR16-16 (pseudogene)",
+         "soTermId" : "SO:0000336",
+         "symbol" : "IGHV3OR16-16"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000274540"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000255378"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000255251"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000284870"
+               },
+               {
+                  "id" : "NCBI_Gene:100133251"
+               },
+               {
+                  "id" : "UniProtKB:P0DMB1"
+               },
+               {
+                  "id" : "UniProtKB:E9PI22"
+               },
+               {
+                  "id" : "RGD:7406305",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:49396",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:7406305"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "8",
+                  "endPosition" : 7784165,
+                  "startPosition" : 7778591,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "8",
+                  "endPosition" : 7542450,
+                  "startPosition" : 7539627,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "HGNC:49396",
+            "secondaryIds" : [
+               "RGD:7406305"
+            ],
+            "synonyms" : [
+               "PRR23D1",
+               "Proline-rich protein 23D1",
+               "proline-rich protein 23C-like",
+               "proline-rich protein 23D2"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "proline rich 23 domain containing 2",
+         "soTermId" : "SO:0001217",
+         "symbol" : "PRR23D2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000222765"
+               },
+               {
+                  "id" : "NCBI_Gene:106480671"
+               },
+               {
+                  "id" : "RGD:10400077",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:48533",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:10400077"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "4",
+                  "endPosition" : 65807435,
+                  "startPosition" : 65807240,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:48533",
+            "secondaryIds" : [
+               "RGD:10400077"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "RNA, U2 small nuclear 40, pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "RNU2-40P"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000201085"
+               },
+               {
+                  "id" : "NCBI_Gene:106479643"
+               },
+               {
+                  "id" : "RGD:10398993",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:47136",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:10398993"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "4",
+                  "endPosition" : 188121634,
+                  "startPosition" : 188121531,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:47136",
+            "secondaryIds" : [
+               "RGD:10398993"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "RNA, U6 small nuclear 173, pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "RNU6-173P"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000258706"
+               },
+               {
+                  "id" : "NCBI_Gene:646052"
+               },
+               {
+                  "id" : "RGD:5487956",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:42538",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:5487956"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "15",
+                  "endPosition" : 19968365,
+                  "startPosition" : 19966630,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:42538",
+            "secondaryIds" : [
+               "RGD:5487956"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "solute carrier family 20 member 1 pseudogene 3",
+         "soTermId" : "SO:0000336",
+         "symbol" : "SLC20A1P3"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000176797"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000284978"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000273641"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000177243"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000285376"
+               },
+               {
+                  "id" : "NCBI_Gene:55894"
+               },
+               {
+                  "id" : "UniProtKB:P81534"
+               },
+               {
+                  "id" : "RGD:1344949",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:31702",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1344949"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "8",
+                  "endPosition" : 7430348,
+                  "startPosition" : 7428888,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "8",
+                  "endPosition" : 7882663,
+                  "startPosition" : 7881392,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "HGNC:31702",
+            "secondaryIds" : [
+               "RGD:1344949"
+            ],
+            "synonyms" : [
+               "BD-3",
+               "DEFB-3",
+               "DEFB103",
+               "DEFB3",
+               "HBD-3",
+               "HBD3",
+               "HBP-3",
+               "HBP3",
+               "beta-defensin 103",
+               "beta-defensin 3",
+               "defensin, beta 103",
+               "defensin, beta 103B",
+               "defensin, beta 3",
+               "defensin-like protein"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "Defensins form a family of microbicidal and cytotoxic peptides made by neutrophils. Members of the defensin family are highly similar in protein sequence. This gene encodes defensin, beta 103, which has broad spectrum antimicrobial activity and may play an important role in innate epithelial defense. [provided by RefSeq, Oct 2014]",
+         "name" : "defensin beta 103B",
+         "soTermId" : "SO:0001217",
+         "symbol" : "DEFB103B"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000205571"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000275349"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000273772"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000172062"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000277773"
+               },
+               {
+                  "id" : "NCBI_Gene:6606"
+               },
+               {
+                  "id" : "UniProtKB:Q16637"
+               },
+               {
+                  "id" : "RGD:736439",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:11117",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:736439"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "5",
+                  "endPosition" : 70953942,
+                  "startPosition" : 70924941,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "5",
+                  "endPosition" : 70078522,
+                  "startPosition" : 70049638,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "HGNC:11117",
+            "secondaryIds" : [
+               "RGD:736439"
+            ],
+            "synonyms" : [
+               "BCD541",
+               "GEMIN1",
+               "SMA",
+               "SMA1",
+               "SMA2",
+               "SMA3",
+               "SMA4",
+               "SMA@",
+               "SMN",
+               "SMN2",
+               "SMNT",
+               "T-BCD541",
+               "TDRD16A",
+               "component of gems 1",
+               "gemin 1",
+               "gemin-1",
+               "spinal muscular atrophy (Werdnig-Hoffmann disease, Kugelberg-Welander disease)",
+               "survival motor neuron 1 protein",
+               "survival motor neuron protein",
+               "survival of motor neuron 1 isoform D2A2B345",
+               "survival of motor neuron 1 isoform D2A2B3457",
+               "survival of motor neuron 1 isoform D2A3457",
+               "survival of motor neuron 1 isoform D2B3457",
+               "survival of motor neuron 1 isoform D345",
+               "survival of motor neuron 1 isoform D3457",
+               "survival of motor neuron 1 isoform D347",
+               "tudor domain containing 16A"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "This gene is part of a 500 kb inverted duplication on chromosome 5q13. This duplicated region contains at least four genes and repetitive elements which make it prone to rearrangements and deletions. The repetitiveness and complexity of the sequence have also caused difficulty in determining the organization of this genomic region. The telomeric and centromeric copies of this gene are nearly identical and encode the same protein. However, mutations in this gene, the telomeric copy, are associated with spinal muscular atrophy; mutations in the centromeric copy do not lead to disease. The centromeric copy may be a modifier of disease caused by mutation in the telomeric copy. The critical sequence difference between the two genes is a single nucleotide in exon 7, which is thought to be an exon splice enhancer. Note that the nine exons of both the telomeric and centromeric copies are designated historically as exon 1, 2a, 2b, and 3-8. It is thought that gene conversion events may involve the two genes, leading to varying copy numbers of each gene. The protein encoded by this gene localizes to both the cytoplasm and the nucleus. Within the nucleus, the protein localizes to subnuclear bodies called gems which are found near coiled bodies containing high concentrations of small ribonucleoproteins (snRNPs). This protein forms heteromeric complexes with proteins such as SIP1 and GEMIN4, and also interacts with several proteins known to be involved in the biogenesis of snRNPs, such as hnRNP U protein and the small nucleolar RNA binding protein. Multiple transcript variants encoding distinct isoforms have been described. [provided by RefSeq, Jul 2014]",
+         "name" : "survival of motor neuron 1, telomeric",
+         "soTermId" : "SO:0001217",
+         "symbol" : "SMN1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000171711"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000285181"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000275444"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000177257"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000285433"
+               },
+               {
+                  "id" : "NCBI_Gene:100289462"
+               },
+               {
+                  "id" : "UniProtKB:O15263"
+               },
+               {
+                  "id" : "RGD:1625102",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:30193",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1625102"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "8",
+                  "endPosition" : 7416863,
+                  "startPosition" : 7414855,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "8",
+                  "endPosition" : 7896716,
+                  "startPosition" : 7894677,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "HGNC:30193",
+            "secondaryIds" : [
+               "RGD:1625102"
+            ],
+            "synonyms" : [
+               "DEFB4P",
+               "beta defensin 2",
+               "beta defensin-2",
+               "beta-defensin 2",
+               "beta-defensin 4B",
+               "defensin, beta 4, pseudogene",
+               "defensin, beta 4B"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "Defensins form a family of microbicidal and cytotoxic peptides made by neutrophils. Members of the defensin family are highly similar in protein sequence. This gene encodes defensin, beta 4, an antibiotic peptide which is locally regulated by inflammation. [provided by RefSeq, Oct 2014]",
+         "name" : "defensin beta 4B",
+         "soTermId" : "SO:0001217",
+         "symbol" : "DEFB4B"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000175658"
+               },
+               {
+                  "id" : "NCBI_Gene:1818"
+               },
+               {
+                  "id" : "RGD:1354254",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:3028",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1354254"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "1",
+                  "endPosition" : 144691842,
+                  "startPosition" : 144689614,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "1",
+                  "endPosition" : 144277993,
+                  "startPosition" : 144274892,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:3028",
+            "secondaryIds" : [
+               "RGD:1354254"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "INTERACTS WITH aflatoxin B1; benzo[a]pyrene; N-Nitrosopyrrolidine",
+         "name" : "dopamine receptor D5 pseudogene 2",
+         "soTermId" : "SO:0000336",
+         "symbol" : "DRD5P2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000237940"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000261186"
+               },
+               {
+                  "id" : "NCBI_Gene:102723927"
+               },
+               {
+                  "id" : "RGD:11568944",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:49795",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:11568944"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "2",
+                  "endPosition" : 241977276,
+                  "startPosition" : 241970683,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "2",
+                  "endPosition" : 242088457,
+                  "startPosition" : 242087351,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:49795",
+            "secondaryIds" : [
+               "RGD:11568944"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "INTERACTS WITH aflatoxin B1; aflatoxin B2; aristolochic acid",
+         "name" : "long intergenic non-protein coding RNA 1238",
+         "soTermId" : "SO:0001263",
+         "symbol" : "LINC01238"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000224416"
+               },
+               {
+                  "id" : "NCBI_Gene:3453"
+               },
+               {
+                  "id" : "RGD:1344393",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:5431",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1344393"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "9",
+                  "endPosition" : 21278619,
+                  "startPosition" : 21277688,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:5431",
+            "secondaryIds" : [
+               "RGD:1344393"
+            ],
+            "synonyms" : [
+               "IFNAP22",
+               "interferon, alpha 22, pseudogene"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "interferon alpha 22, pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "IFNA22P"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000283948"
+               },
+               {
+                  "id" : "NCBI_Gene:28350"
+               },
+               {
+                  "id" : "RGD:1346164",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:5694",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1346164"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "14",
+                  "endPosition" : 106171052,
+                  "startPosition" : 106170746,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:5694",
+            "secondaryIds" : [
+               "RGD:1346164"
+            ],
+            "synonyms" : [
+               "3-16.1P",
+               "IGHVIII161"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "immunoglobulin heavy variable (III)-16-1 (pseudogene)",
+         "soTermId" : "SO:0000336",
+         "symbol" : "IGHVIII-16-1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000253920"
+               },
+               {
+                  "id" : "NCBI_Gene:28788"
+               },
+               {
+                  "id" : "RGD:1346403",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:5913",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1346403"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "22",
+                  "endPosition" : 22605185,
+                  "startPosition" : 22604445,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "HGNC:5913",
+            "secondaryIds" : [
+               "RGD:1346403"
+            ],
+            "synonyms" : [
+               "IGLV331",
+               "V2-22P"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "immunoglobulin lambda variable 3-31 (pseudogene)",
+         "soTermId" : "SO:0000336",
+         "symbol" : "IGLV3-31"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000276050"
+               },
+               {
+                  "id" : "NCBI_Gene:28855"
+               },
+               {
+                  "id" : "RGD:1348675",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:5806",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1348675"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "2",
+                  "endPosition" : 97376973,
+                  "startPosition" : 97376255,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "2",
+                  "endPosition" : 97331843,
+                  "startPosition" : 97331533,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:5806",
+            "secondaryIds" : [
+               "RGD:1348675"
+            ],
+            "synonyms" : [
+               "IGKV2OR210"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "immunoglobulin kappa variable 2/OR2-10 (pseudogene)",
+         "soTermId" : "SO:0000336",
+         "symbol" : "IGKV2OR2-10"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000271093"
+               },
+               {
+                  "id" : "ENSEMBL:ENSG00000243519"
+               },
+               {
+                  "id" : "NCBI_Gene:84086"
+               },
+               {
+                  "id" : "RGD:1353616",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:15697",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1353616"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "22",
+                  "endPosition" : 32377135,
+                  "startPosition" : 32376682,
+                  "strand" : "+"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "22",
+                  "endPosition" : 32356988,
+                  "startPosition" : 32356676,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:15697",
+            "secondaryIds" : [
+               "RGD:1353616"
+            ],
+            "synonyms" : [
+               "IGLC/OR22-2"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "immunoglobulin lambda constant/OR22-2 (pseudogene)",
+         "soTermId" : "SO:0000336",
+         "symbol" : "IGLCOR22-2"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000207012"
+               },
+               {
+                  "id" : "NCBI_Gene:100873775"
+               },
+               {
+                  "id" : "RGD:6481537",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:42562",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:6481537"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "13",
+                  "endPosition" : 85584853,
+                  "startPosition" : 85584748,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "11",
+                  "endPosition" : 72047951,
+                  "startPosition" : 72047873,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:42562",
+            "secondaryIds" : [
+               "RGD:6481537"
+            ],
+            "synonyms" : [
+               "RNU6-72"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "RNA, U6 small nuclear 72, pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "RNU6-72P"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000221116"
+               },
+               {
+                  "id" : "NCBI_Gene:692213"
+               },
+               {
+                  "id" : "RGD:1602359",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:32775",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1602359"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "20",
+                  "endPosition" : 2654286,
+                  "startPosition" : 2654212,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "HGNC:32775",
+            "secondaryIds" : [
+               "RGD:1602359"
+            ],
+            "synonyms" : [
+               "HBII-55"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "INTERACTS WITH versicolorin A",
+         "name" : "small nucleolar RNA, C/D box 110",
+         "soTermId" : "SO:0001267",
+         "symbol" : "SNORD110"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "NCBI_Gene:767584"
+               },
+               {
+                  "id" : "RGD:1602516",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:32996",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1602516"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "14",
+                  "endPosition" : 100964851,
+                  "startPosition" : 100964781,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "HGNC:32996",
+            "secondaryIds" : [
+               "RGD:1602516"
+            ],
+            "synonyms" : [
+               "14q(II-8)"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "ASSOCIATED WITH Kagami-Ogata syndrome; INTERACTS WITH benzo[a]pyrene; sodium arsenite",
+         "name" : "small nucleolar RNA, C/D box 114-8",
+         "soTermId" : "SO:0001267",
+         "symbol" : "SNORD114-8"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000249353"
+               },
+               {
+                  "id" : "NCBI_Gene:100422243"
+               },
+               {
+                  "id" : "RGD:7253328",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:45206",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:7253328"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "5",
+                  "endPosition" : 93683733,
+                  "startPosition" : 93682519,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:45206",
+            "secondaryIds" : [
+               "RGD:7253328"
+            ],
+            "synonyms" : [
+               "nucleophosmin 1 (nucleolar phosphoprotein B23, numatrin) pseudogene 27"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "INTERACTS WITH aristolochic acid",
+         "name" : "nucleophosmin 1 pseudogene 27",
+         "soTermId" : "SO:0000336",
+         "symbol" : "NPM1P27"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000199318"
+               },
+               {
+                  "id" : "NCBI_Gene:100873290"
+               },
+               {
+                  "id" : "RGD:6482085",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:42829",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:6482085"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "1",
+                  "endPosition" : 87453373,
+                  "startPosition" : 87453240,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:42829",
+            "secondaryIds" : [
+               "RGD:6482085"
+            ],
+            "synonyms" : [
+               "RN5S52"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "RNA, 5S ribosomal pseudogene 52",
+         "soTermId" : "SO:0000336",
+         "symbol" : "RNA5SP52"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000214077"
+               },
+               {
+                  "id" : "NCBI_Gene:2777"
+               },
+               {
+                  "id" : "RGD:1353631",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:4391",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1353631"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "2",
+                  "endPosition" : 131425140,
+                  "startPosition" : 131422443,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:4391",
+            "secondaryIds" : [
+               "RGD:1353631"
+            ],
+            "synonyms" : [
+               "GNAQP"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "G protein subunit alpha q pseudogene 1",
+         "soTermId" : "SO:0000336",
+         "symbol" : "GNAQP1"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000232858"
+               },
+               {
+                  "id" : "NCBI_Gene:651249"
+               },
+               {
+                  "id" : "RGD:2305613",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:36369",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:2305613"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "13",
+                  "endPosition" : 24988956,
+                  "startPosition" : 24988533,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:36369",
+            "secondaryIds" : [
+               "RGD:2305613"
+            ],
+            "synonyms" : [
+               "RPL34_11_1303"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "name" : "ribosomal protein L34 pseudogene 27",
+         "soTermId" : "SO:0000336",
+         "symbol" : "RPL34P27"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000230542"
+               },
+               {
+                  "id" : "NCBI_Gene:100359394"
+               },
+               {
+                  "id" : "RGD:3497317",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:30470",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:3497317"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "X",
+                  "endPosition" : 2615347,
+                  "startPosition" : 2612988,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "Y",
+                  "endPosition" : 2615347,
+                  "startPosition" : 2612991,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:30470",
+            "secondaryIds" : [
+               "RGD:3497317"
+            ],
+            "synonyms" : [
+               "NCRNA00102"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "ASSOCIATED WITH autistic disorder; Schizophrenia; INTERACTS WITH antirheumatic drug; cisplatin",
+         "name" : "long intergenic non-protein coding RNA 102",
+         "soTermId" : "SO:0001263",
+         "symbol" : "LINC00102"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000227242"
+               },
+               {
+                  "id" : "NCBI_Gene:644861"
+               },
+               {
+                  "id" : "RGD:1606849",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:31995",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:1606849"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "1",
+                  "endPosition" : 147114346,
+                  "startPosition" : 147099482,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "1",
+                  "endPosition" : 147056593,
+                  "startPosition" : 147019656,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:31995",
+            "secondaryIds" : [
+               "RGD:1606849"
+            ],
+            "synonyms" : [
+               "neuroblastoma breakpoint family member 13, pseudogene"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "This gene is a member of the neuroblastoma breakpoint family (NBPF) which consists of dozens of recently duplicated genes primarily located in segmental duplications on human chromosome 1. This gene family has experienced its greatest expansion within the human lineage and has expanded, to a lesser extent, among primates in general. Members of this gene family are characterized by tandemly repeated copies of DUF1220 protein domains. Gene copy number variations in the human chromosomal region 1q21.1, where most DUF1220 domains are located, have been implicated in a number of developmental and neurogenetic diseases such as microcephaly, macrocephaly, autism, schizophrenia, cognitive disability, congenital heart disease, neuroblastoma, and congenital kidney and urinary tract anomalies. Altered expression of some gene family members is associated with several types of cancer. This gene family contains numerous pseudogenes. [provided by RefSeq, May 2013]",
+         "name" : "NBPF member 13, pseudogene",
+         "soTermId" : "SO:0000336",
+         "symbol" : "NBPF13P"
+      },
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "ENSEMBL:ENSG00000223274"
+               },
+               {
+                  "id" : "NCBI_Gene:106480770"
+               },
+               {
+                  "id" : "RGD:10398929",
+                  "pages" : [
+                     "gene/references"
+                  ]
+               },
+               {
+                  "id" : "HGNC:43398",
+                  "pages" : [
+                     "gene"
+                  ]
+               },
+               {
+                  "id" : "RGD:10398929"
+               }
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "Y",
+                  "endPosition" : 1300375,
+                  "startPosition" : 1300256,
+                  "strand" : "-"
+               },
+               {
+                  "assembly" : "GRCh38",
+                  "chromosome" : "X",
+                  "endPosition" : 1300375,
+                  "startPosition" : 1300256,
+                  "strand" : "-"
+               }
+            ],
+            "primaryId" : "HGNC:43398",
+            "secondaryIds" : [
+               "RGD:10398929"
+            ],
+            "synonyms" : [
+               "RN5S498"
+            ],
+            "taxonId" : "NCBITaxon:9606"
+         },
+         "geneSynopsis" : "INTERACTS WITH herbicide",
+         "name" : "RNA, 5S ribosomal pseudogene 498",
+         "soTermId" : "SO:0000336",
+         "symbol" : "RNA5SP498"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/01_all_fields.json
+++ b/src/test/resources/gene/01_all_fields.json
@@ -1,0 +1,59 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref1a"
+               },
+               {
+                  "id" : "TEST:xref1b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "1",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00001",
+            "secondaryIds" : [
+               "TEST:TG00001"
+            ],
+            "synonyms" : [
+               "Test1",
+               "ExampleGene1"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Test gene with all fields populated",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_1", 
+         "name" : "Test gene 1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg1"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/02_no_cross_references.json
+++ b/src/test/resources/gene/02_no_cross_references.json
@@ -1,0 +1,44 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "2",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00002",
+            "secondaryIds" : [
+               "TEST:TG00002"
+            ],
+            "synonyms" : [
+               "Test2",
+               "ExampleGene2"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Test gene with all fields populated except crossReferences",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_2", 
+         "name" : "Test gene 2",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg2"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/03_no_genome_locations.json
+++ b/src/test/resources/gene/03_no_genome_locations.json
@@ -1,0 +1,50 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref3a"
+               },
+               {
+                  "id" : "TEST:xref3b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "primaryId" : "TEST:TestGene00003",
+            "secondaryIds" : [
+               "TEST:TG00003"
+            ],
+            "synonyms" : [
+               "Test3",
+               "ExampleGene3"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Test gene with all fields populated except genomeLocations",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_3", 
+         "name" : "Test gene 3",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg3"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/04_no_primary_id.json
+++ b/src/test/resources/gene/04_no_primary_id.json
@@ -1,0 +1,58 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref4a"
+               },
+               {
+                  "id" : "TEST:xref4b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "4",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "secondaryIds" : [
+               "TEST:TG00004"
+            ],
+            "synonyms" : [
+               "Test4",
+               "ExampleGene4"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Test gene with all fields populated except primaryId",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_4", 
+         "name" : "Test gene 4",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg4"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/05_no_secondary_ids.json
+++ b/src/test/resources/gene/05_no_secondary_ids.json
@@ -1,0 +1,56 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref5a"
+               },
+               {
+                  "id" : "TEST:xref5b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "5",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00005",
+            "synonyms" : [
+               "Test5",
+               "ExampleGene5"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Test gene with all fields populated except secondaryIds",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_5", 
+         "name" : "Test gene 5",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg5"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/06_no_synonyms.json
+++ b/src/test/resources/gene/06_no_synonyms.json
@@ -1,0 +1,55 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref6a"
+               },
+               {
+                  "id" : "TEST:xref6b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "6",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00006",
+            "secondaryIds" : [
+               "TEST:TG00006"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Test gene with all fields populated except synonyms",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_6", 
+         "name" : "Test gene 6",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg6"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/07_no_taxon_id.json
+++ b/src/test/resources/gene/07_no_taxon_id.json
@@ -1,0 +1,58 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref7a"
+               },
+               {
+                  "id" : "TEST:xref7b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "7",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00007",
+            "secondaryIds" : [
+               "TEST:TG00007"
+            ],
+            "synonyms" : [
+               "Test7",
+               "ExampleGene7"
+            ],
+         },
+         "geneSynopsis" : "Test gene with all fields populated except taxonId",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_7", 
+         "name" : "Test gene 7",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg7"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/08_no_gene_synopsis.json
+++ b/src/test/resources/gene/08_no_gene_synopsis.json
@@ -1,0 +1,58 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref8a"
+               },
+               {
+                  "id" : "TEST:xref8b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "8",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00008",
+            "secondaryIds" : [
+               "TEST:TG00008"
+            ],
+            "synonyms" : [
+               "Test8",
+               "ExampleGene8"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_8", 
+         "name" : "Test gene 8",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg8"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/09_no_gene_synopsis_url.json
+++ b/src/test/resources/gene/09_no_gene_synopsis_url.json
@@ -1,0 +1,58 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref9a"
+               },
+               {
+                  "id" : "TEST:xref9b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "9",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00009",
+            "secondaryIds" : [
+               "TEST:TG00009"
+            ],
+            "synonyms" : [
+               "Test9",
+               "ExampleGene9"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Test gene with all fields populated except geneSynopsisUrl",
+         "name" : "Test gene 9",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg9"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/10_no_name.json
+++ b/src/test/resources/gene/10_no_name.json
@@ -1,0 +1,58 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref10a"
+               },
+               {
+                  "id" : "TEST:xref10b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "10",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00010",
+            "secondaryIds" : [
+               "TEST:TG00010"
+            ],
+            "synonyms" : [
+               "Test10",
+               "ExampleGene10"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Test gene with all fields populated except name",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_10", 
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg10"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/11_no_so_term_id.json
+++ b/src/test/resources/gene/11_no_so_term_id.json
@@ -1,0 +1,58 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref11a"
+               },
+               {
+                  "id" : "TEST:xref11b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "11",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00011",
+            "secondaryIds" : [
+               "TEST:TG00011"
+            ],
+            "synonyms" : [
+               "Test11",
+               "ExampleGene11"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Test gene with all fields populated except soTermId",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_11", 
+         "name" : "Test gene 11",
+         "symbol" : "Tg11"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/12_no_symbol.json
+++ b/src/test/resources/gene/12_no_symbol.json
@@ -1,0 +1,58 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref12a"
+               },
+               {
+                  "id" : "TEST:xref12b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "12",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00012",
+            "secondaryIds" : [
+               "TEST:TG00012"
+            ],
+            "synonyms" : [
+               "Test12",
+               "ExampleGene12"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Test gene with all fields populated except symbol",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_12", 
+         "name" : "Test gene 12",
+         "soTermId" : "SO:0001217"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/13_additional_field.json
+++ b/src/test/resources/gene/13_additional_field.json
@@ -1,0 +1,60 @@
+{
+   "data" : [
+       {
+	  "additionalField" : "Not in BGI ingest schema", 
+          "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref13a"
+               },
+               {
+                  "id" : "TEST:xref13b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "13",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00013",
+            "secondaryIds" : [
+               "TEST:TG00013"
+            ],
+            "synonyms" : [
+               "Test13",
+               "ExampleGene13"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Test gene with additional field not in BGI schema",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_13", 
+         "name" : "Test gene 13",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg13"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/14_invalid_so_term_id.json
+++ b/src/test/resources/gene/14_invalid_so_term_id.json
@@ -1,0 +1,59 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref14a"
+               },
+               {
+                  "id" : "TEST:xref14b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "14",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00014",
+            "secondaryIds" : [
+               "TEST:TG00014"
+            ],
+            "synonyms" : [
+               "Test14",
+               "ExampleGene14"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Test gene invalid SO term ID",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_14", 
+         "name" : "Test gene 14",
+         "soTermId" : "SO:99999999999",
+         "symbol" : "Tg14"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/15_invalid_taxon_id.json
+++ b/src/test/resources/gene/15_invalid_taxon_id.json
@@ -1,0 +1,59 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref15a"
+               },
+               {
+                  "id" : "TEST:xref15b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "15",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00015",
+            "secondaryIds" : [
+               "TEST:TG00015"
+            ],
+            "synonyms" : [
+               "Test15",
+               "ExampleGene15"
+            ],
+            "taxonId" : "NCBITaxon:999999999"
+         },
+         "geneSynopsis" : "Test gene invalid taxon ID",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_15", 
+         "name" : "Test gene 15",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg15"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/16_start_after_end.json
+++ b/src/test/resources/gene/16_start_after_end.json
@@ -1,0 +1,59 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref16a"
+               },
+               {
+                  "id" : "TEST:xref16b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "16",
+                  "endPosition" : 1,
+                  "startPosition" : 100,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00016",
+            "secondaryIds" : [
+               "TEST:TG00016"
+            ],
+            "synonyms" : [
+               "Test16",
+               "ExampleGene16"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Test gene with gene start position downstream of gene end position",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_16", 
+         "name" : "Test gene 16",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg16"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/17_invalid_strand.json
+++ b/src/test/resources/gene/17_invalid_strand.json
@@ -1,0 +1,59 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref17a"
+               },
+               {
+                  "id" : "TEST:xref17b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "17",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "x"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00017",
+            "secondaryIds" : [
+               "TEST:TG00017"
+            ],
+            "synonyms" : [
+               "Test17",
+               "ExampleGene17"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Test gene invalid strand",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_17", 
+         "name" : "Test gene 17",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg17"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}

--- a/src/test/resources/gene/18_duplicate_primary_ids.json
+++ b/src/test/resources/gene/18_duplicate_primary_ids.json
@@ -1,0 +1,101 @@
+{
+   "data" : [
+      {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref18_1a"
+               },
+               {
+                  "id" : "TEST:xref18_1b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "18",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00018",
+            "secondaryIds" : [
+               "TEST:TG00018_1"
+            ],
+            "synonyms" : [
+               "Test18_1",
+               "ExampleGene18_1"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Duplicate primaryId - entry 1 of 2",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_18_1", 
+         "name" : "Test gene 18_1",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg18_1"
+      },
+       {
+         "basicGeneticEntity" : {
+            "crossReferences" : [
+               {
+                  "id" : "TEST:xref18_2a"
+               },
+               {
+                  "id" : "TEST:xref18_2b",
+                  "pages" : [
+                     "gene",
+                     "gene/references",
+                     "gene/expression",
+                     "gene/expression_images",
+                     "gene/phenotype"
+                  ]
+               },
+            ],
+            "genomeLocations" : [
+               {
+                  "assembly" : "TEST_assembly",
+                  "chromosome" : "18",
+                  "endPosition" : 100,
+                  "startPosition" : 1,
+                  "strand" : "+"
+               }
+            ],
+            "primaryId" : "TEST:TestGene00018",
+            "secondaryIds" : [
+               "TEST:TG00018_2"
+            ],
+            "synonyms" : [
+               "Test18_2",
+               "ExampleGene18_2"
+            ],
+            "taxonId" : "NCBITaxon:10090"
+         },
+         "geneSynopsis" : "Duplicate primaryId - entry 2 of 2",
+	 "geneSynopsisUrl" : "http://test.org/test_synopsis_18_2", 
+         "name" : "Test gene 18_2",
+         "soTermId" : "SO:0001217",
+         "symbol" : "Tg18_2"
+      }
+   ],
+   "metaData" : {
+      "dataProvider" : {
+         "crossReference" : {
+            "id" : "TEST",
+            "pages" : [
+               "homepage"
+            ]
+         },
+         "type" : "curated"
+      },
+      "dateProduced" : "2021-09-13T12:39:18+01:00",
+      "release" : "TEST"
+   }
+}


### PR DESCRIPTION
Pseudocode for possible tests using these files can be found here:
https://docs.google.com/spreadsheets/d/1nT_4Avis361ymRZXv-QRhNn1G9n1htdZTxqLgcL_ZCM/edit?usp=sharing

00_mod_examples.json contains 605 gene entries from MOD-submitted BGI
files, representing all currently submitted combinations of fields.
Files 01-17 contain single gene entries, with 01-12 missing a single
field, and 13-17 containing invalid entries (although we currently do
not carry out data validation).  File 18 contains 2 gene entries with
duplicate primaryId field values.