### PR TITLE
SCRUM-725

### DIFF
--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ConditionGeneOntologyEditor.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ConditionGeneOntologyEditor.js
@@ -87,7 +87,6 @@ export const ConditionGeneOntologyEditor = ({ rowProps, searchService, setExperi
   return (
     <div>
       <AutoComplete
-        id={rowProps.rowData.conditionGeneOntology.curie}
         panelStyle={{ width: '15%', display: 'flex', maxHeight: '350px'}}
         field="curie"
         value={rowProps.rowData.conditionGeneOntology.curie}
@@ -97,8 +96,7 @@ export const ConditionGeneOntologyEditor = ({ rowProps, searchService, setExperi
         onHide={(e) => op.current.hide(e)}
         onChange={(e) => onConditionGeneOntologyEditorValueChange(e)}
       />
-      <ConditionGeneOntologyTooltip op={op} autocompleteSelectedItem={autocompleteSelectedItem} inputValue={trimWhitespace(rowProps.rowData.conditionGeneOntology.curie.toLowerCase())}
-      />
+      <ConditionGeneOntologyTooltip op={op} autocompleteSelectedItem={autocompleteSelectedItem}/>
     </div>
   )
 };

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ConditionGeneOntologyEditor.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ConditionGeneOntologyEditor.js
@@ -10,19 +10,19 @@ export const ConditionGeneOntologyEditor = ({ rowProps, searchService, setExperi
   const [autocompleteSelectedItem, setAutocompleteSelectedItem] = useState({});
   
   const searchConditionGeneOntology = (event) => {
-  let conditionGeneOntologyFilter = {};
-  autocompleteFields.forEach( field => {
-    conditionGeneOntologyFilter[field] = event.query;
-  });
-  let obsoleteFilter = {"obsolete": false};
-
-  searchService.search('goterm', 15, 0, [], {"conditionGeneOntologyFilter":conditionGeneOntologyFilter, "obsoleteFilter":obsoleteFilter})
-    .then((data) => {
-    if(data.results && data.results.length >0)
-      setFilteredConditionGeneOntologies(data.results);
-    else
-      setFilteredConditionGeneOntologies([]);
+    let conditionGeneOntologyFilter = {};
+    autocompleteFields.forEach( field => {
+      conditionGeneOntologyFilter[field] = event.query;
     });
+    let obsoleteFilter = {"obsolete": false};
+
+    searchService.search('goterm', 15, 0, [], {"conditionGeneOntologyFilter":conditionGeneOntologyFilter, "obsoleteFilter":obsoleteFilter})
+      .then((data) => {
+        if(data.results && data.results.length >0)
+          setFilteredConditionGeneOntologies(data.results);
+        else
+          setFilteredConditionGeneOntologies([]);
+      });
   };
 
   const onConditionGeneOntologyEditorValueChange = (event) => {//this should propably be generalized so that all of these editor value changes can use the same method
@@ -30,7 +30,7 @@ export const ConditionGeneOntologyEditor = ({ rowProps, searchService, setExperi
     if(event.target.value || event.target.value === '') {
       updatedConditions[rowProps.rowIndex].conditionGeneOntology = {};//this needs to be fixed. Otherwise, we won't have access to the other subject fields
       if(typeof event.target.value === "object"){
-        updatedConditions[rowProps.rowIndex].conditionGeneOntology.curie = event.target.value.curie;
+        updatedConditions[rowProps.rowIndex].conditionGeneOntology = event.target.value;
       } else {
         if (event.target.value === '') {
           updatedConditions[rowProps.rowIndex].conditionGeneOntology = null;
@@ -94,6 +94,7 @@ export const ConditionGeneOntologyEditor = ({ rowProps, searchService, setExperi
   return (
     <div>
       <AutoComplete
+        id = {rowProps.rowData.conditionGeneOntology ? rowProps.rowData.conditionGeneOntology.curie : null}
         panelStyle={{ width: '15%', display: 'flex', maxHeight: '350px'}}
         field="curie"
         value={rowProps.rowData.conditionGeneOntology ? rowProps.rowData.conditionGeneOntology.curie : null}
@@ -103,7 +104,7 @@ export const ConditionGeneOntologyEditor = ({ rowProps, searchService, setExperi
         onHide={(e) => op.current.hide(e)}
         onChange={(e) => onConditionGeneOntologyEditorValueChange(e)}
       />
-      <ConditionGeneOntologyTooltip op={op} autocompleteSelectedItem={autocompleteSelectedItem}/>
+      <ConditionGeneOntologyTooltip op={op} autocompleteSelectedItem={autocompleteSelectedItem} inputValue={rowProps.rowData.conditionGeneOntology ? trimWhitespace(rowProps.rowData.conditionGeneOntology.curie.toLowerCase()) : null}/>
     </div>
   )
 };

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ConditionGeneOntologyEditor.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ConditionGeneOntologyEditor.js
@@ -1,0 +1,122 @@
+import React, {useState, useRef} from 'react';
+import {AutoComplete} from "primereact/autocomplete";
+import {trimWhitespace } from '../../utils/utils';
+import {ConditionGeneOntologyTooltip} from './ConditionGeneOntologyTooltip';
+
+export const ConditionGeneOntologyEditor = ({ rowProps, searchService, setExperimentalConditions, autocompleteFields }) => {
+  const [filteredConditionGeneOntologies, setFilteredConditionGeneOntologies] = useState([]);
+
+  const op = useRef(null);
+  const [autocompleteSelectedItem, setAutocompleteSelectedItem] = useState({});
+  
+  const searchConditionGeneOntology = (event) => {
+    let conditionGeneOntologyFilter = {};
+    autocompleteFields.forEach( field => {
+      conditionGeneOntologyFilter[field] = event.query;
+    });
+    let obsoleteFilter = {"obsolete": false};
+
+    searchService.search('goterm', 15, 0, [], {"conditionGeneOntologyFilter":conditionGeneOntologyFilter, "obsoleteFilter":obsoleteFilter})
+        .then((data) => {
+      if(data.results && data.results.length >0)
+        setFilteredConditionGeneOntologies(data.results);
+      else
+        setFilteredConditionGeneOntologies([]);
+      });
+    };
+
+    const onConditionGeneOntologyEditorValueChange = (event) => {//this should propably be generalized so that all of these editor value changes can use the same method
+      let updatedConditions = [...rowProps.value];
+      if(event.target.value || event.target.value === '') {
+        updatedConditions[rowProps.rowIndex].conditionGeneOntology = {};//this needs to be fixed. Otherwise, we won't have access to the other subject fields
+        if(typeof event.target.value === "object"){
+          updatedConditions[rowProps.rowIndex].conditionGeneOntology.curie = event.target.value.curie;
+        } else {
+          updatedConditions[rowProps.rowIndex].conditionGeneOntology.curie = event.target.value;
+        }
+        setExperimentalConditions(updatedConditions);
+      }
+    };
+
+    const onSelectionOver = (event, item) => {
+      setAutocompleteSelectedItem(item);
+      op.current.show(event);
+    };
+
+    const conditionGeneOntologyItemTemplate = (item) => {
+      let inputValue = trimWhitespace(rowProps.rowData.conditionGeneOntology.curie.toLowerCase());    
+      let str = "";
+      let synonymsStr = "";
+            let isSynonym = false;
+            let crossReferencesStr = "";
+            let isCrossReference = false;
+            let secondaryIdentifiersStr = "";
+            let isSecondaryIdentifier = false;
+            autocompleteFields.forEach( field => {
+                if(field === "synonyms" && item["synonyms"]){
+                    for(let i=0; i< item["synonyms"].length ; i++ ) {
+                        if(item["synonyms"][i]) {
+                            if (item["synonyms"][i].toLowerCase().indexOf(inputValue) >= 0) {
+                                synonymsStr +=  item["synonyms"][i] + ", ";
+                                isSynonym = true;
+                            }
+                        }
+                    }
+                if(isSynonym){
+                    str += "Synonym: " + synonymsStr;
+                }
+                }else if(field === "crossReferences.curie" && item["crossReferences"]){
+                    for(let i=0; i< item["crossReferences"].length ; i++ ) {
+                        if(item["crossReferences"][i].curie) {
+                            if (item["crossReferences"][i].curie.toString().toLowerCase().indexOf(inputValue) >= 0) {
+                                crossReferencesStr += item["crossReferences"][i].curie.toString() + ", ";
+                                isCrossReference = true;
+                            }
+                        }
+                    }
+                    if(isCrossReference){
+                        str += "CrossReferences: " + crossReferencesStr;
+                    }
+                }else {
+                    if (item[field]) {
+                        if(field === "secondaryIdentifiers") {
+                            for(var i=0; i< item["secondaryIdentifiers"].length ; i++ ) {
+                                if (item["secondaryIdentifiers"][i].toLowerCase().indexOf(inputValue) >= 0) {
+                                    secondaryIdentifiersStr += item["secondaryIdentifiers"][i] + ", ";
+                                    isSecondaryIdentifier = true;
+                                }
+                            }
+                            if(isSecondaryIdentifier){
+                                str += "SecondaryIdentifiers: " + secondaryIdentifiersStr;
+                            }
+                        }else {
+                            if (item[field].toString().toLowerCase().indexOf(inputValue) >= 0) {
+                                if (field !== "curie" && field !== "name")
+                                    str += field + ": " + item[field].toString() + ", ";
+                            }
+                        }
+                    }
+                }
+            });
+      str = str.length > 0 ? str.substring(0 , str.length-2) : " "; //To remove trailing comma
+            return <div dangerouslySetInnerHTML={{__html: item.abbreviation + ' - ' + item.name + ' (' + item.curie + ') ' + str.toString()}}/>;
+        };
+
+    return (
+      <div>
+        <AutoComplete
+          id={rowProps.rowData.conditionGeneOntology.curie}
+          panelStyle={{ width: '15%', display: 'flex', maxHeight: '350px'}}
+          field="curie"
+          value={rowProps.rowData.conditionGeneOntology.curie}
+          suggestions={filteredConditionGeneOntologies}
+          itemTemplate={conditionGeneOntologyItemTemplate}
+          completeMethod={searchConditionGeneOntology}
+          onHide={(e) => op.current.hide(e)}
+          onChange={(e) => onConditionGeneOntologyEditorValueChange(e)}
+      />
+      <ConditionGeneOntologyTooltip op={op} autocompleteSelectedItem={autocompleteSelectedItem} inputValue={trimWhitespace(rowProps.rowData.conditionGeneOntology.curie.toLowerCase())}
+            />
+      </div>
+    )
+};

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ConditionGeneOntologyEditor.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ConditionGeneOntologyEditor.js
@@ -10,113 +10,95 @@ export const ConditionGeneOntologyEditor = ({ rowProps, searchService, setExperi
   const [autocompleteSelectedItem, setAutocompleteSelectedItem] = useState({});
   
   const searchConditionGeneOntology = (event) => {
-    let conditionGeneOntologyFilter = {};
-    autocompleteFields.forEach( field => {
-      conditionGeneOntologyFilter[field] = event.query;
+  let conditionGeneOntologyFilter = {};
+  autocompleteFields.forEach( field => {
+    conditionGeneOntologyFilter[field] = event.query;
+  });
+  let obsoleteFilter = {"obsolete": false};
+
+  searchService.search('goterm', 15, 0, [], {"conditionGeneOntologyFilter":conditionGeneOntologyFilter, "obsoleteFilter":obsoleteFilter})
+    .then((data) => {
+    if(data.results && data.results.length >0)
+      setFilteredConditionGeneOntologies(data.results);
+    else
+      setFilteredConditionGeneOntologies([]);
     });
-    let obsoleteFilter = {"obsolete": false};
+  };
 
-    searchService.search('goterm', 15, 0, [], {"conditionGeneOntologyFilter":conditionGeneOntologyFilter, "obsoleteFilter":obsoleteFilter})
-        .then((data) => {
-      if(data.results && data.results.length >0)
-        setFilteredConditionGeneOntologies(data.results);
-      else
-        setFilteredConditionGeneOntologies([]);
-      });
-    };
-
-    const onConditionGeneOntologyEditorValueChange = (event) => {//this should propably be generalized so that all of these editor value changes can use the same method
-      let updatedConditions = [...rowProps.value];
-      if(event.target.value || event.target.value === '') {
-        updatedConditions[rowProps.rowIndex].conditionGeneOntology = {};//this needs to be fixed. Otherwise, we won't have access to the other subject fields
-        if(typeof event.target.value === "object"){
-          updatedConditions[rowProps.rowIndex].conditionGeneOntology.curie = event.target.value.curie;
-        } else {
-          updatedConditions[rowProps.rowIndex].conditionGeneOntology.curie = event.target.value;
-        }
-        setExperimentalConditions(updatedConditions);
+  const onConditionGeneOntologyEditorValueChange = (event) => {//this should propably be generalized so that all of these editor value changes can use the same method
+    let updatedConditions = [...rowProps.value];
+    if(event.target.value || event.target.value === '') {
+      updatedConditions[rowProps.rowIndex].conditionGeneOntology = {};//this needs to be fixed. Otherwise, we won't have access to the other subject fields
+      if(typeof event.target.value === "object"){
+        updatedConditions[rowProps.rowIndex].conditionGeneOntology.curie = event.target.value.curie;
+      } else {
+        updatedConditions[rowProps.rowIndex].conditionGeneOntology.curie = event.target.value;
       }
-    };
+      setExperimentalConditions(updatedConditions);
+    }
+  };
 
-    const onSelectionOver = (event, item) => {
-      setAutocompleteSelectedItem(item);
-      op.current.show(event);
-    };
+  const onSelectionOver = (event, item) => {
+    setAutocompleteSelectedItem(item);
+    op.current.show(event);
+  };
 
-    const conditionGeneOntologyItemTemplate = (item) => {
-      let inputValue = trimWhitespace(rowProps.rowData.conditionGeneOntology.curie.toLowerCase());    
-      let str = "";
-      let synonymsStr = "";
-            let isSynonym = false;
-            let crossReferencesStr = "";
-            let isCrossReference = false;
-            let secondaryIdentifiersStr = "";
-            let isSecondaryIdentifier = false;
-            autocompleteFields.forEach( field => {
-                if(field === "synonyms" && item["synonyms"]){
-                    for(let i=0; i< item["synonyms"].length ; i++ ) {
-                        if(item["synonyms"][i]) {
-                            if (item["synonyms"][i].toLowerCase().indexOf(inputValue) >= 0) {
-                                synonymsStr +=  item["synonyms"][i] + ", ";
-                                isSynonym = true;
-                            }
-                        }
-                    }
-                if(isSynonym){
-                    str += "Synonym: " + synonymsStr;
-                }
-                }else if(field === "crossReferences.curie" && item["crossReferences"]){
-                    for(let i=0; i< item["crossReferences"].length ; i++ ) {
-                        if(item["crossReferences"][i].curie) {
-                            if (item["crossReferences"][i].curie.toString().toLowerCase().indexOf(inputValue) >= 0) {
-                                crossReferencesStr += item["crossReferences"][i].curie.toString() + ", ";
-                                isCrossReference = true;
-                            }
-                        }
-                    }
-                    if(isCrossReference){
-                        str += "CrossReferences: " + crossReferencesStr;
-                    }
-                }else {
-                    if (item[field]) {
-                        if(field === "secondaryIdentifiers") {
-                            for(var i=0; i< item["secondaryIdentifiers"].length ; i++ ) {
-                                if (item["secondaryIdentifiers"][i].toLowerCase().indexOf(inputValue) >= 0) {
-                                    secondaryIdentifiersStr += item["secondaryIdentifiers"][i] + ", ";
-                                    isSecondaryIdentifier = true;
-                                }
-                            }
-                            if(isSecondaryIdentifier){
-                                str += "SecondaryIdentifiers: " + secondaryIdentifiersStr;
-                            }
-                        }else {
-                            if (item[field].toString().toLowerCase().indexOf(inputValue) >= 0) {
-                                if (field !== "curie" && field !== "name")
-                                    str += field + ": " + item[field].toString() + ", ";
-                            }
-                        }
-                    }
-                }
-            });
-      str = str.length > 0 ? str.substring(0 , str.length-2) : " "; //To remove trailing comma
-            return <div dangerouslySetInnerHTML={{__html: item.abbreviation + ' - ' + item.name + ' (' + item.curie + ') ' + str.toString()}}/>;
-        };
 
-    return (
-      <div>
-        <AutoComplete
-          id={rowProps.rowData.conditionGeneOntology.curie}
-          panelStyle={{ width: '15%', display: 'flex', maxHeight: '350px'}}
-          field="curie"
-          value={rowProps.rowData.conditionGeneOntology.curie}
-          suggestions={filteredConditionGeneOntologies}
-          itemTemplate={conditionGeneOntologyItemTemplate}
-          completeMethod={searchConditionGeneOntology}
-          onHide={(e) => op.current.hide(e)}
-          onChange={(e) => onConditionGeneOntologyEditorValueChange(e)}
+  const conditionGeneOntologyItemTemplate = (item) => {
+    let inputValue = trimWhitespace(rowProps.rowData.conditionGeneOntology.curie.toLowerCase());
+    if (autocompleteSelectedItem.synonyms && autocompleteSelectedItem.synonyms.length>0){
+      for(let i in autocompleteSelectedItem.synonyms){
+        if(autocompleteSelectedItem.synonyms[i].toString().toLowerCase().indexOf(inputValue)<0){
+          delete autocompleteSelectedItem.synonyms[i];
+        }
+      }
+    }
+    if (autocompleteSelectedItem.crossReferences && autocompleteSelectedItem.crossReferences.length>0){
+      for(let i in autocompleteSelectedItem.crossReferences){
+        if(autocompleteSelectedItem.crossReferences[i].curie.toString().toLowerCase().indexOf(inputValue)< 0){
+          delete autocompleteSelectedItem.crossReferences[i];
+        }
+      }
+    }
+      
+    if(autocompleteSelectedItem.secondaryIdentifiers && autocompleteSelectedItem.secondaryIdentifiers.length>0){
+      for(let i in autocompleteSelectedItem.secondaryIdentifiers){
+        if(autocompleteSelectedItem.secondaryIdentifiers[i].toString().toLowerCase().indexOf(inputValue)< 0){
+          delete autocompleteSelectedItem.secondaryIdentifiers[i];
+        }
+      }
+    }
+      
+    if (item.name){
+      return (
+        <div>
+          <div onMouseOver={(event) => onSelectionOver(event, item)} dangerouslySetInnerHTML={{__html: item.name + ' (' + item.curie + ') '}}/>
+        </div>
+      );
+    }else {
+      return (
+        <div>
+          <div onMouseOver={(event) => onSelectionOver(event, item)}>{item.curie}</div>
+        </div>
+      );
+    }     
+  };
+
+  return (
+    <div>
+      <AutoComplete
+        id={rowProps.rowData.conditionGeneOntology.curie}
+        panelStyle={{ width: '15%', display: 'flex', maxHeight: '350px'}}
+        field="curie"
+        value={rowProps.rowData.conditionGeneOntology.curie}
+        suggestions={filteredConditionGeneOntologies}
+        itemTemplate={conditionGeneOntologyItemTemplate}
+        completeMethod={searchConditionGeneOntology}
+        onHide={(e) => op.current.hide(e)}
+        onChange={(e) => onConditionGeneOntologyEditorValueChange(e)}
       />
       <ConditionGeneOntologyTooltip op={op} autocompleteSelectedItem={autocompleteSelectedItem} inputValue={trimWhitespace(rowProps.rowData.conditionGeneOntology.curie.toLowerCase())}
-            />
-      </div>
-    )
+      />
+    </div>
+  )
 };

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ConditionGeneOntologyEditor.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ConditionGeneOntologyEditor.js
@@ -32,7 +32,12 @@ export const ConditionGeneOntologyEditor = ({ rowProps, searchService, setExperi
       if(typeof event.target.value === "object"){
         updatedConditions[rowProps.rowIndex].conditionGeneOntology.curie = event.target.value.curie;
       } else {
-        updatedConditions[rowProps.rowIndex].conditionGeneOntology.curie = event.target.value;
+        if (event.target.value === '') {
+          updatedConditions[rowProps.rowIndex].conditionGeneOntology = null;
+        }
+        else {
+          updatedConditions[rowProps.rowIndex].conditionGeneOntology.curie = event.target.value;
+        }
       }
       setExperimentalConditions(updatedConditions);
     }
@@ -45,43 +50,45 @@ export const ConditionGeneOntologyEditor = ({ rowProps, searchService, setExperi
 
 
   const conditionGeneOntologyItemTemplate = (item) => {
-    let inputValue = trimWhitespace(rowProps.rowData.conditionGeneOntology.curie.toLowerCase());
-    if (autocompleteSelectedItem.synonyms && autocompleteSelectedItem.synonyms.length>0){
-      for(let i in autocompleteSelectedItem.synonyms){
-        if(autocompleteSelectedItem.synonyms[i].toString().toLowerCase().indexOf(inputValue)<0){
-          delete autocompleteSelectedItem.synonyms[i];
+    if (rowProps.rowData.conditionGeneOntology) {
+      let inputValue = trimWhitespace(rowProps.rowData.conditionGeneOntology.curie.toLowerCase());
+      if (autocompleteSelectedItem.synonyms && autocompleteSelectedItem.synonyms.length>0){
+        for(let i in autocompleteSelectedItem.synonyms){
+          if(autocompleteSelectedItem.synonyms[i].toString().toLowerCase().indexOf(inputValue)<0){
+            delete autocompleteSelectedItem.synonyms[i];
+          }
         }
       }
-    }
-    if (autocompleteSelectedItem.crossReferences && autocompleteSelectedItem.crossReferences.length>0){
-      for(let i in autocompleteSelectedItem.crossReferences){
-        if(autocompleteSelectedItem.crossReferences[i].curie.toString().toLowerCase().indexOf(inputValue)< 0){
-          delete autocompleteSelectedItem.crossReferences[i];
+      if (autocompleteSelectedItem.crossReferences && autocompleteSelectedItem.crossReferences.length>0){
+        for(let i in autocompleteSelectedItem.crossReferences){
+          if(autocompleteSelectedItem.crossReferences[i].curie.toString().toLowerCase().indexOf(inputValue)< 0){
+            delete autocompleteSelectedItem.crossReferences[i];
+          }
         }
       }
-    }
       
-    if(autocompleteSelectedItem.secondaryIdentifiers && autocompleteSelectedItem.secondaryIdentifiers.length>0){
-      for(let i in autocompleteSelectedItem.secondaryIdentifiers){
-        if(autocompleteSelectedItem.secondaryIdentifiers[i].toString().toLowerCase().indexOf(inputValue)< 0){
-          delete autocompleteSelectedItem.secondaryIdentifiers[i];
+      if(autocompleteSelectedItem.secondaryIdentifiers && autocompleteSelectedItem.secondaryIdentifiers.length>0){
+        for(let i in autocompleteSelectedItem.secondaryIdentifiers){
+          if(autocompleteSelectedItem.secondaryIdentifiers[i].toString().toLowerCase().indexOf(inputValue)< 0){
+            delete autocompleteSelectedItem.secondaryIdentifiers[i];
+          }
         }
       }
-    }
       
-    if (item.name){
-      return (
-        <div>
-          <div onMouseOver={(event) => onSelectionOver(event, item)} dangerouslySetInnerHTML={{__html: item.name + ' (' + item.curie + ') '}}/>
-        </div>
-      );
-    }else {
-      return (
-        <div>
-          <div onMouseOver={(event) => onSelectionOver(event, item)}>{item.curie}</div>
-        </div>
-      );
-    }     
+      if (item.name){
+        return (
+          <div>
+            <div onMouseOver={(event) => onSelectionOver(event, item)} dangerouslySetInnerHTML={{__html: item.name + ' (' + item.curie + ') '}}/>
+          </div>
+        );
+      }else {
+        return (
+          <div>
+            <div onMouseOver={(event) => onSelectionOver(event, item)}>{item.curie}</div>
+          </div>
+        );
+      }
+    }       
   };
 
   return (
@@ -89,7 +96,7 @@ export const ConditionGeneOntologyEditor = ({ rowProps, searchService, setExperi
       <AutoComplete
         panelStyle={{ width: '15%', display: 'flex', maxHeight: '350px'}}
         field="curie"
-        value={rowProps.rowData.conditionGeneOntology.curie}
+        value={rowProps.rowData.conditionGeneOntology ? rowProps.rowData.conditionGeneOntology.curie : null}
         suggestions={filteredConditionGeneOntologies}
         itemTemplate={conditionGeneOntologyItemTemplate}
         completeMethod={searchConditionGeneOntology}

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ConditionGeneOntologyTooltip.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ConditionGeneOntologyTooltip.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import {Tooltip} from "primereact/tooltip";
+
+export function ConditionGeneOntologyTooltip({ op, autocompleteSelectedItem }) {
+
+    return (
+        <>
+            <Tooltip ref={op} style={{width: '450px', maxWidth: '450px'}} position={'right'} mouseTrack mouseTrackLeft={30}>
+                Curie: {autocompleteSelectedItem.curie}<br />
+                { autocompleteSelectedItem.name &&
+                <div dangerouslySetInnerHTML={{__html: 'Name: ' + autocompleteSelectedItem.name}}/>
+                }
+                { autocompleteSelectedItem.symbol &&
+                <div dangerouslySetInnerHTML={{__html: 'Symbol: ' + autocompleteSelectedItem.symbol }} />
+                }
+                {  autocompleteSelectedItem.synonyms &&
+                autocompleteSelectedItem.synonyms.map((syn) => <div>Synonym: {syn}</div>)
+                }
+                {  autocompleteSelectedItem.crossReferences &&
+                autocompleteSelectedItem.crossReferences.map((cr) => <div>Cross Reference: {cr.curie}</div>)
+                }
+                {  autocompleteSelectedItem.secondaryIdentifiers &&
+                autocompleteSelectedItem.secondaryIdentifiers.map((si) => <div>Secondary Identifiers: {si}</div>)
+                }
+            </Tooltip>
+        </>
+    )
+}

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ConditionGeneOntologyTooltip.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ConditionGeneOntologyTooltip.js
@@ -3,26 +3,26 @@ import {Tooltip} from "primereact/tooltip";
 
 export function ConditionGeneOntologyTooltip({ op, autocompleteSelectedItem }) {
 
-    return (
-        <>
-            <Tooltip ref={op} style={{width: '450px', maxWidth: '450px'}} position={'right'} mouseTrack mouseTrackLeft={30}>
-                Curie: {autocompleteSelectedItem.curie}<br />
-                { autocompleteSelectedItem.name &&
-                <div dangerouslySetInnerHTML={{__html: 'Name: ' + autocompleteSelectedItem.name}}/>
-                }
-                { autocompleteSelectedItem.symbol &&
-                <div dangerouslySetInnerHTML={{__html: 'Symbol: ' + autocompleteSelectedItem.symbol }} />
-                }
-                {  autocompleteSelectedItem.synonyms &&
-                autocompleteSelectedItem.synonyms.map((syn) => <div>Synonym: {syn}</div>)
-                }
-                {  autocompleteSelectedItem.crossReferences &&
-                autocompleteSelectedItem.crossReferences.map((cr) => <div>Cross Reference: {cr.curie}</div>)
-                }
-                {  autocompleteSelectedItem.secondaryIdentifiers &&
-                autocompleteSelectedItem.secondaryIdentifiers.map((si) => <div>Secondary Identifiers: {si}</div>)
-                }
-            </Tooltip>
-        </>
-    )
+  return (
+    <>
+      <Tooltip ref={op} style={{width: '450px', maxWidth: '450px'}} position={'right'} mouseTrack mouseTrackLeft={30}>
+        Curie: {autocompleteSelectedItem.curie}<br />
+        { autocompleteSelectedItem.name &&
+          <div dangerouslySetInnerHTML={{__html: 'Name: ' + autocompleteSelectedItem.name}}/>
+        }
+          { autocompleteSelectedItem.symbol &&
+          <div dangerouslySetInnerHTML={{__html: 'Symbol: ' + autocompleteSelectedItem.symbol }} />
+        }
+        {  autocompleteSelectedItem.synonyms &&
+          autocompleteSelectedItem.synonyms.map((syn) => <div>Synonym: {syn}</div>)
+        }
+        {  autocompleteSelectedItem.crossReferences &&
+          autocompleteSelectedItem.crossReferences.map((cr) => <div>Cross Reference: {cr.curie}</div>)
+        }
+        {  autocompleteSelectedItem.secondaryIdentifiers &&
+          autocompleteSelectedItem.secondaryIdentifiers.map((si) => <div>Secondary Identifiers: {si}</div>)
+        }
+      </Tooltip>
+    </>
+  )
 }

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsPage.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsPage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ExperimentalConditionsTable } from './ExperimentalConditionsTable';
 
-function ExperimentalConditionsPage() {
+export function ExperimentalConditionsPage() {
     return (
         <ExperimentalConditionsTable />
     );

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
@@ -110,7 +110,7 @@ export const ExperimentalConditionsTable = () => {
 
 
     const onRowEditSave = (event) => {
-    rowsInEdit.current--;
+      rowsInEdit.current--;
       if (rowsInEdit.current === 0) {
         setIsEnabled(true);
       }
@@ -121,12 +121,11 @@ export const ExperimentalConditionsTable = () => {
       if (event.data.conditionGeneOntology && Object.keys(event.data.conditionGeneOntology).length >= 1) {
           event.data.conditionGeneOntology.curie = trimWhitespace(event.data.conditionGeneOntology.curie);
           updatedRow.conditionGeneOntology = {};
-          updatedRow.conditionGeneOntology.curie = event.data.conditionGeneOntology.curie;
+          updatedRow.conditionGeneOntology = event.data.conditionGeneOntology;
       }
 
       mutation.mutate(updatedRow, {
           onSuccess: (data, variables, context) => {
-            console.log(data);
             toast_topright.current.show({ severity: 'success', summary: 'Successful', detail: 'Row Updated' });
 
             let conditions = [...experimentalConditions];
@@ -275,10 +274,10 @@ export const ExperimentalConditionsTable = () => {
       field:"conditionGeneOntology.name",
       header:"Gene Ontology",
       sortable: isEnabled,
-      body: conditionGeneOntologyBodyTemplate,
       filter: true, 
       filterElement: filterComponentTemplate("conditionGeneOntologyFilter", ["conditionGeneOntology.curie", "conditionGeneOntology.name"]),
-      editor: (props) => conditionGeneOntologyEditorTemplate(props)
+      editor: (props) => conditionGeneOntologyEditorTemplate(props),
+      body: conditionGeneOntologyBodyTemplate
     },
     {
       field:"conditionChemical.name",

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
@@ -114,8 +114,11 @@ export const ExperimentalConditionsTable = () => {
       if (rowsInEdit.current === 0) {
         setIsEnabled(true);
       }
+      if (event.data.conditionGeneOntology === null) {
+        delete event.data.conditionGeneOntology;
+      }
       let updatedRow = JSON.parse(JSON.stringify(event.data));//deep copy
-      if (Object.keys(event.data.conditionGeneOntology).length >= 1) {
+      if (event.data.conditionGeneOntology && Object.keys(event.data.conditionGeneOntology).length >= 1) {
           event.data.conditionGeneOntology.curie = trimWhitespace(event.data.conditionGeneOntology.curie);
           updatedRow.conditionGeneOntology = {};
           updatedRow.conditionGeneOntology.curie = event.data.conditionGeneOntology.curie;

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
@@ -171,7 +171,7 @@ export const ExperimentalConditionsTable = () => {
   return (
     <div>
       <div className="card">
-        <h3>Experimental Conditions Table</h3>
+        <h3>Genes Table</h3>
         <Messages ref={errorMessage} />
         <DataTable value={experimentalConditions} className="p-datatable-sm" header={header} reorderableColumns  
           sortMode="multiple" removableSort onSort={onSort} multiSortMeta={multiSortMeta}

--- a/src/main/cliapp/src/service/ExperimentalConditionService.js
+++ b/src/main/cliapp/src/service/ExperimentalConditionService.js
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+export class ExperimentalConditionService {
+
+    saveExperimentalCondition(updatedCondition){
+        return axios.put(`api/experimental-condition`, updatedCondition)
+    }
+}
+

--- a/src/main/cliapp/src/service/ExperimentalConditionService.js
+++ b/src/main/cliapp/src/service/ExperimentalConditionService.js
@@ -1,9 +1,14 @@
 import axios from 'axios';
+import { BaseAuthService } from './BaseAuthService';
 
-export class ExperimentalConditionService {
+export class ExperimentalConditionService extends BaseAuthService{
+  //eslint-disable-next-line
+  constructor(authState) {
+    super(authState);
+  }
 
-    saveExperimentalCondition(updatedCondition){
-        return axios.put(`api/experimental-condition`, updatedCondition)
-    }
+  saveExperimentalCondition(updatedCondition){
+    return axios.put(`api/experimental-condition`, updatedCondition, this.apiAuthHeader);
+  }
 }
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ExperimentalCondition.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ExperimentalCondition.java
@@ -68,13 +68,25 @@ public class ExperimentalCondition extends BaseGeneratedAndUniqueIdEntity {
     @IndexedEmbedded(includeDepth = 1)
     @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
     @ManyToOne
-    @JsonView({View.FieldsOnly.class})private AnatomicalTerm conditionAnatomy;                 
+    @JsonView({View.FieldsOnly.class})
+    private AnatomicalTerm conditionAnatomy;                   
+    
+    
+    @IndexedEmbedded(includeDepth = 1)
+    @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
+    @ManyToOne
+    @JsonView({View.FieldsOnly.class})
     private GOTerm conditionGeneOntology;           
     
     @IndexedEmbedded(includeDepth = 1)
     @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
     @ManyToOne
-    @JsonView({View.FieldsOnly.class})private NCBITaxonTerm conditionTaxon;                   
+    @JsonView({View.FieldsOnly.class})private NCBITaxonTerm conditionTaxon; 
+    
+    @IndexedEmbedded(includeDepth = 1)
+    @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
+    @ManyToOne
+    @JsonView({View.FieldsOnly.class})
     private ChemicalTerm conditionChemical;                
     
     @IndexedEmbedded(includeDepth = 1)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/AnatomicalTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/AnatomicalTerm.java
@@ -9,6 +9,6 @@ import lombok.*;
 @Audited
 @Entity
 @Data @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-public abstract class AnatomicalTerm extends OntologyTerm {
+public class AnatomicalTerm extends OntologyTerm {
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ChemicalTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ChemicalTerm.java
@@ -18,7 +18,7 @@ import lombok.*;
 @Audited
 @Entity
 @Data @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-public abstract class ChemicalTerm extends OntologyTerm {
+public class ChemicalTerm extends OntologyTerm {
 
     @FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
     @KeywordField(name = "inchi_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/EMAPATerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/EMAPATerm.java
@@ -13,6 +13,6 @@ import lombok.*;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-public class EMAPATerm extends OntologyTerm {
+public class EMAPATerm extends AnatomicalTerm {
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ExperimentalConditionOntologyTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ExperimentalConditionOntologyTerm.java
@@ -4,11 +4,12 @@ import javax.persistence.Entity;
 
 import org.hibernate.envers.Audited;
 
+
 import lombok.*;
 
 @Audited
 @Entity
 @Data @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-public abstract class ExperimentalConditionOntologyTerm extends OntologyTerm {
+public class ExperimentalConditionOntologyTerm extends OntologyTerm {
 
 }


### PR DESCRIPTION
Some experimental condition entity fixes, change of EMAPATerm to extend AnatomicalTerm, various Experimental Condition table fixes, and make conditionGeneOntology editable.

Had to be make AnatomicalTerm ExperimentalConditionOntologyTerm and ChemicalTerm non-abstract in order to be able to create test experimental conditions via the API (possibly another way around this?).

Known bug: After editing, conditionGeneOntology only displays curie and not name until page is refreshed.