### PR TITLE
SCRUM-953: Breaking change increasing name for Ontology Term

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
@@ -28,6 +28,7 @@ public class OntologyTerm extends BaseCurieEntity {
     @FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
     @KeywordField(name = "name_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
     @JsonView(View.FieldsOnly.class)
+    @Column(length = 2000)
     private String name;
 
     @FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")


### PR DESCRIPTION
There are 8364 names in CheBI larger than 255 chars.
The largest name has 1741 chars
This pr implies to drop and reload the ontology term related tables

Tested by:

- Loading zeco ontology without errors
- Checking table definition:

  Table "public.ontologyterm"
   Column    |            Type             | Collation | Nullable | Default | Storage  | Stats target | Description 
-------------+-----------------------------+-----------+----------+---------+----------+--------------+-------------
 curie       | character varying(255)      |           | not null |         | extended |              | 
 created     | timestamp without time zone |           |          |         | plain    |              | 
 lastupdated | timestamp without time zone |           |          |         | plain    |              | 
 definition  | text                        |           |          |         | extended |              | 
 name        | character varying(2000)     |           |          |         | extended |              | 
`

