### PR TITLE
SCRUM-1415 Set UniqueID for new ExperimentalCondition entities

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/ExperimentalConditionService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ExperimentalConditionService.java
@@ -62,6 +62,7 @@ public class ExperimentalConditionService extends BaseCrudService<ExperimentalCo
         SearchResponse<ExperimentalCondition> searchResponse = experimentalConditionDAO.findByField("uniqueId", uniqueId);
         if (searchResponse == null || searchResponse.getSingleResult() == null) {
             experimentalCondition = new ExperimentalCondition();
+            experimentalCondition.setUniqueId(uniqueId);
         } else {
             experimentalCondition = searchResponse.getSingleResult();
         }


### PR DESCRIPTION
UniqueId was getting constructed and checked for existing entries, but not set for new entries.