### PR TITLE
Switch vocabularyTerm lookup from search to find

### DIFF
--- a/src/main/cliapp/src/service/useControlledVocabularyService.js
+++ b/src/main/cliapp/src/service/useControlledVocabularyService.js
@@ -28,7 +28,7 @@ export function useControlledVocabularyService(termType) {
 
   useQuery(['terms', termType],
     () => {
-      return searchService.search("vocabularyterm", 15, 0, null, { "vocabFilter": { "vocabulary.name": { "queryString": termType } } })
+      return searchService.find("vocabularyterm", 15, 0, {"vocabulary.name" : termType } )
     }, {
       onSuccess: (data) => {
         if (data.results) {


### PR DESCRIPTION
Search for 'Annotation notes' was also returning 'Disease note
types' terms, presumably due to the 'note' part.