### PR TITLE
Updated GH PR validation to only run on merges to main

### DIFF
--- a/.github/workflows/github-actions-PR-validation.yml
+++ b/.github/workflows/github-actions-PR-validation.yml
@@ -8,8 +8,8 @@ on:
       - '**.md'
       - .gitignore
 jobs:
-  #TODO: add context conditionals to prevent PR validation triggering on PR edits if base-ref was not changed
   verify-test-api:
+    if: github.event.action != 'edited' || github.event.changes.base
     runs-on: ubuntu-20.04
     steps:
       - name: Report workflow details
@@ -47,6 +47,7 @@ jobs:
           make integration-test
 
   test-build-docker-image:
+      if: github.event.action != 'edited' || github.event.changes.base
       runs-on: ubuntu-20.04
       steps:
         - name: Check out repository code

--- a/.github/workflows/github-actions-PR-validation.yml
+++ b/.github/workflows/github-actions-PR-validation.yml
@@ -1,12 +1,14 @@
 name: PR validation
 on:
   pull_request:
+    types: [synchronize, opened, reopened, edited]
     branches:
       - main
     paths-ignore:
       - '**.md'
       - .gitignore
 jobs:
+  #TODO: add context conditionals to prevent PR validation triggering on PR edits if base-ref was not changed
   verify-test-api:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/github-actions-PR-validation.yml
+++ b/.github/workflows/github-actions-PR-validation.yml
@@ -1,6 +1,8 @@
 name: PR validation
 on:
   pull_request:
+    branches:
+      - main
     paths-ignore:
       - '**.md'
       - .gitignore


### PR DESCRIPTION
See title.
On first iteration this PR was made to merge in to a branch that is not main, to ensure it did not trigger the PR validation.
After that, the PR was updated to merge to main, which did not immediately trigger the validation (unexpected), so the PR validation workflow was updated to include triggering on edits to the PR that involve changing the base branch. Edits to the PR title etc. are ignored.