### PR TITLE
SCRUM-491: delete disease annotation - integration test

### DIFF
--- a/src/test/java/org/alliancegenome/curation_api/crud/controllers/DiseaseAnnotationITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/crud/controllers/DiseaseAnnotationITCase.java
@@ -117,4 +117,14 @@ public class DiseaseAnnotationITCase {
             then().
             statusCode(200);
     }
+
+    @Test
+    @Order(3)
+    public void deleteDiseaseAnnotation() throws Exception {
+        RestAssured.given().
+            when().
+            delete("/api/disease-annotation/" + DISEASE_ANNOTATION).
+            then().
+            statusCode(200);
+    }
 }


### PR DESCRIPTION
Adding this test to restore the number of disease annotations in the DB to avoid interference with the bulk upload count checks.