### PR TITLE
SCRUM-737 Disable sgdStrainBackground editing for non-gene annotations

### DIFF
--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/DiseaseAnnotationsTable.js
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/DiseaseAnnotationsTable.js
@@ -770,6 +770,15 @@ export const DiseaseAnnotationsTable = () => {
     />);
   }
 
+  const sgdStrainBackgroundEditorSelector = (props) => {
+    if (props.rowData.type === "GeneDiseaseAnnotation") {
+      return sgdStrainBackgroundEditorTemplate(props);
+    }
+    else {
+      return null;
+    }
+  }
+
   const columns = [{
     field: "uniqueId",
     header: "Unique Id",
@@ -869,7 +878,7 @@ export const DiseaseAnnotationsTable = () => {
     sortable: isEnabled,
     filter: true,
     filterElement: filterComponentInputTextTemplate("sgdStrainBackgroundFilter", ["sgdStrainBackground.name", "sgdStrainBackground.curie"]),
-    editor: (props) => sgdStrainBackgroundEditorTemplate(props),
+    editor: (props) => sgdStrainBackgroundEditorSelector(props),
     body: sgdStrainBackgroundBodyTemplate
   },
   {


### PR DESCRIPTION
sgdStrainBackground is only a property of gene disease annotations, so editing needs to be disabled for non-gene annotations.