### PR TITLE
SCRUM-897 GO ontology

### DIFF
--- a/src/main/cliapp/src/App.js
+++ b/src/main/cliapp/src/App.js
@@ -22,6 +22,7 @@ import { ApiVersionService } from './service/ApiVersionService';
 
 import { DiseaseOntologyComponent } from './components/ontologies/DiseaseOntologyComponent';
 import { ECOOntologyComponent } from './components/ontologies/ECOOntologyComponent';
+import { GOOntologyComponent } from './components/ontologies/GOOntologyComponent';
 import { MAOntologyComponent } from './components/ontologies/MAOntologyComponent';
 import { ZFAOntologyComponent } from './components/ontologies/ZFAOntologyComponent';
 import { MPOntologyComponent } from './components/ontologies/MPOntologyComponent';
@@ -131,6 +132,7 @@ const App = () => {
             items: [
                 { label: 'Disease Ontology (DO)', icon: 'pi pi-fw pi-home', to: '/ontology/do' },
                 { label: 'Evidence & Conclusion Ontology (ECO)', icon: 'pi pi-fw pi-home', to: '/ontology/eco' },
+                { label: 'Gene Ontology (GO)', icon: 'pi pi-fw pi-home', to: '/ontology/go' },
                 { label: 'Mouse adult gross anatomy Ontology (MA)', icon: 'pi pi-fw pi-home', to: '/ontology/ma' },
                 { label: 'The Mammalian Phenotype Ontology (MP)', icon: 'pi pi-fw pi-home', to: '/ontology/mp' },
                 { label: 'Drosophila Anatomy Ontology (DAO)', icon: 'pi pi-fw pi-home', to: '/ontology/dao' },
@@ -212,6 +214,7 @@ const App = () => {
                 <Route path="/vocabterms" component={ControlledVocabularyComponent} />
                 <Route path="/ontology/do" component={DiseaseOntologyComponent} />
                 <Route path="/ontology/eco" component={ECOOntologyComponent} />
+                <Route path="/ontology/go" component={GOOntologyComponent} />
                 <Route path="/ontology/ma" component={MAOntologyComponent} />
                 <Route path="/ontology/zfa" component={ZFAOntologyComponent} />
                 <Route path="/ontology/mp" component={MPOntologyComponent} />

--- a/src/main/cliapp/src/components/Dashboard.js
+++ b/src/main/cliapp/src/components/Dashboard.js
@@ -11,6 +11,7 @@ export const Dashboard = () => {
 
     const [ECOCount, setECOCount] = useState(0);
     const [DOCount, setDOCount] = useState(0);
+    const [GOCount, setGOCount] = useState(0);
     const [MACount, setMACount] = useState(0);
     const [ZFACount, setZFACount] = useState(0);
     const [MPCount, setMPCount] = useState(0);
@@ -48,6 +49,9 @@ export const Dashboard = () => {
 
         searchService.search('doterm', 0, 0).then(results => {
           setDOCount(results.totalResults);
+        });
+        searchService.search('goterm', 0, 0).then(results => {
+          setGOCount(results.totalResults);
         });
 
         searchService.search('materm', 0, 0).then(results => {
@@ -135,6 +139,16 @@ export const Dashboard = () => {
                         <i className="pi pi-question-circle"></i>
                         <span>Total Term Count</span>
                         <span className="count">{DOCount}</span>
+                    </div>
+                </div>
+            </div>
+            <div className="p-col-12 p-md-6 p-xl-3">
+                <div className="highlight-box">
+                    <div className="initials" style={{ backgroundColor: '#ef6262', color: '#a83d3b' }}><span>GO</span></div>
+                    <div className="highlight-details ">
+                        <i className="pi pi-question-circle"></i>
+                        <span>Total Term Count</span>
+                        <span className="count">{GOCount}</span>
                     </div>
                 </div>
             </div>

--- a/src/main/cliapp/src/components/ontologies/GOOntologyComponent.js
+++ b/src/main/cliapp/src/components/ontologies/GOOntologyComponent.js
@@ -1,0 +1,85 @@
+import React, {useRef, useState} from 'react';
+import { DataTable } from 'primereact/datatable';
+import { Column } from 'primereact/column';
+import { SearchService } from '../../service/SearchService';
+import { useQuery } from 'react-query';
+import { Messages } from "primereact/messages";
+import { FilterComponent } from '../FilterComponent'
+
+import { returnSorted } from '../../utils/utils';
+
+export const GOOntologyComponent = () => {
+
+  const [terms, setTerms] = useState(null);
+  const [multiSortMeta, setMultiSortMeta] = useState([]);
+  const [filters, setFilters] = useState({});
+  const [page, setPage] = useState(0);
+  const [first, setFirst] = useState(0);
+  const [rows, setRows] = useState(50);
+  const [totalRecords, setTotalRecords] = useState(0);
+  const [isEnabled, setIsEnabled] = useState(true);
+  const searchService = new SearchService();
+  const errorMessage = useRef(null);
+
+  useQuery(['terms', rows, page, multiSortMeta, filters],
+    () => searchService.search('goterm', rows, page, multiSortMeta, filters), {
+    onSuccess: (data) => {
+      setIsEnabled(true);
+      setTerms(data.results);
+      setTotalRecords(data.totalResults);
+    },
+      onError: (error) => {
+          errorMessage.current.show([
+              { severity: 'error', summary: 'Error', detail: error.message, sticky: true }
+          ])
+      },
+    keepPreviousData: true
+  });
+
+
+
+  const onLazyLoad = (event) => {
+    setRows(event.rows);
+    setPage(event.page);
+    setFirst(event.first);
+  }
+
+  const onFilter = (filtersCopy) => { 
+      setFilters({...filtersCopy});
+  };
+
+  const onSort = (event) => {
+      setMultiSortMeta(
+          returnSorted(event, multiSortMeta)
+      )
+  };
+
+  const filterComponentTemplate = (filterName, fields) => {
+    return (<FilterComponent 
+          isEnabled={isEnabled} 
+          fields={fields} 
+          filterName={filterName}
+          currentFilters={filters}
+          onFilter={onFilter}
+      />);
+  };
+
+  return (
+      <div>
+        <div className="card">
+            <h3>GO Table</h3>
+            <Messages ref={errorMessage}/>
+          <DataTable value={terms} className="p-datatable-sm"
+            sortMode="multiple" removableSort onSort={onSort} multiSortMeta={multiSortMeta}
+            paginator totalRecords={totalRecords} onPage={onLazyLoad} lazy first={first}
+            paginatorTemplate="CurrentPageReport FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown"
+            currentPageReportTemplate="Showing {first} to {last} of {totalRecords}" rows={rows} rowsPerPageOptions={[10,20,50,100,250,1000]}
+          >
+            <Column field="curie" header="Curie" sortable={isEnabled} filter filterElement={filterComponentTemplate("curieFilter", ["curie"])} />
+            <Column field="name" header="Name" sortable={isEnabled} filter filterElement={filterComponentTemplate("nameFilter", ["name"])} />
+            <Column field="definition" header="Definition" sortable={isEnabled} filter filterElement={filterComponentTemplate("definitionFilter", ["definition"])} />
+          </DataTable>
+        </div>
+      </div>
+  )
+}

--- a/src/main/java/org/alliancegenome/curation_api/controllers/bulk/ontology/EmapaTermBulkController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/bulk/ontology/EmapaTermBulkController.java
@@ -20,7 +20,7 @@ public class EmapaTermBulkController extends BaseOntologyTermBulkController<Emap
     @PostConstruct
     public void init() {
         GenericOntologyLoadConfig config = new GenericOntologyLoadConfig();
-        config.setAltNameSpace("anatomical_structure");
+        config.getAltNameSpaces().add("anatomical_structure");
         setService(emapaTermService, EMAPATerm.class, config);
     }
 

--- a/src/main/java/org/alliancegenome/curation_api/controllers/bulk/ontology/GoTermBulkController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/bulk/ontology/GoTermBulkController.java
@@ -1,0 +1,29 @@
+package org.alliancegenome.curation_api.controllers.bulk.ontology;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.alliancegenome.curation_api.base.BaseOntologyTermBulkController;
+import org.alliancegenome.curation_api.dao.ontology.GoTermDAO;
+import org.alliancegenome.curation_api.interfaces.bulk.ontology.GoTermBulkRESTInterface;
+import org.alliancegenome.curation_api.model.entities.ontology.GOTerm;
+import org.alliancegenome.curation_api.services.helpers.GenericOntologyLoadConfig;
+import org.alliancegenome.curation_api.services.ontology.GoTermService;
+
+@RequestScoped
+public class GoTermBulkController extends BaseOntologyTermBulkController<GoTermService, GOTerm, GoTermDAO> implements GoTermBulkRESTInterface {
+
+    @Inject GoTermService goTermService;
+
+    @Override
+    @PostConstruct
+    public void init() {
+        GenericOntologyLoadConfig config = new GenericOntologyLoadConfig();
+        config.getAltNameSpaces().add("biological_process");
+        config.getAltNameSpaces().add("molecular_function");
+        config.getAltNameSpaces().add("cellular_component");
+        setService(goTermService, GOTerm.class, config);
+    }
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/controllers/crud/ontology/GoTermController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/crud/ontology/GoTermController.java
@@ -1,0 +1,24 @@
+package org.alliancegenome.curation_api.controllers.crud.ontology;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.alliancegenome.curation_api.base.BaseOntologyTermController;
+import org.alliancegenome.curation_api.dao.ontology.GoTermDAO;
+import org.alliancegenome.curation_api.interfaces.crud.ontology.GoTermRESTInterface;
+import org.alliancegenome.curation_api.model.entities.ontology.GOTerm;
+import org.alliancegenome.curation_api.services.ontology.GoTermService;
+
+@RequestScoped
+public class GoTermController extends BaseOntologyTermController<GoTermService, GOTerm, GoTermDAO> implements GoTermRESTInterface {
+
+    @Inject GoTermService goTermService;
+
+    @Override
+    @PostConstruct
+    protected void init() {
+        setService(goTermService);
+    }
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/dao/ontology/GoTermDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ontology/GoTermDAO.java
@@ -1,0 +1,15 @@
+package org.alliancegenome.curation_api.dao.ontology;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.alliancegenome.curation_api.base.BaseSQLDAO;
+import org.alliancegenome.curation_api.model.entities.ontology.GOTerm;
+
+@ApplicationScoped
+public class GoTermDAO extends BaseSQLDAO<GOTerm> {
+
+    protected GoTermDAO() {
+        super(GOTerm.class);
+    }
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/bulk/ontology/GoTermBulkRESTInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/bulk/ontology/GoTermBulkRESTInterface.java
@@ -1,0 +1,16 @@
+package org.alliancegenome.curation_api.interfaces.bulk.ontology;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+
+import org.alliancegenome.curation_api.base.BaseOntologyTermBulkRESTInterface;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/goterm/bulk")
+@Tag(name = "Ontology - GO")
+@Tag(name = "Ontology - Bulk Import")
+@Produces(MediaType.APPLICATION_JSON)
+public interface GoTermBulkRESTInterface extends BaseOntologyTermBulkRESTInterface {
+
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ontology/GoTermRESTInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ontology/GoTermRESTInterface.java
@@ -1,0 +1,16 @@
+package org.alliancegenome.curation_api.interfaces.crud.ontology;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+
+import org.alliancegenome.curation_api.base.BaseCrudRESTInterface;
+import org.alliancegenome.curation_api.model.entities.ontology.GOTerm;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/goterm")
+@Tag(name = "Ontology - GO")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface GoTermRESTInterface extends BaseCrudRESTInterface<GOTerm> {
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/GOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/GOTerm.java
@@ -1,0 +1,18 @@
+package org.alliancegenome.curation_api.model.entities.ontology;
+
+import javax.persistence.Entity;
+
+import org.hibernate.envers.Audited;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+import lombok.*;
+
+@Audited
+@Indexed
+@Entity
+@Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
+@ToString(callSuper = true)
+public class GOTerm extends OntologyTerm {
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadConfig.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadConfig.java
@@ -1,5 +1,6 @@
 package org.alliancegenome.curation_api.services.helpers;
 
+import java.util.ArrayList;
 import lombok.Data;
 
 @Data
@@ -9,6 +10,6 @@ public class GenericOntologyLoadConfig {
     // Only change them in the bulk controller
     // that is going to make use of the GenericOntologyLoader
     private boolean loadWithoutDefaultNameSpace = false;
-    private String altNameSpace = null;
+    private ArrayList<String> altNameSpaces = new ArrayList<String>();
     
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadHelper.java
@@ -91,13 +91,15 @@ public class GenericOntologyLoadHelper<T extends OntologyTerm> implements OWLObj
 
             termParent = getOntologyTerm(parent);
 
-            String requiredNamespace = config.getAltNameSpace();
-            if (requiredNamespace == null) {
-                requiredNamespace = defaultNamespace;
+            ArrayList<String> requiredNamespaces = config.getAltNameSpaces();
+            if (requiredNamespaces.isEmpty()) {
+                if (defaultNamespace != null) {
+                    requiredNamespaces.add(defaultNamespace);
+                }
             }
             
             if(
-                (termParent.getNamespace() != null && requiredNamespace != null && termParent.getNamespace().equals(requiredNamespace)) ||
+                (termParent.getNamespace() != null && !requiredNamespaces.isEmpty() && requiredNamespaces.contains(termParent.getNamespace())) ||
                 config.isLoadWithoutDefaultNameSpace()
             ) {
                 //System.out.println(termParent);

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadHelper.java
@@ -101,7 +101,7 @@ public class GenericOntologyLoadHelper<T extends OntologyTerm> implements OWLObj
             
             
             if(
-                (termParent.getNamespace() != null && !requiredNamespaces.isEmpty() && requiredNamespaces.contains(termParent.getNamespace())) ||
+                (termParent.getNamespace() != null && requiredNamespaces.contains(termParent.getNamespace())) ||
                 config.isLoadWithoutDefaultNameSpace()
             ) {
                 //System.out.println(termParent);

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadHelper.java
@@ -65,6 +65,13 @@ public class GenericOntologyLoadHelper<T extends OntologyTerm> implements OWLObj
             }
         });
 
+        ArrayList<String> requiredNamespaces = config.getAltNameSpaces();
+        if (requiredNamespaces.isEmpty()) {
+            if (defaultNamespace != null) {
+                requiredNamespaces.add(defaultNamespace);
+            }
+        }
+        
         OWLClass root = manager.getOWLDataFactory().getOWLThing();
 
         log.info("Ontology Loaded...");
@@ -76,14 +83,14 @@ public class GenericOntologyLoadHelper<T extends OntologyTerm> implements OWLObj
         reasoner = reasonerFactory.createReasoner(ontology);
 
         log.info("Traversing Ontology");
-        T rootTerm = traverse(root, 0);
+        T rootTerm = traverse(root, 0, requiredNamespaces);
         log.info("Finished Traversing Ontology");
         
         return allNodes;
 
     }
 
-    public T traverse(OWLClass parent, int depth) throws Exception {
+    public T traverse(OWLClass parent, int depth, ArrayList<String> requiredNamespaces) throws Exception {
 
         T termParent = null;
 
@@ -91,12 +98,7 @@ public class GenericOntologyLoadHelper<T extends OntologyTerm> implements OWLObj
 
             termParent = getOntologyTerm(parent);
 
-            ArrayList<String> requiredNamespaces = config.getAltNameSpaces();
-            if (requiredNamespaces.isEmpty()) {
-                if (defaultNamespace != null) {
-                    requiredNamespaces.add(defaultNamespace);
-                }
-            }
+            
             
             if(
                 (termParent.getNamespace() != null && !requiredNamespaces.isEmpty() && requiredNamespaces.contains(termParent.getNamespace())) ||
@@ -117,7 +119,7 @@ public class GenericOntologyLoadHelper<T extends OntologyTerm> implements OWLObj
 
                 if (!child.equals(parent)) {
                     try {
-                        T childTerm = traverse(child, depth + 1);
+                        T childTerm = traverse(child, depth + 1, requiredNamespaces);
                             
 //                          TODO LinkML to define the following fields                          
 //                          if(childTerm != null) {

--- a/src/main/java/org/alliancegenome/curation_api/services/ontology/GoTermService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ontology/GoTermService.java
@@ -1,0 +1,22 @@
+package org.alliancegenome.curation_api.services.ontology;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.alliancegenome.curation_api.base.BaseOntologyTermService;
+import org.alliancegenome.curation_api.dao.ontology.GoTermDAO;
+import org.alliancegenome.curation_api.model.entities.ontology.GOTerm;
+
+@RequestScoped
+public class GoTermService extends BaseOntologyTermService<GOTerm, GoTermDAO> {
+
+    @Inject GoTermDAO goTermDAO;
+
+    @Override
+    @PostConstruct
+    protected void init() {
+        setSQLDao(goTermDAO);
+    }
+    
+}


### PR DESCRIPTION
This includes code to allow multiple namespaces to be specified in the config and loaded in a single load into a single table.  I think this is what we want to do for GO (at least for now), but if not I can retract this PR and push just the code for multiple namespaces (I think this will be useful for other ontologies).