### PR TITLE
SCRUM-1756 Fix saving of notes attached to DAs

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/DiseaseAnnotationValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/DiseaseAnnotationValidator.java
@@ -188,7 +188,6 @@ public class DiseaseAnnotationValidator extends AuditedObjectValidator<DiseaseAn
 		
 		List<Long> previousNoteIds = dbEntity.getRelatedNotes().stream().map(Note::getId).collect(Collectors.toList());
 		List<Long> validatedNoteIds = validatedNotes.stream().map(Note::getId).collect(Collectors.toList());
-		List<Long> idsToPersist = ListUtils.subtract(validatedNoteIds, previousNoteIds);
 		for (Note validatedNote: validatedNotes) {
 			if (!previousNoteIds.contains(validatedNote.getId())) {
 				noteDAO.persist(validatedNote);

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/DiseaseAnnotationValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/DiseaseAnnotationValidator.java
@@ -12,6 +12,7 @@ import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.BiologicalEntityDAO;
 import org.alliancegenome.curation_api.dao.GeneDAO;
+import org.alliancegenome.curation_api.dao.NoteDAO;
 import org.alliancegenome.curation_api.dao.ReferenceDAO;
 import org.alliancegenome.curation_api.dao.VocabularyTermDAO;
 import org.alliancegenome.curation_api.dao.ontology.DoTermDAO;
@@ -26,7 +27,6 @@ import org.alliancegenome.curation_api.model.entities.VocabularyTerm;
 import org.alliancegenome.curation_api.model.entities.ontology.DOTerm;
 import org.alliancegenome.curation_api.model.entities.ontology.EcoTerm;
 import org.alliancegenome.curation_api.response.ObjectResponse;
-import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.NoteService;
 import org.alliancegenome.curation_api.services.ReferenceService;
 import org.apache.commons.collections.CollectionUtils;
@@ -59,6 +59,8 @@ public class DiseaseAnnotationValidator extends AuditedObjectValidator<DiseaseAn
 	NoteValidator noteValidator;
 	@Inject
 	NoteService noteService;
+	@Inject
+	NoteDAO noteDAO;
 	@Inject
 	ConditionRelationValidator conditionRelationValidator;
 	
@@ -186,6 +188,12 @@ public class DiseaseAnnotationValidator extends AuditedObjectValidator<DiseaseAn
 		
 		List<Long> previousNoteIds = dbEntity.getRelatedNotes().stream().map(Note::getId).collect(Collectors.toList());
 		List<Long> validatedNoteIds = validatedNotes.stream().map(Note::getId).collect(Collectors.toList());
+		List<Long> idsToPersist = ListUtils.subtract(validatedNoteIds, previousNoteIds);
+		for (Note validatedNote: validatedNotes) {
+			if (!previousNoteIds.contains(validatedNote.getId())) {
+				noteDAO.persist(validatedNote);
+			}
+		}
 		List<Long> idsToRemove = ListUtils.subtract(previousNoteIds, validatedNoteIds);
 		for (Long id : idsToRemove) {
 			noteService.delete(id);

--- a/src/test/java/org/alliancegenome/curation_api/crud/controllers/DiseaseAnnotationITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/crud/controllers/DiseaseAnnotationITCase.java
@@ -1184,6 +1184,7 @@ public class DiseaseAnnotationITCase {
 				body("", is(Collections.emptyMap()));
 		
 		Long nextDeletedNoteId = relatedNotes.get(0).getId();
+		relatedNotes.remove(0);
 		editedDiseaseAnnotation.setRelatedNotes(null);
 		
 		RestAssured.given().
@@ -1200,6 +1201,56 @@ public class DiseaseAnnotationITCase {
 			then().
 			statusCode(200).
 			body("", is(Collections.emptyMap()));
+	}
+	
+	
+	@Test
+	@Order(26)
+	public void addRelatedNote() {
+		
+		Note note = new Note();
+		note.setNoteType(noteType);
+		note.setFreeText("Test text 3");
+		note.setInternal(false);
+		relatedNotes.add(note);
+		
+		GeneDiseaseAnnotation editedDiseaseAnnotation = getGeneDiseaseAnnotation();
+		editedDiseaseAnnotation.setDiseaseRelation(geneDiseaseRelation);
+		editedDiseaseAnnotation.setNegated(true);
+		editedDiseaseAnnotation.setObject(testDoTerm2);
+		editedDiseaseAnnotation.setDataProvider("TEST2");
+		editedDiseaseAnnotation.setSubject(testGene2);
+		editedDiseaseAnnotation.setEvidenceCodes(testEcoTerms2);
+		editedDiseaseAnnotation.setModEntityId("TEST:Mod0001");
+		editedDiseaseAnnotation.setSecondaryDataProvider("TEST3");
+		editedDiseaseAnnotation.setGeneticSex(geneticSex);
+		editedDiseaseAnnotation.setDiseaseGeneticModifier(testBiologicalEntity);
+		editedDiseaseAnnotation.setDiseaseGeneticModifierRelation(diseaseGeneticModifierRelation);
+		editedDiseaseAnnotation.setAnnotationType(annotationType);
+		editedDiseaseAnnotation.setDiseaseQualifiers(diseaseQualifiers);
+		editedDiseaseAnnotation.setWith(testWithGenes);
+		editedDiseaseAnnotation.setSgdStrainBackground(testAgm2);
+		editedDiseaseAnnotation.setCreatedBy(testPerson);
+		editedDiseaseAnnotation.setDateCreated(testDate);
+		editedDiseaseAnnotation.setRelatedNotes(relatedNotes);
+		editedDiseaseAnnotation.setSingleReference(testReference);
+		
+		RestAssured.given().
+				contentType("application/json").
+				body(editedDiseaseAnnotation).
+				when().
+				put("/api/gene-disease-annotation").
+				then().
+				statusCode(200);
+		
+		RestAssured.given().
+				when().
+				get("/api/gene-disease-annotation/findBy/" + GENE_DISEASE_ANNOTATION).
+				then().
+				statusCode(200).
+				body("entity.relatedNotes", hasSize(1)).
+				body("entity.relatedNotes[0].freeText", is("Test text 3"));
+		
 	}
 
 	private GeneDiseaseAnnotation getGeneDiseaseAnnotation() {


### PR DESCRIPTION
Saving of new notes attached to DAs is broken on alpha.  It's not clear to me how this is working on beta, or how that has been lost for alpha, but this fixes it!