### PR TITLE
SCRUM-887 IRI prefix filter

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/controllers/bulk/ontology/DaoTermBulkController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/bulk/ontology/DaoTermBulkController.java
@@ -21,8 +21,7 @@ public class DaoTermBulkController extends BaseOntologyTermBulkController<DaoTer
     @PostConstruct
     public void init() {
         GenericOntologyLoadConfig config = new GenericOntologyLoadConfig();
-        config.setIriPrefixFilter("FBbt");
-        config.setLoadWithoutDefaultNameSpace(true);
+        config.setLoadOnlyIRIPrefix("FBbt");
         setService(daoTermService, DAOTerm.class, config);
     }
 

--- a/src/main/java/org/alliancegenome/curation_api/controllers/bulk/ontology/DaoTermBulkController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/bulk/ontology/DaoTermBulkController.java
@@ -8,6 +8,7 @@ import org.alliancegenome.curation_api.base.BaseOntologyTermBulkController;
 import org.alliancegenome.curation_api.dao.ontology.DaoTermDAO;
 import org.alliancegenome.curation_api.interfaces.bulk.ontology.DaoTermBulkRESTInterface;
 import org.alliancegenome.curation_api.model.entities.ontology.DAOTerm;
+import org.alliancegenome.curation_api.model.entities.ontology.EMAPATerm;
 import org.alliancegenome.curation_api.services.helpers.GenericOntologyLoadConfig;
 import org.alliancegenome.curation_api.services.ontology.DaoTermService;
 
@@ -19,7 +20,10 @@ public class DaoTermBulkController extends BaseOntologyTermBulkController<DaoTer
     @Override
     @PostConstruct
     public void init() {
-        setService(daoTermService, DAOTerm.class);
+        GenericOntologyLoadConfig config = new GenericOntologyLoadConfig();
+        config.setIriPrefixFilter("FBbt");
+        config.setLoadWithoutDefaultNameSpace(true);
+        setService(daoTermService, DAOTerm.class, config);
     }
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/controllers/bulk/ontology/ZecoTermBulkController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/bulk/ontology/ZecoTermBulkController.java
@@ -23,7 +23,7 @@ public class ZecoTermBulkController extends BaseOntologyTermBulkController<ZecoT
     @PostConstruct
     public void init() {
         GenericOntologyLoadConfig config = new GenericOntologyLoadConfig();
-        config.setLoadWithoutDefaultNameSpace(true);
+        config.setLoadOnlyIRIPrefix("ZECO");
         setService(zecoTermService, ZecoTerm.class, config);
     }
 

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadConfig.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadConfig.java
@@ -9,8 +9,8 @@ public class GenericOntologyLoadConfig {
     // These values should not be changed here
     // Only change them in the bulk controller
     // that is going to make use of the GenericOntologyLoader
-    private boolean loadWithoutDefaultNameSpace = false;
-    private String iriPrefixFilter = null;
     private ArrayList<String> altNameSpaces = new ArrayList<String>();
     
+    // must be set and will only load that Prefix of terms
+    private String loadOnlyIRIPrefix = null;
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadConfig.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadConfig.java
@@ -10,6 +10,7 @@ public class GenericOntologyLoadConfig {
     // Only change them in the bulk controller
     // that is going to make use of the GenericOntologyLoader
     private boolean loadWithoutDefaultNameSpace = false;
+    private String iriPrefixFilter = null;
     private ArrayList<String> altNameSpaces = new ArrayList<String>();
     
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadHelper.java
@@ -97,12 +97,11 @@ public class GenericOntologyLoadHelper<T extends OntologyTerm> implements OWLObj
         if (reasoner.isSatisfiable(parent)) {
 
             termParent = getOntologyTerm(parent);
-
-            
-            
+    
             if(
-                (termParent.getNamespace() != null && requiredNamespaces.contains(termParent.getNamespace())) ||
-                config.isLoadWithoutDefaultNameSpace()
+                ((termParent.getNamespace() != null && requiredNamespaces.contains(termParent.getNamespace())) ||
+                config.isLoadWithoutDefaultNameSpace()) &&
+                ((config.getIriPrefixFilter() == null) || parent.getIRI().getShortForm().startsWith(config.getIriPrefixFilter()))
             ) {
                 //System.out.println(termParent);
 

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadHelper.java
@@ -99,9 +99,8 @@ public class GenericOntologyLoadHelper<T extends OntologyTerm> implements OWLObj
             termParent = getOntologyTerm(parent);
     
             if(
-                ((termParent.getNamespace() != null && requiredNamespaces.contains(termParent.getNamespace())) ||
-                config.isLoadWithoutDefaultNameSpace()) &&
-                ((config.getIriPrefixFilter() == null) || parent.getIRI().getShortForm().startsWith(config.getIriPrefixFilter()))
+                (termParent.getNamespace() != null && requiredNamespaces.contains(termParent.getNamespace())) ||
+                (parent.getIRI().getShortForm().startsWith(config.getLoadOnlyIRIPrefix()))
             ) {
                 //System.out.println(termParent);
 


### PR DESCRIPTION
Allows IRI-prefix to be specified in ontology config, which can be used in combination with other config parameters for filtering.  Applied to the DAO/FBbt ontology to load nodes without a namespace attribute, but only those with the IRI prefix 'FBbt'.