### PR TITLE
SCRUM-879 evidence code abbreviations

### DIFF
--- a/src/main/cliapp/src/components/EvidenceEditor.js
+++ b/src/main/cliapp/src/components/EvidenceEditor.js
@@ -11,8 +11,9 @@ import {AutoComplete} from "primereact/autocomplete";
                 evidenceFilter[field] = event.query;
             });
             let obsoleteFilter = {"obsolete": false};
+            let subsetFilter = {"subsets": "agr_eco_terms"};
 
-            searchService.search("ecoterm", 15, 0, null, {"evidenceFilter":evidenceFilter, "obsoleteFilter:":obsoleteFilter})
+            searchService.search("ecoterm", 15, 0, null, {"evidenceFilter":evidenceFilter, "obsoleteFilter:":obsoleteFilter, "subsetFilter":subsetFilter})
                 .then((data) => {
                     //console.log(data)
                     setFilteredEvidenceCodes(data.results);
@@ -28,7 +29,7 @@ import {AutoComplete} from "primereact/autocomplete";
         };
 
         const evidenceItemTemplate = (item) => {
-            return <div>{item.curie} ({item.name})</div>
+            return <div>{item.abbreviation} - {item.name} ({item.curie})</div>
         };
 
 

--- a/src/main/cliapp/src/components/datatables/DiseaseAnnotationsComponent.js
+++ b/src/main/cliapp/src/components/datatables/DiseaseAnnotationsComponent.js
@@ -117,7 +117,7 @@ export const DiseaseAnnotationsComponent = () => {
             return (<div>
                 <ul style={{listStyleType : 'none'}}>
                     {rowData.evidenceCodes.map((a,index) =>
-                        <li key={index}>{a.curie}</li>
+                        <li key={index}>{a.abbreviation + ' - ' + a.name + ' (' + a.curie + ')'}</li>
                     )}
                 </ul>
             </div>);
@@ -345,7 +345,7 @@ export const DiseaseAnnotationsComponent = () => {
         return (
             <>
                 <EvidenceEditor
-                    autocompleteFields={["curie", "name"]}
+                    autocompleteFields={["curie", "name", "abbreviation"]}
                     rowProps={props}
                     searchService={searchService}
                     setDiseaseAnnotations={setDiseaseAnnotations}
@@ -431,7 +431,7 @@ export const DiseaseAnnotationsComponent = () => {
                     header="Evidence Code"
                     body={evidenceTemplate}
                     sortable={isEnabled} 
-                    filter filterElement={filterComponentTemplate("evidenceCodes", ["evidenceCodes.curie"])}
+                    filter filterElement={filterComponentTemplate("evidenceCodes", ["evidenceCodes.curie", "evidenceCodes.name", "evidenceCodes.abbreviation"])}
                     editor={(props) => evidenceEditorTemplate(props)}
                   />
 

--- a/src/main/java/org/alliancegenome/curation_api/base/BaseOntologyTermBulkController.java
+++ b/src/main/java/org/alliancegenome/curation_api/base/BaseOntologyTermBulkController.java
@@ -19,19 +19,19 @@ import lombok.extern.jbosslog.JBossLog;
 @JBossLog
 public abstract class BaseOntologyTermBulkController<S extends BaseOntologyTermService<T, D>, T extends OntologyTerm, D extends BaseDAO<T>> implements Runnable {
 
-    private GenericOntologyLoadHelper<T> loader;
+    protected GenericOntologyLoadHelper<T> loader;
 
     private BaseOntologyTermService<T, D> service;
-    private Class<T> termClazz;
+    protected Class<T> termClazz;
 
     @Inject ConnectionFactory connectionFactory1;
     @Inject ConnectionFactory connectionFactory2;
 
-    private JMSProducer producer;
-    private JMSContext context;
+    protected JMSProducer producer;
+    protected JMSContext context;
 
     private int threadCount = 1;
-    private String queueName;
+    protected String queueName;
 
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(threadCount);
     

--- a/src/main/java/org/alliancegenome/curation_api/base/BaseOntologyTermService.java
+++ b/src/main/java/org/alliancegenome/curation_api/base/BaseOntologyTermService.java
@@ -41,7 +41,7 @@ public abstract class BaseOntologyTermService<E extends OntologyTerm, D extends 
     
     
     
-    private void handleDefinitionUrls(OntologyTerm dbTerm, OntologyTerm incomingTerm) {
+    protected void handleDefinitionUrls(OntologyTerm dbTerm, OntologyTerm incomingTerm) {
         Set<String> currentDefinitionUrls;
         if(dbTerm.getDefinitionUrls() == null) {
             currentDefinitionUrls = new HashSet<>();
@@ -74,7 +74,7 @@ public abstract class BaseOntologyTermService<E extends OntologyTerm, D extends 
     
     
     
-    private void handleSubsets(OntologyTerm dbTerm, OntologyTerm incomingTerm) {
+    protected void handleSubsets(OntologyTerm dbTerm, OntologyTerm incomingTerm) {
         Set<String> currentSubsets;
         if(dbTerm.getSubsets() == null) {
             currentSubsets = new HashSet<>();
@@ -104,7 +104,7 @@ public abstract class BaseOntologyTermService<E extends OntologyTerm, D extends 
 
     }
     
-    private void handleSynonyms(OntologyTerm dbTerm, OntologyTerm incomingTerm) {
+    protected void handleSynonyms(OntologyTerm dbTerm, OntologyTerm incomingTerm) {
         Set<String> currentSynonyms;
         if(dbTerm.getSynonyms() == null) {
             currentSynonyms = new HashSet<>();
@@ -135,7 +135,7 @@ public abstract class BaseOntologyTermService<E extends OntologyTerm, D extends 
     }
     
     
-    private void handleSecondaryIds(OntologyTerm dbTerm, OntologyTerm incomingTerm) {
+    protected void handleSecondaryIds(OntologyTerm dbTerm, OntologyTerm incomingTerm) {
         Set<String> currentIds;
         if(dbTerm.getSecondaryIdentifiers() == null) {
             currentIds = new HashSet<>();

--- a/src/main/java/org/alliancegenome/curation_api/controllers/bulk/ontology/EcoTermBulkController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/bulk/ontology/EcoTermBulkController.java
@@ -1,22 +1,33 @@
 package org.alliancegenome.curation_api.controllers.bulk.ontology;
 
+import java.util.Map;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
+import javax.jms.ConnectionFactory;
+import javax.jms.DeliveryMode;
+import javax.jms.Session;
+import javax.transaction.Transactional;
 
 import org.alliancegenome.curation_api.base.BaseOntologyTermBulkController;
 import org.alliancegenome.curation_api.dao.ontology.EcoTermDAO;
 import org.alliancegenome.curation_api.interfaces.bulk.ontology.EcoTermBulkRESTInterface;
 import org.alliancegenome.curation_api.model.entities.ontology.EcoTerm;
+import org.alliancegenome.curation_api.services.helpers.EcoTermLoadHelper;
 import org.alliancegenome.curation_api.services.ontology.EcoTermService;
+import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
 
 import lombok.extern.jbosslog.JBossLog;
 
 @JBossLog
 @RequestScoped
 public class EcoTermBulkController extends BaseOntologyTermBulkController<EcoTermService, EcoTerm, EcoTermDAO> implements EcoTermBulkRESTInterface {
-
+    
     @Inject EcoTermService ecoTermService;
+    @Inject EcoTermDAO ecoTermDAO;
+    @Inject ConnectionFactory connectionFactory;
+    
 
     @Override
     @PostConstruct
@@ -24,4 +35,37 @@ public class EcoTermBulkController extends BaseOntologyTermBulkController<EcoTer
         setService(ecoTermService, EcoTerm.class);
     }
 
+    @Override
+    public String updateTerms(String fullText) {
+
+        context = connectionFactory.createContext(Session.AUTO_ACKNOWLEDGE);
+        producer = context.createProducer().setDeliveryMode(DeliveryMode.NON_PERSISTENT); // In memory only will loose all messages if the broker restarts
+
+        log.info(context);
+        log.info(producer);
+        
+        EcoTermLoadHelper ecoTermHelper = new EcoTermLoadHelper();
+        
+        try {
+            Map<String, EcoTerm> termMap = loader.load(fullText);
+            termMap = ecoTermHelper.addAbbreviations(termMap);      
+            ProcessDisplayHelper ph = new ProcessDisplayHelper(10000);
+            ph.startProcess(termClazz.getSimpleName() + " Database Persistance", termMap.size());
+            for(String termKey: termMap.keySet()) {
+                //service.processUpdate(termMap.get(termKey));
+                producer.send(context.createQueue(queueName), context.createObjectMessage(termMap.get(termKey)));
+
+                ph.progressProcess();
+            }
+            ph.finishProcess();
+        } catch (Exception e) {
+            e.printStackTrace();
+            context.close();
+            return "FAIL";
+        }
+        
+        context.close();
+
+        return "OK";
+    }
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/EcoTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/EcoTerm.java
@@ -4,7 +4,6 @@ import javax.persistence.Entity;
 
 import org.alliancegenome.curation_api.view.View;
 import org.hibernate.envers.Audited;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 
 import lombok.*;
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/EcoTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/EcoTerm.java
@@ -20,7 +20,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.*;
 @ToString(callSuper = true)
 public class EcoTerm extends OntologyTerm {
     
-    @FullTextField(analyzer = "autocompelteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
+    @FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
     @KeywordField(name = "abbreviation_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
     @JsonView(View.FieldsOnly.class)
     private String abbreviation;

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/EcoTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/EcoTerm.java
@@ -2,10 +2,15 @@ package org.alliancegenome.curation_api.model.entities.ontology;
 
 import javax.persistence.Entity;
 
+import org.alliancegenome.curation_api.view.View;
 import org.hibernate.envers.Audited;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 
 import lombok.*;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import org.hibernate.search.engine.backend.types.*;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.*;
 
 @Audited
 @Indexed
@@ -14,5 +19,10 @@ import lombok.*;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 public class EcoTerm extends OntologyTerm {
-
+    
+    @FullTextField(analyzer = "autocompelteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
+    @KeywordField(name = "abbreviation_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
+    @JsonView(View.FieldsOnly.class)
+    private String abbreviation;
+    
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/EcoTermLoadHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/EcoTermLoadHelper.java
@@ -1,0 +1,57 @@
+package org.alliancegenome.curation_api.services.helpers;
+
+import java.util.*;
+
+import org.alliancegenome.curation_api.dao.ontology.EcoTermDAO;
+import org.alliancegenome.curation_api.model.entities.ontology.EcoTerm;
+
+import lombok.extern.jbosslog.JBossLog;
+
+import javax.transaction.Transactional;
+
+@JBossLog
+public class EcoTermLoadHelper {
+
+    private static String agr_subset = "agr_eco_terms";
+    
+    private static Map<String, String> abbreviationMap;
+    static
+    {
+        abbreviationMap = new HashMap<>();
+        abbreviationMap.put("ECO:0000270", "IEP");
+        abbreviationMap.put("ECO:0000316", "IGI");
+        abbreviationMap.put("ECO:0007014", "CEC");
+        abbreviationMap.put("ECO:0000315", "IMP");
+        abbreviationMap.put("ECO:0007013", "CEA");
+        abbreviationMap.put("ECO:0000501", "IEA");
+        abbreviationMap.put("ECO:0000021", "IPI");
+        abbreviationMap.put("ECO:0000304", "TAS");
+        abbreviationMap.put("ECO:0000314", "IDA");
+        abbreviationMap.put("ECO:0007191", "IAGP");
+        abbreviationMap.put("ECO:0000250", "ISS");
+        abbreviationMap.put("ECO:0000033", "TAS");
+        abbreviationMap.put("ECO:0000247", "ISA");
+        abbreviationMap.put("ECO:0000305", "IC");
+    }
+    
+    public Map<String, EcoTerm> addAbbreviations(Map<String, EcoTerm> termMap) {
+        abbreviationMap.forEach((curie, abbreviation) ->
+            {
+                EcoTerm term = termMap.get(curie);
+                if (term == null) {
+                    log.info("Could not retrieve " + curie + " to set abbreviation");
+                    return;
+                }
+                term.setAbbreviation(abbreviation);
+                List<String> subsets = term.getSubsets();
+                if (subsets == null) {
+                    subsets = new ArrayList<String>();
+                }
+                subsets.add(agr_subset);
+                term.setSubsets(subsets);
+                
+            }
+        );
+        return termMap;
+    }
+}

--- a/src/main/java/org/alliancegenome/curation_api/services/ontology/EcoTermService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ontology/EcoTermService.java
@@ -3,6 +3,7 @@ package org.alliancegenome.curation_api.services.ontology;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
+import javax.transaction.Transactional;
 
 import org.alliancegenome.curation_api.base.BaseOntologyTermService;
 import org.alliancegenome.curation_api.dao.ontology.EcoTermDAO;
@@ -17,6 +18,33 @@ public class EcoTermService extends BaseOntologyTermService<EcoTerm, EcoTermDAO>
     @PostConstruct
     protected void init() {
         setSQLDao(ecoTermDAO);
+    }
+    
+    @Override
+    @Transactional
+    public EcoTerm processUpdate (EcoTerm inTerm) {
+        EcoTerm term = ecoTermDAO.find(inTerm.getCurie());
+        
+        if(term == null) {
+            term = ecoTermDAO.getNewInstance();
+            term.setCurie(inTerm.getCurie());
+        }
+        
+        term.setName(inTerm.getName());
+        term.setType(inTerm.getType());
+        term.setObsolete(inTerm.getObsolete());
+        term.setNamespace(inTerm.getNamespace());
+        term.setDefinition(inTerm.getDefinition());
+        term.setAbbreviation(inTerm.getAbbreviation());
+        
+        handleSubsets(term, inTerm);
+        handleDefinitionUrls(term, inTerm);
+        handleSecondaryIds(term, inTerm);
+        handleSynonyms(term, inTerm);
+
+        dao.persist(term);
+        
+        return term;
     }
     
 }


### PR DESCRIPTION
Uses a hard-coded list of abbreviations in a helper, so that when the ECO ontology is loaded the abbreviations get added.  This seemed better than having a separate script or running separate loads as it will be more manageable.