### PR TITLE
SCRUM-1569 Save null values on editing VocabularyTerm abbreviation/definition

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/VocabularyTermValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/VocabularyTermValidator.java
@@ -44,11 +44,17 @@ public class VocabularyTermValidator extends AuditedObjectValidator<VocabularyTe
         String name = validateName(uiEntity);
         dbEntity.setName(name);
         
-        if (!StringUtils.isBlank(uiEntity.getAbbreviation()))
+        if (!StringUtils.isBlank(uiEntity.getAbbreviation())) {
             dbEntity.setAbbreviation(uiEntity.getAbbreviation());
-            
-        if (!StringUtils.isBlank(uiEntity.getDefinition()))
+        } else {
+            dbEntity.setAbbreviation(null);
+        }
+        
+        if (!StringUtils.isBlank(uiEntity.getDefinition())) {
             dbEntity.setDefinition(uiEntity.getDefinition());
+        } else {
+            dbEntity.setDefinition(null);
+        }
         
         if (uiEntity.getObsolete() == null) {
             dbEntity.setObsolete(false);


### PR DESCRIPTION
Fixes bug where values for (non-required) abbreviation and definition fields were only saved if non-empty string