### PR TITLE
SCRUM-490 Add CRUD test files for disease_relation predicate

### DIFF
--- a/src/test/resources/crud/disease_annotation/10_invalid_gene_disease_relation.json
+++ b/src/test/resources/crud/disease_annotation/10_invalid_gene_disease_relation.json
@@ -1,0 +1,14 @@
+{
+    "subject": {
+        "curie": "SGD:S000002889"
+    },
+    "object" : {
+	"curie" : "DOID:3347"
+    },
+    "referenceList" : [
+	{
+	    "curie" : "PMID:25860149"
+	}
+    ],
+    "diseaseRelation" : "is_model_of"
+}

--- a/src/test/resources/crud/disease_annotation/11_invalid_allele_disease_relation.json
+++ b/src/test/resources/crud/disease_annotation/11_invalid_allele_disease_relation.json
@@ -1,0 +1,14 @@
+{
+    "subject" : {
+        "curie" : "FB:FBal0210563"
+    },
+    "object" : {
+	"curie" : "DOID:1059"
+    },
+    "referenceList" : [
+	{
+	    "curie" : "PMID:25125150"
+	}
+    ],
+    "diseaseRelation" : "is_model_of"
+}

--- a/src/test/resources/crud/disease_annotation/12_invalid_allele_disease_relation_2.json
+++ b/src/test/resources/crud/disease_annotation/12_invalid_allele_disease_relation_2.json
@@ -1,0 +1,14 @@
+{
+    "subject" : {
+        "curie" : "RGD:1290492"
+    },
+    "object" : {
+	"curie" : "DOID:2018"
+    },
+    "referenceList" : [
+	{
+	    "curie" : "PMID:22948215"
+	}
+    ],
+    "diseaseRelation" : "is_marker_for"
+}

--- a/src/test/resources/crud/disease_annotation/13_invalid_agm_disease_relation.json
+++ b/src/test/resources/crud/disease_annotation/13_invalid_agm_disease_relation.json
@@ -1,0 +1,14 @@
+{
+    "subject" : {
+        "curie" : "WB:WBGenotype00000028"
+    },
+    "object" : {
+	"curie" : "DOID:0080690"
+    },
+    "referenceList" : [
+	{
+	    "curie" : "PMID:24705357"
+	}
+    ],
+    "diseaseRelation" : "is_implicated_in"
+}

--- a/src/test/resources/crud/disease_annotation/14_invalid_agm_disease_relation_2.json
+++ b/src/test/resources/crud/disease_annotation/14_invalid_agm_disease_relation_2.json
@@ -1,0 +1,14 @@
+{
+    "subject" : {
+        "curie" : "ZFIN:ZDB-FISH-150901-1967"
+    },
+    "object" : {
+	"curie" : "DOID:10907"
+    },
+    "referenceList" : [
+	{
+	    "curie" : "PMID:23332918"
+	}
+    ],
+    "diseaseRelation" : "is_marker_for"
+}

--- a/src/test/resources/crud/disease_annotation/15_invalid_disease_relation.json
+++ b/src/test/resources/crud/disease_annotation/15_invalid_disease_relation.json
@@ -1,0 +1,14 @@
+{
+    "subject" : {
+        "curie" : "HGNC:483"
+    },
+    "object" : {
+	"curie" : "DOID:10283"
+    },
+    "referenceList" : [
+	{
+	    "curie" : "PMID:19276260"
+	}
+    ],
+    "diseaseRelation" : "is_not_a_valid_relation"
+}

--- a/src/test/resources/crud/disease_annotation/16_empty_disease_relation.json
+++ b/src/test/resources/crud/disease_annotation/16_empty_disease_relation.json
@@ -1,0 +1,14 @@
+{
+    "subject" : {
+        "curie" : "SGD:S000005324"
+    },
+    "object" : {
+	"curie" : "DOID:0070238"
+    },
+    "referenceList" : [
+	{
+	    "curie" : "PMID:21816947"
+	}
+    ],
+    "diseaseRelation" : ""
+}


### PR DESCRIPTION
Existing tests already cover valid disease_relation values.  Adding tests to cover various incorrect combinations of subject type and disease_relation, and incorrect or empty values.