### PR TITLE
SCRUM-955 fix autosuggest for search by symbol

### DIFF
--- a/src/main/cliapp/src/components/WithEditor.js
+++ b/src/main/cliapp/src/components/WithEditor.js
@@ -89,10 +89,8 @@ import {AutoComplete} from "primereact/autocomplete";
                 }
             });
             str = str.length > 0 ? str.substring(0 , str.length-2) : " "; //To remove trailing comma
-            if(item.name){
-                return <div dangerouslySetInnerHTML={{__html: item.name + ' (' + item.curie + ') ' + str.toString()}}/>;
-            }else if(item.symbol){
-                return <div dangerouslySetInnerHTML={{_html: item.symbol + ' (' +item.curie + ') ' + str.toString()}}/>;
+            if(item.symbol){
+                return <div dangerouslySetInnerHTML={{__html: item.symbol + ' (' +item.curie + ') ' + str.toString()}}/>;
             }else{
                 return <div>{item.curie + str.toString()}</div>;
             }


### PR DESCRIPTION
Fixes issue where match to symbol not shown.  Autosuggest results now start with the symbol as intended, rather than the name.