### PR TITLE
Fixes error where getLoadOnlyIRIPrefix is null

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadHelper.java
@@ -100,7 +100,7 @@ public class GenericOntologyLoadHelper<T extends OntologyTerm> implements OWLObj
     
             if(
                 (termParent.getNamespace() != null && requiredNamespaces.contains(termParent.getNamespace())) ||
-                (parent.getIRI().getShortForm().startsWith(config.getLoadOnlyIRIPrefix()))
+                (config.getLoadOnlyIRIPrefix() != null && parent.getIRI().getShortForm().startsWith(config.getLoadOnlyIRIPrefix()))
             ) {
                 //System.out.println(termParent);
 


### PR DESCRIPTION
Was getting the following error:
java.lang.NullPointerException: Cannot invoke "String.length()"
because "prefix" is null