### PR TITLE
SCRUM-1733 Fix bug with manual entry for Reference fields

### DIFF
--- a/src/main/cliapp/src/components/AutocompleteEditor.js
+++ b/src/main/cliapp/src/components/AutocompleteEditor.js
@@ -91,7 +91,7 @@ export const AutocompleteEditor = (
 		if (typeof event.target.value === "object") {
 			if (isReference) {
 				updatedRows[rowProps.rowIndex][fieldName] = event.target.value;
-				setFieldValue(updatedRows[rowProps.rowIndex][fieldName].primaryCrossReference);
+				setFieldValue(updatedRows[rowProps.rowIndex][fieldName].submittedCrossReference);
 			} else if (valueSelector) {
 				updatedRows[rowProps.rowIndex][fieldName].curie = valueSelector(event.target.value);
 				setFieldValue(valueSelector(event.target.value));
@@ -100,8 +100,13 @@ export const AutocompleteEditor = (
 				setFieldValue(updatedRows[rowProps.rowIndex][fieldName]?.curie);
 			}
 		} else {
-			updatedRows[rowProps.rowIndex][fieldName].curie = event.target.value;
-			setFieldValue(updatedRows[rowProps.rowIndex][fieldName]?.curie);
+			if (isReference) {
+				updatedRows[rowProps.rowIndex][fieldName].submittedCrossReference = event.target.value;
+				setFieldValue(updatedRows[rowProps.rowIndex][fieldName]?.submittedCrossReference);
+			} else {
+				updatedRows[rowProps.rowIndex][fieldName].curie = event.target.value;
+				setFieldValue(updatedRows[rowProps.rowIndex][fieldName]?.curie);
+			}
 		}
 
 	};

--- a/src/main/cliapp/src/components/AutocompleteEditor.js
+++ b/src/main/cliapp/src/components/AutocompleteEditor.js
@@ -216,7 +216,6 @@ export const AutocompleteEditor = (
 }
 
 const EditorTooltip = ({op, autocompleteSelectedItem}) => {
-	console.log(autocompleteSelectedItem);
 	return (
 		<>
 			<Tooltip ref={op} style={{width: '450px', maxWidth: '450px'}} position={'right'} mouseTrack

--- a/src/main/java/org/alliancegenome/curation_api/controllers/crud/ReferenceCrudController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/crud/ReferenceCrudController.java
@@ -27,7 +27,7 @@ public class ReferenceCrudController extends BaseCrudController<ReferenceService
 	}
 
 	@Override
-	public ObjectResponse<Reference> synchroniseReference(String primaryCrossReference) {
-		return referenceService.synchroniseReference(primaryCrossReference);
+	public ObjectResponse<Reference> synchroniseReference(String submittedCrossReference) {
+		return referenceService.synchroniseReference(submittedCrossReference);
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ReferenceCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ReferenceCrudInterface.java
@@ -9,6 +9,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.alliancegenome.curation_api.base.interfaces.BaseCurieCrudInterface;
+import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
 import org.alliancegenome.curation_api.model.entities.Reference;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.View;
@@ -23,6 +24,10 @@ import com.fasterxml.jackson.annotation.JsonView;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface ReferenceCrudInterface extends BaseCurieCrudInterface<Reference> {
 	
+	@Override
+	@JsonView(View.FieldsAndLists.class)
+	public ObjectResponse<Reference> get(@PathParam("submittedCrossReference") String submittedCrossReference);
+	
 	@GET
 	@Path("/sync")
 	public void synchroniseReferences();
@@ -30,5 +35,5 @@ public interface ReferenceCrudInterface extends BaseCurieCrudInterface<Reference
 	@GET
 	@Path("/sync/{primaryCrossReference}")
 	@JsonView(View.FieldsAndLists.class)
-	public ObjectResponse<Reference> synchroniseReference(@PathParam("primaryCrossReference") String primaryCrossReference);
+	public ObjectResponse<Reference> synchroniseReference(@PathParam("submittedCrossReference") String submittedCrossReference);
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/ReferenceService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ReferenceService.java
@@ -90,7 +90,6 @@ public class ReferenceService extends BaseCrudService<Reference, ReferenceDAO> {
 	}
 		
 	protected Reference copyLiteratureReferenceFields(LiteratureReference litRef, Reference ref, String searchCurie) {
-		log.info(litRef);
 		ref.setCurie(litRef.getCurie());
 		
 		ArrayList<String> otherXrefs = new ArrayList<String>();
@@ -101,8 +100,6 @@ public class ReferenceService extends BaseCrudService<Reference, ReferenceDAO> {
 				otherXrefs.add(litXref.getCurie());	
 			} 
 		}
-		log.info(ref.getPrimaryCrossReference());
-		log.info(otherXrefs);
 		Collections.sort(otherXrefs);	
 		if (ref.getPrimaryCrossReference() == null || !ref.getPrimaryCrossReference().startsWith("PMID:")) {
 			if (otherXrefs.size() > 1) {
@@ -114,7 +111,6 @@ public class ReferenceService extends BaseCrudService<Reference, ReferenceDAO> {
 		} else {
 			ref.setSecondaryCrossReferences(otherXrefs);
 		}
-		log.info(ref);
 		return ref;
 	}
 


### PR DESCRIPTION
Previously, manually entering a value in the Reference field (instead of picking from the Autocomplete) caused a blank screen error.