### PR TITLE
SCRUM-1630 & SCRUM-1632 Fix bug in relatedNote deletion

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/DiseaseAnnotationValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/DiseaseAnnotationValidator.java
@@ -167,16 +167,18 @@ public class DiseaseAnnotationValidator extends AuditedObjectValidator<DiseaseAn
 	
 	public List<Note> validateRelatedNotes(DiseaseAnnotation uiEntity, DiseaseAnnotation dbEntity) {
 		List<Note> validatedNotes = new ArrayList<Note>();
-		for (Note note : uiEntity.getRelatedNotes()) {
-			ObjectResponse<Note> noteResponse = noteValidator.validateNote(note, VocabularyConstants.DISEASE_ANNOTATION_NOTE_TYPES_VOCABULARY);
-			if (noteResponse.getEntity() == null) {
-				Map<String, String> errors = noteResponse.getErrorMessages();
-				for (String field : errors.keySet()) {
-					addMessageResponse("relatedNotes", field + " - " + errors.get(field));
+		if (uiEntity.getRelatedNotes() != null) {
+			for (Note note : uiEntity.getRelatedNotes()) {
+				ObjectResponse<Note> noteResponse = noteValidator.validateNote(note, VocabularyConstants.DISEASE_ANNOTATION_NOTE_TYPES_VOCABULARY);
+				if (noteResponse.getEntity() == null) {
+					Map<String, String> errors = noteResponse.getErrorMessages();
+					for (String field : errors.keySet()) {
+						addMessageResponse("relatedNotes", field + " - " + errors.get(field));
+					}
+					return null;
 				}
-				return null;
+				validatedNotes.add(noteResponse.getEntity());
 			}
-			validatedNotes.add(noteResponse.getEntity());
 		}
 		
 		List<Long> previousNoteIds = dbEntity.getRelatedNotes().stream().map(Note::getId).collect(Collectors.toList());
@@ -185,6 +187,9 @@ public class DiseaseAnnotationValidator extends AuditedObjectValidator<DiseaseAn
 		for (Long id : idsToRemove) {
 			noteService.delete(id);
 		}
+		
+		if (CollectionUtils.isEmpty(validatedNotes))
+			return null;
 		
 		return validatedNotes;
 	}
@@ -273,10 +278,8 @@ public class DiseaseAnnotationValidator extends AuditedObjectValidator<DiseaseAn
 			dbEntity.setConditionRelations(conditionRelations);
 		}
 		
-		if (CollectionUtils.isNotEmpty(uiEntity.getRelatedNotes())) {
-			List<Note> relatedNotes = validateRelatedNotes(uiEntity, dbEntity);
-			if (relatedNotes != null) dbEntity.setRelatedNotes(relatedNotes);
-		}
+		List<Note> relatedNotes = validateRelatedNotes(uiEntity, dbEntity);
+		dbEntity.setRelatedNotes(relatedNotes);
 		
 		if (CollectionUtils.isNotEmpty(uiEntity.getDiseaseQualifiers()))
 			dbEntity.setDiseaseQualifiers(uiEntity.getDiseaseQualifiers());

--- a/src/test/java/org/alliancegenome/curation_api/crud/controllers/DiseaseAnnotationITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/crud/controllers/DiseaseAnnotationITCase.java
@@ -1182,6 +1182,24 @@ public class DiseaseAnnotationITCase {
 				then().
 				statusCode(200).
 				body("", is(Collections.emptyMap()));
+		
+		Long nextDeletedNoteId = relatedNotes.get(0).getId();
+		editedDiseaseAnnotation.setRelatedNotes(null);
+		
+		RestAssured.given().
+			contentType("application/json").
+			body(editedDiseaseAnnotation).
+			when().
+			put("/api/gene-disease-annotation").
+			then().
+			statusCode(200);
+
+		RestAssured.given().
+			when().
+			get("/api/note/" + nextDeletedNoteId).
+			then().
+			statusCode(200).
+			body("", is(Collections.emptyMap()));
 	}
 
 	private GeneDiseaseAnnotation getGeneDiseaseAnnotation() {


### PR DESCRIPTION
Deletion of notes previously only worked if there were notes remaining for the DA after the deletion.