### PR TITLE
SCRUM-1598 Added DiseaseAnnotationUpdate view to conditions

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ConditionRelation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ConditionRelation.java
@@ -44,7 +44,7 @@ public class ConditionRelation extends UniqueIdAuditedObject {
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToMany
-	@JsonView({View.FieldsAndLists.class})
+	@JsonView({View.FieldsAndLists.class, View.DiseaseAnnotationUpdate.class})
 	private List<ExperimentalCondition> conditions;
 
 


### PR DESCRIPTION
This change is meant to include the conditions array under the coditionRelations entity on return from the DiseaseAnnotations update endpoints.

I don't know if this is the best solution for this, but it worked on my local machine.  