### PR TITLE
SCRUM-1154 Generalise editing of single-value ontology fields

### DIFF
--- a/src/main/cliapp/src/components/SingleOntologyEditor.js
+++ b/src/main/cliapp/src/components/SingleOntologyEditor.js
@@ -1,42 +1,42 @@
 import React, {useState, useRef} from 'react';
 import {AutoComplete} from "primereact/autocomplete";
-import {trimWhitespace } from '../../utils/utils';
-import {ConditionGeneOntologyTooltip} from './ConditionGeneOntologyTooltip';
+import {trimWhitespace } from '../utils/utils';
+import {SingleOntologyTooltip} from './SingleOntologyTooltip';
 
-export const ConditionGeneOntologyEditor = ({ rowProps, searchService, setExperimentalConditions, autocompleteFields }) => {
-  const [filteredConditionGeneOntologies, setFilteredConditionGeneOntologies] = useState([]);
+export const SingleOntologyEditor = ({ rowProps, searchService, setExperimentalConditions, autocompleteFields, fieldname, endpoint }) => {
+  const [filteredSingleOntologies, setFilteredSingleOntologies] = useState([]);
 
   const op = useRef(null);
   const [autocompleteSelectedItem, setAutocompleteSelectedItem] = useState({});
   
-  const searchConditionGeneOntology = (event) => {
-    let conditionGeneOntologyFilter = {};
+  const searchSingleOntology = (event) => {
+    let singleOntologyFilter = {};
     autocompleteFields.forEach( field => {
-      conditionGeneOntologyFilter[field] = event.query;
+      singleOntologyFilter[field] = event.query;
     });
     let obsoleteFilter = {"obsolete": false};
 
-    searchService.search('goterm', 15, 0, [], {"conditionGeneOntologyFilter":conditionGeneOntologyFilter, "obsoleteFilter":obsoleteFilter})
+    searchService.search(endpoint, 15, 0, [], {"singleOntologyFilter":singleOntologyFilter, "obsoleteFilter":obsoleteFilter})
       .then((data) => {
         if(data.results && data.results.length >0)
-          setFilteredConditionGeneOntologies(data.results);
+          setFilteredSingleOntologies(data.results);
         else
-          setFilteredConditionGeneOntologies([]);
+          setFilteredSingleOntologies([]);
       });
   };
 
-  const onConditionGeneOntologyEditorValueChange = (event) => {//this should propably be generalized so that all of these editor value changes can use the same method
+  const onSingleOntologyEditorValueChange = (event) => {//this should propably be generalized so that all of these editor value changes can use the same method
     let updatedConditions = [...rowProps.value];
     if(event.target.value || event.target.value === '') {
-      updatedConditions[rowProps.rowIndex].conditionGeneOntology = {};//this needs to be fixed. Otherwise, we won't have access to the other subject fields
+      updatedConditions[rowProps.rowIndex][fieldname] = {};//this needs to be fixed. Otherwise, we won't have access to the other subject fields
       if(typeof event.target.value === "object"){
-        updatedConditions[rowProps.rowIndex].conditionGeneOntology = event.target.value;
+        updatedConditions[rowProps.rowIndex][fieldname] = event.target.value;
       } else {
         if (event.target.value === '') {
-          updatedConditions[rowProps.rowIndex].conditionGeneOntology = null;
+          updatedConditions[rowProps.rowIndex][fieldname] = null;
         }
         else {
-          updatedConditions[rowProps.rowIndex].conditionGeneOntology.curie = event.target.value;
+          updatedConditions[rowProps.rowIndex][fieldname].curie = event.target.value;
         }
       }
       setExperimentalConditions(updatedConditions);
@@ -49,9 +49,9 @@ export const ConditionGeneOntologyEditor = ({ rowProps, searchService, setExperi
   };
 
 
-  const conditionGeneOntologyItemTemplate = (item) => {
-    if (rowProps.rowData.conditionGeneOntology) {
-      let inputValue = trimWhitespace(rowProps.rowData.conditionGeneOntology.curie.toLowerCase());
+  const singleOntologyItemTemplate = (item) => {
+    if (rowProps.rowData[fieldname]) {
+      let inputValue = trimWhitespace(rowProps.rowData[fieldname].curie.toLowerCase());
       if (autocompleteSelectedItem.synonyms && autocompleteSelectedItem.synonyms.length>0){
         for(let i in autocompleteSelectedItem.synonyms){
           if(autocompleteSelectedItem.synonyms[i].toString().toLowerCase().indexOf(inputValue)<0){
@@ -94,17 +94,17 @@ export const ConditionGeneOntologyEditor = ({ rowProps, searchService, setExperi
   return (
     <div>
       <AutoComplete
-        id = {rowProps.rowData.conditionGeneOntology ? rowProps.rowData.conditionGeneOntology.curie : null}
+        id = {rowProps.rowData[fieldname] ? rowProps.rowData[fieldname].curie : null}
         panelStyle={{ width: '15%', display: 'flex', maxHeight: '350px'}}
         field="curie"
-        value={rowProps.rowData.conditionGeneOntology ? rowProps.rowData.conditionGeneOntology.curie : null}
-        suggestions={filteredConditionGeneOntologies}
-        itemTemplate={conditionGeneOntologyItemTemplate}
-        completeMethod={searchConditionGeneOntology}
+        value={rowProps.rowData[fieldname] ? rowProps.rowData[fieldname].curie : null}
+        suggestions={filteredSingleOntologies}
+        itemTemplate={singleOntologyItemTemplate}
+        completeMethod={searchSingleOntology}
         onHide={(e) => op.current.hide(e)}
-        onChange={(e) => onConditionGeneOntologyEditorValueChange(e)}
+        onChange={(e) => onSingleOntologyEditorValueChange(e)}
       />
-      <ConditionGeneOntologyTooltip op={op} autocompleteSelectedItem={autocompleteSelectedItem} inputValue={rowProps.rowData.conditionGeneOntology ? trimWhitespace(rowProps.rowData.conditionGeneOntology.curie.toLowerCase()) : null}/>
+      <SingleOntologyTooltip op={op} autocompleteSelectedItem={autocompleteSelectedItem} inputValue={rowProps.rowData[fieldname] ? trimWhitespace(rowProps.rowData[fieldname].curie.toLowerCase()) : null}/>
     </div>
   )
 };

--- a/src/main/cliapp/src/components/SingleOntologyTooltip.js
+++ b/src/main/cliapp/src/components/SingleOntologyTooltip.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Tooltip} from "primereact/tooltip";
 
-export function ConditionGeneOntologyTooltip({ op, autocompleteSelectedItem }) {
+export function SingleOntologyTooltip({ op, autocompleteSelectedItem }) {
 
   return (
     <>

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
@@ -247,11 +247,11 @@ export const ExperimentalConditionsTable = () => {
       }
     };
 
-  const singleOntologyEditorTemplate = (props, fieldname, endpoint) => {
+  const singleOntologyEditorTemplate = (props, fieldname, endpoint, autocomplete) => {
     return (
       <>
         <SingleOntologyEditor
-          autocompleteFields={["curie", "name", "crossReferences.curie", "secondaryIdentifiers", "synonyms"]}
+          autocompleteFields={autocomplete}
           rowProps={props}
           searchService={searchService}
           setExperimentalConditions={setExperimentalConditions}
@@ -265,6 +265,8 @@ export const ExperimentalConditionsTable = () => {
       </>
     );
   };
+  
+  const curieAutocompleteFields = ["curie", "name", "crossReferences.curie", "secondaryIdentifiers", "synonyms"];
 
   const columns = [
     {
@@ -290,7 +292,7 @@ export const ExperimentalConditionsTable = () => {
       body: conditionClassBodyTemplate,
       filter : true, 
       filterElement: filterComponentTemplate("conditionClassFilter", ["conditionClass.curie", "conditionClass.name"]),
-      editor: (props) => singleOntologyEditorTemplate(props, "conditionClass", "zecoterm")
+      editor: (props) => singleOntologyEditorTemplate(props, "conditionClass", "zecoterm", curieAutocompleteFields)
     },
     {
       field:"conditionId.name",
@@ -299,7 +301,7 @@ export const ExperimentalConditionsTable = () => {
       body: conditionIdBodyTemplate,
       filter: true, 
       filterElement: filterComponentTemplate("conditionIdFilter", ["conditionId.curie", "conditionId.name"]),
-      editor: (props) => singleOntologyEditorTemplate(props, "conditionId", "experimentalconditionontologyterm")
+      editor: (props) => singleOntologyEditorTemplate(props, "conditionId", "experimentalconditionontologyterm", curieAutocompleteFields)
     },
     {
       field:"conditionGeneOntology.name",
@@ -307,7 +309,7 @@ export const ExperimentalConditionsTable = () => {
       sortable: isEnabled,
       filter: true, 
       filterElement: filterComponentTemplate("conditionGeneOntologyFilter", ["conditionGeneOntology.curie", "conditionGeneOntology.name"]),
-      editor: (props) => singleOntologyEditorTemplate(props, "conditionGeneOntology", "goterm"),
+      editor: (props) => singleOntologyEditorTemplate(props, "conditionGeneOntology", "goterm", curieAutocompleteFields),
       body: conditionGeneOntologyBodyTemplate
     },
     {
@@ -317,7 +319,7 @@ export const ExperimentalConditionsTable = () => {
       body: conditionChemicalBodyTemplate,
       filter: true, 
       filterElement: filterComponentTemplate("conditionChemicalFilter", ["conditionChemical.curie", "conditionChemical.name"]),
-      editor: (props) => singleOntologyEditorTemplate(props, "conditionChemical", "chemicalterm")
+      editor: (props) => singleOntologyEditorTemplate(props, "conditionChemical", "chemicalterm", curieAutocompleteFields)
     },
     {
       field:"conditionAnatomy.name",
@@ -326,7 +328,7 @@ export const ExperimentalConditionsTable = () => {
       body: conditionAnatomyBodyTemplate,
       filter: true, 
       filterElement: filterComponentTemplate("conditionAnatomyFilter", ["conditionAnatomy.curie", "conditionAnatomy.name"]),
-      editor: (props) => singleOntologyEditorTemplate(props, "conditionAnatomy", "anatomicalterm")
+      editor: (props) => singleOntologyEditorTemplate(props, "conditionAnatomy", "anatomicalterm", curieAutocompleteFields)
     },
     {
       field:"conditionTaxon.curie",
@@ -335,7 +337,7 @@ export const ExperimentalConditionsTable = () => {
       body: conditionTaxonBodyTemplate,
       filter: true, 
       filterElement: filterComponentTemplate("conditionTaxonFilter", ["conditionTaxon.curie", "conditionTaxon.name"]),
-      editor: (props) => singleOntologyEditorTemplate(props, "conditionTaxon", "ncbitaxonterm")
+      editor: (props) => singleOntologyEditorTemplate(props, "conditionTaxon", "ncbitaxonterm", curieAutocompleteFields)
     },
     {
       field:"conditionQuantity",

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
@@ -11,8 +11,8 @@ import { FilterComponent } from '../../components/FilterComponent'
 import { MultiSelect } from 'primereact/multiselect';
 import { ErrorMessageComponent } from '../../components/ErrorMessageComponent';
 import { returnSorted, trimWhitespace } from '../../utils/utils';
-import { ConditionGeneOntologyEditor } from './ConditionGeneOntologyEditor';
 import { ExperimentalConditionService } from '../../service/ExperimentalConditionService';
+import { SingleOntologyEditor } from '../../components/SingleOntologyEditor';
 
 export const ExperimentalConditionsTable = () => {
 
@@ -240,23 +240,25 @@ export const ExperimentalConditionsTable = () => {
       }
     };
 
-  const conditionGeneOntologyEditorTemplate = (props) => {
-      return (
-          <>
-            <ConditionGeneOntologyEditor
-                autocompleteFields={["curie", "name", "crossReferences.curie", "secondaryIdentifiers", "synonyms"]}
-                rowProps={props}
-                searchService={searchService}
-                setExperimentalConditions={setExperimentalConditions}
-            />
-              <ErrorMessageComponent
-                errorMessages={errorMessages[props.rowIndex]}
-                errorField={"conditionGeneOntology"}
-            />
-          </>
-      );
+  const singleOntologyEditorTemplate = (props, fieldname, endpoint) => {
+    return (
+      <>
+        <SingleOntologyEditor
+          autocompleteFields={["curie", "name", "crossReferences.curie", "secondaryIdentifiers", "synonyms"]}
+          rowProps={props}
+          searchService={searchService}
+          setExperimentalConditions={setExperimentalConditions}
+          fieldname={fieldname}
+          endpoint={endpoint}
+        />
+        <ErrorMessageComponent
+          errorMessages={errorMessages[props.rowIndex]}
+          errorField={fieldname}
+        />
+      </>
+    );
   };
-  
+
   const columns = [
     {
       field: "uniqueId",
@@ -280,7 +282,8 @@ export const ExperimentalConditionsTable = () => {
       sortable: isEnabled, 
       body: conditionClassBodyTemplate,
       filter : true, 
-      filterElement: filterComponentTemplate("conditionClassFilter", ["conditionClass.curie", "conditionClass.name"])
+      filterElement: filterComponentTemplate("conditionClassFilter", ["conditionClass.curie", "conditionClass.name"]),
+      editor: (props) => singleOntologyEditorTemplate(props, "conditionClass", "zecoterm")
     },
     {
       field:"conditionId.name",
@@ -288,7 +291,8 @@ export const ExperimentalConditionsTable = () => {
       sortable: isEnabled,
       body: conditionIdBodyTemplate,
       filter: true, 
-      filterElement: filterComponentTemplate("conditionIdFilter", ["conditionId.curie", "conditionId.name"])
+      filterElement: filterComponentTemplate("conditionIdFilter", ["conditionId.curie", "conditionId.name"]),
+      editor: (props) => singleOntologyEditorTemplate(props, "conditionId", "experimentalconditionontologyterm")
     },
     {
       field:"conditionGeneOntology.name",
@@ -296,7 +300,7 @@ export const ExperimentalConditionsTable = () => {
       sortable: isEnabled,
       filter: true, 
       filterElement: filterComponentTemplate("conditionGeneOntologyFilter", ["conditionGeneOntology.curie", "conditionGeneOntology.name"]),
-      editor: (props) => conditionGeneOntologyEditorTemplate(props),
+      editor: (props) => singleOntologyEditorTemplate(props, "conditionGeneOntology", "goterm"),
       body: conditionGeneOntologyBodyTemplate
     },
     {
@@ -305,7 +309,8 @@ export const ExperimentalConditionsTable = () => {
       sortable: isEnabled,
       body: conditionChemicalBodyTemplate,
       filter: true, 
-      filterElement: filterComponentTemplate("conditionChemicalFilter", ["conditionChemical.curie", "conditionChemical.name"])
+      filterElement: filterComponentTemplate("conditionChemicalFilter", ["conditionChemical.curie", "conditionChemical.name"]),
+      editor: (props) => singleOntologyEditorTemplate(props, "conditionChemical", "chemicalterm")
     },
     {
       field:"conditionAnatomy.name",
@@ -313,7 +318,8 @@ export const ExperimentalConditionsTable = () => {
       sortable: isEnabled,
       body: conditionAnatomyBodyTemplate,
       filter: true, 
-      filterElement: filterComponentTemplate("conditionAnatomyFilter", ["conditionAnatomy.curie", "conditionAnatomy.name"])
+      filterElement: filterComponentTemplate("conditionAnatomyFilter", ["conditionAnatomy.curie", "conditionAnatomy.name"]),
+      editor: (props) => singleOntologyEditorTemplate(props, "conditionAnatomy", "anatomicalterm")
     },
     {
       field:"conditionTaxon.curie",

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
@@ -129,14 +129,13 @@ export const ExperimentalConditionsTable = () => {
         }
       }
       mutation.mutate(updatedRow, {
-          onSuccess: (data, variables, context) => {
+          onSuccess: (response, variables, context) => {
             toast_topright.current.show({ severity: 'success', summary: 'Successful', detail: 'Row Updated' });
 
             let conditions = [...experimentalConditions];
-            console.log(data);
-            const columns = Object.keys(data.data.entity);
+            const columns = Object.keys(response.data.entity);
             columns.forEach(column => {
-              conditions[event.index][column] = data.data.entity[column];
+              conditions[event.index][column] = response.data.entity[column];
             });
             setExperimentalConditions(conditions);
             const errorMessagesCopy = errorMessages;

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
@@ -119,18 +119,25 @@ export const ExperimentalConditionsTable = () => {
         delete event.data.conditionGeneOntology;
       }
       let updatedRow = JSON.parse(JSON.stringify(event.data));//deep copy
-      if (event.data.conditionGeneOntology && Object.keys(event.data.conditionGeneOntology).length >= 1) {
-          event.data.conditionGeneOntology.curie = trimWhitespace(event.data.conditionGeneOntology.curie);
-          updatedRow.conditionGeneOntology = {};
-          updatedRow.conditionGeneOntology = event.data.conditionGeneOntology;
+      
+      const curieFields = ["conditionClass", "conditionId", "conditionAnatomy", "conditionTaxon", "conditionGeneOntolgy", "conditionChemical"];
+      for (var ix = 0; ix < curieFields.length; ix++) {
+        if (event.data[curieFields[ix]] && Object.keys(event.data[curieFields[ix]]).length >= 1) {
+          event.data[curieFields[ix]].curie = trimWhitespace(event.data[curieFields[ix]].curie);
+          updatedRow[curieFields[ix]] = {};
+          updatedRow[curieFields[ix]] = event.data[curieFields[ix]];
+        }
       }
-
       mutation.mutate(updatedRow, {
           onSuccess: (data, variables, context) => {
             toast_topright.current.show({ severity: 'success', summary: 'Successful', detail: 'Row Updated' });
 
             let conditions = [...experimentalConditions];
-            conditions[event.index].conditionGeneOntology = data.data.entity.conditionGeneOntology;
+            console.log(data);
+            const columns = Object.keys(data.data.entity);
+            columns.forEach(column => {
+              conditions[event.index][column] = data.data.entity[column];
+            });
             setExperimentalConditions(conditions);
             const errorMessagesCopy = errorMessages;
             errorMessagesCopy[event.index] = {};
@@ -327,7 +334,8 @@ export const ExperimentalConditionsTable = () => {
       sortable: isEnabled,
       body: conditionTaxonBodyTemplate,
       filter: true, 
-      filterElement: filterComponentTemplate("conditionTaxonFilter", ["conditionTaxon.curie", "conditionTaxon.name"])
+      filterElement: filterComponentTemplate("conditionTaxonFilter", ["conditionTaxon.curie", "conditionTaxon.name"]),
+      editor: (props) => singleOntologyEditorTemplate(props, "conditionTaxon", "ncbitaxonterm")
     },
     {
       field:"conditionQuantity",

--- a/src/main/java/org/alliancegenome/curation_api/controllers/crud/ontology/AnatomicalTermCrudController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/crud/ontology/AnatomicalTermCrudController.java
@@ -1,0 +1,24 @@
+package org.alliancegenome.curation_api.controllers.crud.ontology;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.alliancegenome.curation_api.base.controllers.BaseOntologyTermController;
+import org.alliancegenome.curation_api.dao.ontology.AnatomicalTermDAO;
+import org.alliancegenome.curation_api.interfaces.crud.ontology.AnatomicalTermCrudInterface;
+import org.alliancegenome.curation_api.model.entities.ontology.AnatomicalTerm;
+import org.alliancegenome.curation_api.services.ontology.AnatomicalTermService;
+
+@RequestScoped
+public class AnatomicalTermCrudController extends BaseOntologyTermController<AnatomicalTermService, AnatomicalTerm, AnatomicalTermDAO> implements AnatomicalTermCrudInterface {
+
+    @Inject AnatomicalTermService anatomicalTermService;
+
+    @Override
+    @PostConstruct
+    public void init() {
+        setService(anatomicalTermService, AnatomicalTerm.class);
+    }
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/controllers/crud/ontology/ChemicalTermCrudController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/crud/ontology/ChemicalTermCrudController.java
@@ -1,0 +1,24 @@
+package org.alliancegenome.curation_api.controllers.crud.ontology;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.alliancegenome.curation_api.base.controllers.BaseOntologyTermController;
+import org.alliancegenome.curation_api.dao.ontology.ChemicalTermDAO;
+import org.alliancegenome.curation_api.interfaces.crud.ontology.ChemicalTermCrudInterface;
+import org.alliancegenome.curation_api.model.entities.ontology.ChemicalTerm;
+import org.alliancegenome.curation_api.services.ontology.ChemicalTermService;
+
+@RequestScoped
+public class ChemicalTermCrudController extends BaseOntologyTermController<ChemicalTermService, ChemicalTerm, ChemicalTermDAO> implements ChemicalTermCrudInterface {
+
+    @Inject ChemicalTermService chemicalTermService;
+
+    @Override
+    @PostConstruct
+    public void init() {
+        setService(chemicalTermService, ChemicalTerm.class);
+    }
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/controllers/crud/ontology/ExperimentalConditionOntologyTermCrudController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/crud/ontology/ExperimentalConditionOntologyTermCrudController.java
@@ -1,0 +1,24 @@
+package org.alliancegenome.curation_api.controllers.crud.ontology;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.alliancegenome.curation_api.base.controllers.BaseOntologyTermController;
+import org.alliancegenome.curation_api.dao.ontology.ExperimentalConditionOntologyTermDAO;
+import org.alliancegenome.curation_api.interfaces.crud.ontology.ExperimentalConditionOntologyTermCrudInterface;
+import org.alliancegenome.curation_api.model.entities.ontology.ExperimentalConditionOntologyTerm;
+import org.alliancegenome.curation_api.services.ontology.ExperimentalConditionOntologyTermService;
+
+@RequestScoped
+public class ExperimentalConditionOntologyTermCrudController extends BaseOntologyTermController<ExperimentalConditionOntologyTermService, ExperimentalConditionOntologyTerm, ExperimentalConditionOntologyTermDAO> implements ExperimentalConditionOntologyTermCrudInterface {
+
+    @Inject ExperimentalConditionOntologyTermService experimentalConditionOntologyTermService;
+
+    @Override
+    @PostConstruct
+    public void init() {
+        setService(experimentalConditionOntologyTermService, ExperimentalConditionOntologyTerm.class);
+    }
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/controllers/crud/ontology/OntologyTermCrudController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/crud/ontology/OntologyTermCrudController.java
@@ -1,0 +1,24 @@
+package org.alliancegenome.curation_api.controllers.crud.ontology;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.alliancegenome.curation_api.base.controllers.BaseOntologyTermController;
+import org.alliancegenome.curation_api.dao.ontology.OntologyTermDAO;
+import org.alliancegenome.curation_api.interfaces.crud.ontology.OntologyTermCrudInterface;
+import org.alliancegenome.curation_api.model.entities.ontology.OntologyTerm;
+import org.alliancegenome.curation_api.services.ontology.OntologyTermService;
+
+@RequestScoped
+public class OntologyTermCrudController extends BaseOntologyTermController<OntologyTermService, OntologyTerm, OntologyTermDAO> implements OntologyTermCrudInterface {
+
+    @Inject OntologyTermService ontologyTermService;
+
+    @Override
+    @PostConstruct
+    public void init() {
+        setService(ontologyTermService, OntologyTerm.class);
+    }
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/dao/ontology/AnatomicalTermDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ontology/AnatomicalTermDAO.java
@@ -1,0 +1,15 @@
+package org.alliancegenome.curation_api.dao.ontology;
+
+import org.alliancegenome.curation_api.base.dao.BaseSQLDAO;
+import org.alliancegenome.curation_api.model.entities.ontology.AnatomicalTerm;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class AnatomicalTermDAO extends BaseSQLDAO<AnatomicalTerm> {
+
+    protected AnatomicalTermDAO() {
+        super(AnatomicalTerm.class);
+    }
+    
+}

--- a/src/main/java/org/alliancegenome/curation_api/dao/ontology/ExperimentalConditionOntologyTermDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ontology/ExperimentalConditionOntologyTermDAO.java
@@ -1,0 +1,15 @@
+package org.alliancegenome.curation_api.dao.ontology;
+
+import org.alliancegenome.curation_api.base.dao.BaseSQLDAO;
+import org.alliancegenome.curation_api.model.entities.ontology.ExperimentalConditionOntologyTerm;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ExperimentalConditionOntologyTermDAO extends BaseSQLDAO<ExperimentalConditionOntologyTerm> {
+
+    protected ExperimentalConditionOntologyTermDAO() {
+        super(ExperimentalConditionOntologyTerm.class);
+    }
+    
+}

--- a/src/main/java/org/alliancegenome/curation_api/dao/ontology/OntologyTermDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ontology/OntologyTermDAO.java
@@ -1,0 +1,15 @@
+package org.alliancegenome.curation_api.dao.ontology;
+
+import org.alliancegenome.curation_api.base.dao.BaseSQLDAO;
+import org.alliancegenome.curation_api.model.entities.ontology.OntologyTerm;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class OntologyTermDAO extends BaseSQLDAO<OntologyTerm> {
+
+    protected OntologyTermDAO() {
+        super(OntologyTerm.class);
+    }
+    
+}

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ontology/AnatomicalTermCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ontology/AnatomicalTermCrudInterface.java
@@ -1,0 +1,16 @@
+package org.alliancegenome.curation_api.interfaces.crud.ontology;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+
+import org.alliancegenome.curation_api.base.interfaces.BaseOntologyTermCrudInterface;
+import org.alliancegenome.curation_api.model.entities.ontology.AnatomicalTerm;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/anatomicalterm")
+@Tag(name = "CRUD - Ontology")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface AnatomicalTermCrudInterface extends BaseOntologyTermCrudInterface<AnatomicalTerm> {
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ontology/ChemicalTermCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ontology/ChemicalTermCrudInterface.java
@@ -1,0 +1,16 @@
+package org.alliancegenome.curation_api.interfaces.crud.ontology;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+
+import org.alliancegenome.curation_api.base.interfaces.BaseOntologyTermCrudInterface;
+import org.alliancegenome.curation_api.model.entities.ontology.ChemicalTerm;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/chemicalterm")
+@Tag(name = "CRUD - Ontology")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface ChemicalTermCrudInterface extends BaseOntologyTermCrudInterface<ChemicalTerm> {
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ontology/ExperimentalConditionOntologyTermCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ontology/ExperimentalConditionOntologyTermCrudInterface.java
@@ -1,0 +1,16 @@
+package org.alliancegenome.curation_api.interfaces.crud.ontology;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+
+import org.alliancegenome.curation_api.base.interfaces.BaseOntologyTermCrudInterface;
+import org.alliancegenome.curation_api.model.entities.ontology.ExperimentalConditionOntologyTerm;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/experimentalconditionontologyterm")
+@Tag(name = "CRUD - Ontology")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface ExperimentalConditionOntologyTermCrudInterface extends BaseOntologyTermCrudInterface<ExperimentalConditionOntologyTerm> {
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ontology/OntologyTermCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ontology/OntologyTermCrudInterface.java
@@ -1,0 +1,16 @@
+package org.alliancegenome.curation_api.interfaces.crud.ontology;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+
+import org.alliancegenome.curation_api.base.interfaces.BaseOntologyTermCrudInterface;
+import org.alliancegenome.curation_api.model.entities.ontology.OntologyTerm;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/ontologyterm")
+@Tag(name = "CRUD - Ontology")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface OntologyTermCrudInterface extends BaseOntologyTermCrudInterface<OntologyTerm> {
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/services/ExperimentalConditionService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ExperimentalConditionService.java
@@ -3,10 +3,13 @@ package org.alliancegenome.curation_api.services;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
+import javax.transaction.Transactional;
 
 import org.alliancegenome.curation_api.base.services.BaseCrudService;
 import org.alliancegenome.curation_api.dao.ExperimentalConditionDAO;
 import org.alliancegenome.curation_api.model.entities.ExperimentalCondition;
+import org.alliancegenome.curation_api.response.ObjectResponse;
+import org.alliancegenome.curation_api.services.helpers.validators.ExperimentalConditionValidator;
 
 @RequestScoped
 public class ExperimentalConditionService extends BaseCrudService<ExperimentalCondition, ExperimentalConditionDAO> {
@@ -14,10 +17,20 @@ public class ExperimentalConditionService extends BaseCrudService<ExperimentalCo
     @Inject
     ExperimentalConditionDAO experimentalConditionDAO;
     
+    @Inject
+    ExperimentalConditionValidator experimentalConditionValidator;
+    
     @Override
     @PostConstruct
     protected void init() {
         setSQLDao(experimentalConditionDAO);
+    }
+    
+    @Override
+    @Transactional
+    public ObjectResponse<ExperimentalCondition> update(ExperimentalCondition uiEntity) {
+        ExperimentalCondition dbEntity = experimentalConditionValidator.validateCondition(uiEntity);
+        return new ObjectResponse<ExperimentalCondition>(experimentalConditionDAO.persist(dbEntity));
     }
     
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/DiseaseAnnotationCurie.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/DiseaseAnnotationCurie.java
@@ -55,7 +55,7 @@ public abstract class DiseaseAnnotationCurie {
         return curie.getCurie();
     }
 
-    private static String getExperimentalConditionCurie(ExperimentalCondition cond) {
+    public static String getExperimentalConditionCurie(ExperimentalCondition cond) {
         CurieGeneratorHelper help = new CurieGeneratorHelper();
         if (cond.getConditionStatement() != null)
             help.add(cond.getConditionStatement());

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/ExperimentalConditionValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/ExperimentalConditionValidator.java
@@ -183,6 +183,9 @@ public class ExperimentalConditionValidator {
         }
         NCBITaxonTerm taxonTerm = ncbiTaxonTermDAO.find(uiEntity.getConditionTaxon().getCurie());
         if (taxonTerm == null) {
+            taxonTerm = ncbiTaxonTermDAO.downloadAndSave(uiEntity.getConditionTaxon().getCurie());
+        }
+        if (taxonTerm == null) {
             addMessageResponse(field, invalidMessage);
             return null;
         }

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/ExperimentalConditionValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/ExperimentalConditionValidator.java
@@ -1,0 +1,214 @@
+package org.alliancegenome.curation_api.services.helpers.validators;
+
+import java.util.*;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.alliancegenome.curation_api.dao.*;
+import org.alliancegenome.curation_api.dao.ontology.*;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
+import org.alliancegenome.curation_api.model.entities.*;
+import org.alliancegenome.curation_api.model.entities.ontology.*;
+import org.alliancegenome.curation_api.response.ObjectResponse;
+import org.alliancegenome.curation_api.services.helpers.diseaseAnnotations.DiseaseAnnotationCurie;
+import org.apache.commons.lang3.*;
+
+@RequestScoped
+public class ExperimentalConditionValidator {
+
+    @Inject
+    ExperimentalConditionDAO experimentalConditionDAO;
+    @Inject
+    GoTermDAO goTermDAO;
+    @Inject
+    ZecoTermDAO zecoTermDAO;
+    @Inject
+    AnatomicalTermDAO anatomicalTermDAO;
+    @Inject
+    ChemicalTermDAO chemicalTermDAO;
+    @Inject
+    ExperimentalConditionOntologyTermDAO ecOntologyTermDAO;
+    @Inject
+    NcbiTaxonTermDAO ncbiTaxonTermDAO;
+    
+    
+    protected String invalidMessage = "Not a valid entry";
+    protected String obsoleteMessage = "Obsolete term specified";
+    protected String requiredMessage = "Required field is empty";
+    
+    protected ObjectResponse<ExperimentalCondition> response;
+    
+    public ExperimentalCondition validateCondition(ExperimentalCondition uiEntity) {
+        response = new ObjectResponse<>(uiEntity);
+        String errorTitle = "Could not update ExperimentalCondition: [" + uiEntity.getUniqueId() + "]";
+        
+        Long id = uiEntity.getId();
+        if (id == null) {
+            addMessageResponse("No Experimental Condition ID provided");
+            throw new ApiErrorException(response);
+        }
+        ExperimentalCondition dbEntity = experimentalConditionDAO.find(id);
+        if (dbEntity == null) {
+            addMessageResponse("Could not find ExperimentalCondition with ID: [" + id + "]");
+            throw new ApiErrorException(response);
+            // do not continue validation for update if Disease Annotation ID has not been found
+        }
+        
+        ZecoTerm conditionClass = validateConditionClass(uiEntity, dbEntity);
+        if (conditionClass != null) dbEntity.setConditionClass(conditionClass);
+        
+        ExperimentalConditionOntologyTerm ecOntologyTerm = validateConditionId(uiEntity, dbEntity);
+        if (ecOntologyTerm != null) dbEntity.setConditionId(ecOntologyTerm);
+        
+        GOTerm conditionGeneOntology = validateConditionGeneOntology(uiEntity, dbEntity);
+        if (conditionGeneOntology != null) dbEntity.setConditionGeneOntology(conditionGeneOntology);
+        
+        AnatomicalTerm conditionAnatomy = validateConditionAnatomy(uiEntity, dbEntity);
+        if (conditionAnatomy != null) dbEntity.setConditionAnatomy(conditionAnatomy);
+        
+        ChemicalTerm conditionChemical = validateConditionChemical(uiEntity, dbEntity);
+        if (conditionChemical != null) dbEntity.setConditionChemical(conditionChemical);
+        
+        NCBITaxonTerm conditionTaxon = validateConditionTaxon(uiEntity, dbEntity);
+        if (conditionTaxon != null) dbEntity.setConditionTaxon(conditionTaxon);
+        
+        String conditionStatement = validateConditionStatement(uiEntity, dbEntity);
+        if (conditionStatement != null) dbEntity.setConditionStatement(conditionStatement);
+        
+        if (uiEntity.getConditionQuantity() != null) dbEntity.setConditionQuantity(uiEntity.getConditionQuantity());
+        
+        if (uiEntity.getPaperHandles() != null) dbEntity.setPaperHandles(uiEntity.getPaperHandles());
+        
+        dbEntity.setUniqueId(DiseaseAnnotationCurie.getExperimentalConditionCurie(dbEntity));
+        
+        if (response.hasErrors()) {
+            response.setErrorMessage(errorTitle);
+            throw new ApiErrorException(response);
+        }
+        
+        return dbEntity;
+    }
+    
+    public ZecoTerm validateConditionClass(ExperimentalCondition uiEntity, ExperimentalCondition dbEntity) {
+        String field = "conditionClass";
+        if (ObjectUtils.isEmpty(uiEntity.getConditionClass()) || StringUtils.isEmpty(uiEntity.getConditionClass().getCurie())) {
+            addMessageResponse(field, requiredMessage);
+            return null;
+        }
+        ZecoTerm zecoTerm = zecoTermDAO.find(uiEntity.getConditionClass().getCurie());
+        if (zecoTerm == null) {
+            addMessageResponse(field, invalidMessage);
+            return null;
+        }
+        else if (zecoTerm.getObsolete() && !zecoTerm.getCurie().equals(dbEntity.getConditionClass().getCurie())) {
+            addMessageResponse(field, obsoleteMessage);
+            return null;
+        }
+        return zecoTerm;
+    }
+    
+    public ExperimentalConditionOntologyTerm validateConditionId(ExperimentalCondition uiEntity, ExperimentalCondition dbEntity) {
+        String field = "conditionId";
+        if (ObjectUtils.isEmpty(uiEntity.getConditionId()) || StringUtils.isEmpty(uiEntity.getConditionId().getCurie())) {
+            return null;
+        }
+        ExperimentalConditionOntologyTerm ecOntologyTerm = ecOntologyTermDAO.find(uiEntity.getConditionId().getCurie());
+        if (ecOntologyTerm == null) {
+            addMessageResponse(field, invalidMessage);
+            return null;
+        }
+        else if (ecOntologyTerm.getObsolete() && !ecOntologyTerm.getCurie().equals(dbEntity.getConditionId().getCurie())) {
+            addMessageResponse(field, obsoleteMessage);
+            return null;
+        }
+        return ecOntologyTerm;
+    }
+    
+    public GOTerm validateConditionGeneOntology(ExperimentalCondition uiEntity, ExperimentalCondition dbEntity) {
+        String field = "conditionGeneOntology";
+        if (ObjectUtils.isEmpty(uiEntity.getConditionGeneOntology()) || StringUtils.isEmpty(uiEntity.getConditionGeneOntology().getCurie())) {
+            return null;
+        }
+        GOTerm goTerm = goTermDAO.find(uiEntity.getConditionGeneOntology().getCurie());
+        if (goTerm == null) {
+            addMessageResponse(field, invalidMessage);
+            return null;
+        }
+        else if (goTerm.getObsolete() && !goTerm.getCurie().equals(dbEntity.getConditionGeneOntology().getCurie())) {
+            addMessageResponse(field, obsoleteMessage);
+            return null;
+        }
+        return goTerm;
+    }
+    
+    public AnatomicalTerm validateConditionAnatomy(ExperimentalCondition uiEntity, ExperimentalCondition dbEntity) {
+        String field = "conditionAnatomy";
+        if (ObjectUtils.isEmpty(uiEntity.getConditionAnatomy()) || StringUtils.isEmpty(uiEntity.getConditionAnatomy().getCurie())) {
+            return null;
+        }
+        AnatomicalTerm anatomicalTerm = anatomicalTermDAO.find(uiEntity.getConditionAnatomy().getCurie());
+        if (anatomicalTerm == null) {
+            addMessageResponse(field, invalidMessage);
+            return null;
+        }
+        else if (anatomicalTerm.getObsolete() && !anatomicalTerm.getCurie().equals(dbEntity.getConditionAnatomy().getCurie())) {
+            addMessageResponse(field, obsoleteMessage);
+            return null;
+        }
+        return anatomicalTerm;
+    }
+    
+    public ChemicalTerm validateConditionChemical(ExperimentalCondition uiEntity, ExperimentalCondition dbEntity) {
+        String field = "conditionChemical";
+        if (ObjectUtils.isEmpty(uiEntity.getConditionChemical()) || StringUtils.isEmpty(uiEntity.getConditionChemical().getCurie())) {
+            return null;
+        }
+        ChemicalTerm chemicalTerm = chemicalTermDAO.find(uiEntity.getConditionChemical().getCurie());
+        if (chemicalTerm == null) {
+            addMessageResponse(field, invalidMessage);
+            return null;
+        }
+        else if (chemicalTerm.getObsolete() != null && chemicalTerm.getObsolete() && !chemicalTerm.getCurie().equals(dbEntity.getConditionChemical().getCurie())) {
+            addMessageResponse(field, obsoleteMessage);
+            return null;
+        }
+        return chemicalTerm;
+    }
+
+    public NCBITaxonTerm validateConditionTaxon(ExperimentalCondition uiEntity, ExperimentalCondition dbEntity) {
+        String field = "conditionTaxon";
+        if (ObjectUtils.isEmpty(uiEntity.getConditionTaxon()) || StringUtils.isEmpty(uiEntity.getConditionTaxon().getCurie())) {
+            return null;
+        }
+        NCBITaxonTerm taxonTerm = ncbiTaxonTermDAO.find(uiEntity.getConditionTaxon().getCurie());
+        if (taxonTerm == null) {
+            addMessageResponse(field, invalidMessage);
+            return null;
+        }
+        else if (taxonTerm.getObsolete() && !taxonTerm.getCurie().equals(dbEntity.getConditionTaxon().getCurie())) {
+            addMessageResponse(field, obsoleteMessage);
+            return null;
+        }
+        return taxonTerm;
+    }
+    
+    public String validateConditionStatement(ExperimentalCondition uiEntity, ExperimentalCondition dbEntity) {
+        String field = "conditionStatement";
+        String conditionStatement = uiEntity.getConditionStatement();
+        if (StringUtils.isEmpty(conditionStatement)) {
+            addMessageResponse(field, requiredMessage);
+            return null;
+        }
+        return conditionStatement;
+    }
+
+    
+    protected void addMessageResponse(String message) {
+        response.setErrorMessage(message);
+    }
+    
+    protected void addMessageResponse(String fieldName, String message) {
+        response.addErrorMessage(fieldName, message);
+    }
+}

--- a/src/main/java/org/alliancegenome/curation_api/services/ontology/AnatomicalTermService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ontology/AnatomicalTermService.java
@@ -1,0 +1,25 @@
+package org.alliancegenome.curation_api.services.ontology;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.alliancegenome.curation_api.base.services.BaseOntologyTermService;
+import org.alliancegenome.curation_api.dao.ontology.AnatomicalTermDAO;
+import org.alliancegenome.curation_api.model.entities.ontology.AnatomicalTerm;
+
+import lombok.extern.jbosslog.JBossLog;
+
+@JBossLog
+@RequestScoped
+public class AnatomicalTermService extends BaseOntologyTermService<AnatomicalTerm, AnatomicalTermDAO> {
+
+    @Inject AnatomicalTermDAO anatomicalTermDAO;
+
+    @Override
+    @PostConstruct
+    protected void init() {
+        setSQLDao(anatomicalTermDAO);
+    }
+    
+}

--- a/src/main/java/org/alliancegenome/curation_api/services/ontology/ChemicalTermService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ontology/ChemicalTermService.java
@@ -1,0 +1,25 @@
+package org.alliancegenome.curation_api.services.ontology;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.alliancegenome.curation_api.base.services.BaseOntologyTermService;
+import org.alliancegenome.curation_api.dao.ontology.ChemicalTermDAO;
+import org.alliancegenome.curation_api.model.entities.ontology.ChemicalTerm;
+
+import lombok.extern.jbosslog.JBossLog;
+
+@JBossLog
+@RequestScoped
+public class ChemicalTermService extends BaseOntologyTermService<ChemicalTerm, ChemicalTermDAO> {
+
+    @Inject ChemicalTermDAO chemicalTermDAO;
+
+    @Override
+    @PostConstruct
+    protected void init() {
+        setSQLDao(chemicalTermDAO);
+    }
+    
+}

--- a/src/main/java/org/alliancegenome/curation_api/services/ontology/ExperimentalConditionOntologyTermService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ontology/ExperimentalConditionOntologyTermService.java
@@ -1,0 +1,25 @@
+package org.alliancegenome.curation_api.services.ontology;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.alliancegenome.curation_api.base.services.BaseOntologyTermService;
+import org.alliancegenome.curation_api.dao.ontology.ExperimentalConditionOntologyTermDAO;
+import org.alliancegenome.curation_api.model.entities.ontology.ExperimentalConditionOntologyTerm;
+
+import lombok.extern.jbosslog.JBossLog;
+
+@JBossLog
+@RequestScoped
+public class ExperimentalConditionOntologyTermService extends BaseOntologyTermService<ExperimentalConditionOntologyTerm, ExperimentalConditionOntologyTermDAO> {
+
+    @Inject ExperimentalConditionOntologyTermDAO experimentalConditionOntologyTermDAO;
+
+    @Override
+    @PostConstruct
+    protected void init() {
+        setSQLDao(experimentalConditionOntologyTermDAO);
+    }
+    
+}

--- a/src/main/java/org/alliancegenome/curation_api/services/ontology/OntologyTermService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ontology/OntologyTermService.java
@@ -1,0 +1,25 @@
+package org.alliancegenome.curation_api.services.ontology;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.alliancegenome.curation_api.base.services.BaseOntologyTermService;
+import org.alliancegenome.curation_api.dao.ontology.OntologyTermDAO;
+import org.alliancegenome.curation_api.model.entities.ontology.OntologyTerm;
+
+import lombok.extern.jbosslog.JBossLog;
+
+@JBossLog
+@RequestScoped
+public class OntologyTermService extends BaseOntologyTermService<OntologyTerm, OntologyTermDAO> {
+
+    @Inject OntologyTermDAO ontologyTermDAO;
+
+    @Override
+    @PostConstruct
+    protected void init() {
+        setSQLDao(ontologyTermDAO);
+    }
+    
+}


### PR DESCRIPTION
Create general method for editing of single-value ontology fields.
Create Java components for AnatomicalTerm, ChemicalTerm, and
ExperimentalConditionOntologyTerm to allow autocomplete.
Remove redundant ConditionGeneOntology code.