### PR TITLE
SCRUM-1522 Cascade delete of bulkloadfile to bulkloadhistory

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoadFileHistory.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoadFileHistory.java
@@ -8,6 +8,8 @@ import javax.persistence.*;
 
 import org.alliancegenome.curation_api.base.entity.GeneratedAuditedObject;
 import org.alliancegenome.curation_api.view.View;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.envers.Audited;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -38,6 +40,7 @@ public class BulkLoadFileHistory extends GeneratedAuditedObject {
     private Long completedRecords = 0l;
     
     @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private BulkLoadFile bulkLoadFile;
 
     @JsonView(View.BulkLoadFileHistory.class)

--- a/src/main/resources/db/migration/v0.4.0.4__agr_curation_api.sql
+++ b/src/main/resources/db/migration/v0.4.0.4__agr_curation_api.sql
@@ -1,0 +1,4 @@
+-- Need to drop index to allow hibernate to recreate it with new definition (as hibernate doesn't replace constraints by itself)
+-- This change does require the application to be restarted after initial start-up (so hibernate would create the new constraint)!
+ALTER TABLE "bulkloadfilehistory"
+	DROP CONSTRAINT IF EXISTS "fkk9bvfu4248kgyyrupeii7t6m0";


### PR DESCRIPTION
Deletion of bulkloadfile entries fails due to FK constraint to bulkloadhistory.  Need to cascade delete to be able to clean up old FMS loads.

Restart required after initial merge to rebuild constraints following deletion by migration.