### PR TITLE
SCRUM-881 edit evidence codes

### DIFF
--- a/src/main/cliapp/src/components/EvidenceEditor.js
+++ b/src/main/cliapp/src/components/EvidenceEditor.js
@@ -1,0 +1,52 @@
+import React, {useState} from 'react';
+import {AutoComplete} from "primereact/autocomplete";
+
+   export const EvidenceEditor = ({ rowProps, searchService, setDiseaseAnnotations, autocompleteFields }) => { 
+        const [filteredEvidenceCodes, setFilteredEvidenceCodes] = useState([]);
+
+        const searchEvidenceCodes = (event) => {
+            console.log(event);
+            let evidenceFilter = {};
+            autocompleteFields.forEach( field => {
+                evidenceFilter[field] = event.query;
+            });
+
+            searchService.search("ecoterm", 15, 0, null, {"evidenceFilter":evidenceFilter})
+                .then((data) => {
+                    console.log(data);
+                    if (data.results) {
+                        setFilteredEvidenceCodes(data.results.filter((ecoterm) => Boolean(!ecoterm.obsolete)));
+                    }
+                    else {
+                        setFilteredEvidenceCodes([]);
+                    }
+                });
+        };
+
+        const onEvidenceEditorValueChange = (event) => {//this should propably be generalized so that all of these editor value changes can use the same method
+            let updatedAnnotations = [...rowProps.value];
+            if(event.value) {
+                updatedAnnotations[rowProps.rowIndex].evidenceCodes = event.value;
+            }
+            setDiseaseAnnotations(updatedAnnotations);
+        };
+
+        const evidenceItemTemplate = (item) => {
+            return <div>{item.curie} ({item.name})</div>
+        };
+
+
+        return (
+            
+            <AutoComplete
+                multiple
+                value={rowProps.rowData.evidenceCodes}
+                field="curie"
+                suggestions={filteredEvidenceCodes}
+                itemTemplate={evidenceItemTemplate}
+                completeMethod={searchEvidenceCodes}
+                onChange={(e) => onEvidenceEditorValueChange(e)}
+            />
+           
+        )
+    };

--- a/src/main/cliapp/src/components/datatables/DiseaseAnnotationsComponent.js
+++ b/src/main/cliapp/src/components/datatables/DiseaseAnnotationsComponent.js
@@ -9,6 +9,7 @@ import { returnSorted } from '../../utils/utils';
 import { SubjectEditor } from './../SubjectEditor';
 import { DiseaseEditor } from './../DiseaseEditor';
 import { WithEditor } from './../WithEditor';
+import { EvidenceEditor } from './../EvidenceEditor';
 import { FilterComponent } from './../FilterComponent'
 import { SearchService } from '../../service/SearchService';
 
@@ -340,6 +341,23 @@ export const DiseaseAnnotationsComponent = () => {
         );
     };
 
+    const evidenceEditorTemplate = (props) => {
+        return (
+            <>
+                <EvidenceEditor
+                    autocompleteFields={["curie", "name"]}
+                    rowProps={props}
+                    searchService={searchService}
+                    setDiseaseAnnotations={setDiseaseAnnotations}
+                />
+                <ErrorMessageComponent
+                    errorMessages={errorMessages[props.rowIndex]}
+                    errorField="evidence"
+                />
+            </>
+        );
+    };
+
     return (
         <div>
             <div className="card">
@@ -414,6 +432,7 @@ export const DiseaseAnnotationsComponent = () => {
                     body={evidenceTemplate}
                     sortable={isEnabled} 
                     filter filterElement={filterComponentTemplate("evidenceCodes", ["evidenceCodes.curie"])}
+                    editor={(props) => evidenceEditorTemplate(props)}
                   />
 
                    <Column 

--- a/src/main/java/org/alliancegenome/curation_api/services/DiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/DiseaseAnnotationService.java
@@ -256,7 +256,7 @@ public class DiseaseAnnotationService extends BaseService<DiseaseAnnotation, Dis
         if (CollectionUtils.isNotEmpty(entity.getEvidenceCodes())) {
             for (EcoTerm evidenceCode : entity.getEvidenceCodes()) {
                 if (evidenceCode.getObsolete() && !originalEvidenceCodes.contains(evidenceCode)) {
-                    addInvalidMessagetoResponse("evidence", response);
+                    addObsoleteMessagetoResponse("evidence", response);
                     validEvidenceCodes = false;
                     break;
                 }
@@ -336,6 +336,10 @@ public class DiseaseAnnotationService extends BaseService<DiseaseAnnotation, Dis
 
     private void addInvalidMessagetoResponse(String fieldName, ObjectResponse<DiseaseAnnotation> response) {
         response.addErrorMessage(fieldName, "Not a valid entry");
+    }
+    
+    private void addObsoleteMessagetoResponse(String fieldName, ObjectResponse<DiseaseAnnotation> response) {
+        response.addErrorMessage(fieldName, "Obsolete term specified");
     }
 
     private boolean validateAnnotationDTO(DiseaseModelAnnotationDTO dto) {

--- a/src/main/java/org/alliancegenome/curation_api/services/DiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/DiseaseAnnotationService.java
@@ -262,6 +262,10 @@ public class DiseaseAnnotationService extends BaseService<DiseaseAnnotation, Dis
                 }
             }
         }
+        else {
+            addRequiredMessageToResponse("evidence", response);
+            validEvidenceCodes = false;
+        }
         return validEvidenceCodes;
     }
     


### PR DESCRIPTION
Existing obsolete evidence codes can be kept in an annotation being updated, but annotations cannot be updated or created with obsolete evidence codes that were not pre-existing in the annotation.  Bulk upload unaffected (i.e. entries can be created with obsolete evidence codes).  Auto-suggest limited to non-obsolete terms.