### PR TITLE
SCRUM-948 Add underscore to prefix in IRI search

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/GenericOntologyLoadHelper.java
@@ -99,7 +99,7 @@ public class GenericOntologyLoadHelper<T extends OntologyTerm> implements OWLObj
     
             if(
                 (termParent.getNamespace() != null && requiredNamespaces.contains(termParent.getNamespace())) ||
-                (config.getLoadOnlyIRIPrefix() != null && parent.getIRI().getShortForm().startsWith(config.getLoadOnlyIRIPrefix()))
+                (config.getLoadOnlyIRIPrefix() != null && parent.getIRI().getShortForm().startsWith(config.getLoadOnlyIRIPrefix() + "_"))
             ) {
                 //System.out.println(termParent);
 


### PR DESCRIPTION
Avoids loading of ontology terms with prefixes for which the
desired prefix is a substring at the start of the actual prefix
- e.g. avoids MPATH terms being loaded when MP prefix is
specified in config