### PR TITLE
SCRUM-948 Load all terms with MP prefix

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/controllers/crud/ontology/MpTermCrudController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/crud/ontology/MpTermCrudController.java
@@ -8,6 +8,7 @@ import org.alliancegenome.curation_api.base.controllers.BaseOntologyTermControll
 import org.alliancegenome.curation_api.dao.ontology.MpTermDAO;
 import org.alliancegenome.curation_api.interfaces.crud.ontology.MpTermCrudInterface;
 import org.alliancegenome.curation_api.model.entities.ontology.MPTerm;
+import org.alliancegenome.curation_api.services.helpers.GenericOntologyLoadConfig;
 import org.alliancegenome.curation_api.services.ontology.MpTermService;
 
 @RequestScoped
@@ -18,7 +19,9 @@ public class MpTermCrudController extends BaseOntologyTermController<MpTermServi
     @Override
     @PostConstruct
     public void init() {
-        setService(mpTermService, MPTerm.class);
+        GenericOntologyLoadConfig config = new GenericOntologyLoadConfig();
+        config.setLoadOnlyIRIPrefix("MP");
+        setService(mpTermService, MPTerm.class, config);
     }
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/jobs/BulkLoadJobExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/BulkLoadJobExecutor.java
@@ -163,6 +163,7 @@ public class BulkLoadJobExecutor {
             } else if(bulkLoadFile.getBulkLoad().getOntologyType() == OntologyBulkLoadType.DO) {
                 service = doTermService;
             } else if(bulkLoadFile.getBulkLoad().getOntologyType() == OntologyBulkLoadType.MP) {
+                config.setLoadOnlyIRIPrefix("MP");
                 service = mpTermService;
             } else if(bulkLoadFile.getBulkLoad().getOntologyType() == OntologyBulkLoadType.MA) {
                 service = maTermService;


### PR DESCRIPTION
@oblodgett - When I test this locally, if I load the ontology via the API then ~14,000 terms load (as expected with the changes), but if I load it via the Data Loads page then only the original number of terms (~12,000) get loaded.  Any thoughts?