### PR TITLE
Make ExperimentalCondition uniqueId generation consistent

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/DiseaseAnnotationCurie.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/DiseaseAnnotationCurie.java
@@ -80,12 +80,14 @@ public abstract class DiseaseAnnotationCurie {
 
     public static String getExperimentalConditionCurie(ExperimentalConditionFmsDTO dto) {
         CurieGeneratorHelper curie = new CurieGeneratorHelper();
-        curie.add(dto.getConditionClassId());
         curie.add(dto.getConditionStatement());
+        curie.add(dto.getConditionClassId());
         curie.add(dto.getConditionId());
-        curie.add(dto.getConditionQuantity());
-        curie.add(dto.getNcbiTaxonId());
         curie.add(dto.getAnatomicalOntologyId());
+        curie.add(dto.getChemicalOntologyId());
+        curie.add(dto.getGeneOntologyId());
+        curie.add(dto.getNcbiTaxonId());
+        curie.add(dto.getConditionQuantity());
         return curie.getCurie();
     }
 


### PR DESCRIPTION
uniqueId was being generated in a different order for FMS loads and new loads / UI entries, so edits result in a duplication of entries