### PR TITLE
SCRUM-1067 Add appropriate file extension to s3 URLs

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoadFile.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoadFile.java
@@ -41,6 +41,9 @@ public class BulkLoadFile extends BaseGeneratedEntity {
     @Column(columnDefinition="TEXT")
     private String errorMessage;
 
+    @JsonView({View.FieldsOnly.class})
+    private String fileType;
+    
     @ManyToOne
     private BulkLoad bulkLoad;
 
@@ -56,6 +59,6 @@ public class BulkLoadFile extends BaseGeneratedEntity {
     @JsonIgnore
     @JsonView({View.FieldsOnly.class})
     public String generateS3MD5Path() {
-        return md5Sum.charAt(0) + "/" + md5Sum.charAt(1) + "/" + md5Sum.charAt(2) + "/" + md5Sum.charAt(3) + "/" + md5Sum + ".gz";
+        return md5Sum.charAt(0) + "/" + md5Sum.charAt(1) + "/" + md5Sum.charAt(2) + "/" + md5Sum.charAt(3) + "/" + md5Sum + "." + fileType + ".gz";
     }
 }


### PR DESCRIPTION
No idea if this is a good way of doing this, but works and should cope with more file types in the future.

Determine filetype from source URL or datatype and store in bulkloadfile table.
Add appropriate extension when saving to s3;