### PR TITLE
SCRUM-1765 Bring DA relatedNotes editing in line with conditionRelations 

### DIFF
--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/ConditionRelationsDialog.js
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/ConditionRelationsDialog.js
@@ -83,25 +83,29 @@ export const ConditionRelationsDialog = ({
 		errorMessagesCopy[event.index] = {};
 		let _editingRows = { ...editingRows };
 		if (result.isError) {
+			let reported = false;
 			Object.keys(result.data).forEach((field) => {
 				let messageObject = {
 					severity: "error",
 					message: result.data[field]
 				};
 				errorMessagesCopy[event.index][field] = messageObject;
-				toast_topright.current.show([
-					{ life: 7000, severity: 'error', summary: 'Update error: ',
-					detail: 'Could not update condition relation [' + localConditionRelations[event.index].id + ']', sticky: false }
-				]);
+				if (!reported) {
+					toast_topright.current.show([
+						{ life: 7000, severity: 'error', summary: 'Update error: ',
+						detail: 'Could not update condition relation [' + localConditionRelations[event.index].id + ']', sticky: false }
+					]);
+					reported = true;
+				}
 			});
 		} else {
-			delete _editingRows[event.index];
+			delete _editingRows[event.index];	
+			compareChangesInRelations(event.data,event.index);
 		}
 		setErrorMessages(errorMessagesCopy);
 		let _localConditionRelations = [...localConditionRelations];
 		_localConditionRelations[event.index] = event.data;
-			setEditingRows(_editingRows);	
-			compareChangesInRelations(event.data,event.index);
+		setEditingRows(_editingRows);
 		setLocalConditionRelations(_localConditionRelations);
 		
 	};

--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/DiseaseAnnotationsTable.js
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/DiseaseAnnotationsTable.js
@@ -242,7 +242,7 @@ export const DiseaseAnnotationsTable = () => {
 						</span>
 					</Button>
 				</div>
-					<ErrorMessageComponent errorMessages={errorMessages[props.rowIndex]} errorField={"relatedNotes.freeText"} style={{ 'fontSize': '1em' }}/>
+					<ErrorMessageComponent errorMessages={errorMessages[props.rowIndex]} errorField={"relatedNotes"} style={{ 'fontSize': '1em' }}/>
 				</>
 			)
 		} else {
@@ -261,7 +261,7 @@ export const DiseaseAnnotationsTable = () => {
 							</span>
 						</Button>
 					</div>
-					<ErrorMessageComponent errorMessages={errorMessages[props.rowIndex]} errorField={"relatedNotes.freeText"} style={{ 'fontSize': '1em' }}/>
+					<ErrorMessageComponent errorMessages={errorMessages[props.rowIndex]} errorField={"relatedNotes"} style={{ 'fontSize': '1em' }}/>
 				</>
 			)
 		}

--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/RelatedNotesDialog.js
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/RelatedNotesDialog.js
@@ -7,7 +7,7 @@ import { Toast } from 'primereact/toast';
 import { ColumnGroup } from 'primereact/columngroup';
 import { Row } from 'primereact/row';
 import { InputTextAreaEditor } from '../../components/InputTextAreaEditor';
-import { ErrorMessageComponent } from '../../components/ErrorMessageComponent';
+import { DialogErrorMessageComponent } from '../../components/DialogErrorMessageComponent';
 import { EllipsisTableCell } from '../../components/EllipsisTableCell';
 import { TrueFalseDropdown } from '../../components/TrueFalseDropDownSelector';
 import { useControlledVocabularyService } from '../../service/useControlledVocabularyService';
@@ -21,7 +21,7 @@ export const RelatedNotesDialog = ({
 													setErrorMessagesMainRow
 												}) => {
 	const { originalRelatedNotes, isInEdit, dialog, rowIndex, mainRowProps } = originalRelatedNotesData;
-	const [localRelateNotes, setLocalRelateNotes] = useState(null) ;
+	const [localRelatedNotes, setLocalRelatedNotes] = useState(null) ;
 	const [editingRows, setEditingRows] = useState({});
 	const [errorMessages, setErrorMessages] = useState([]);
 	const booleanTerms = useControlledVocabularyService('generic_boolean_terms');
@@ -34,7 +34,7 @@ export const RelatedNotesDialog = ({
 
 	const showDialogHandler = () => {
 		let _localRelatedNotes = cloneNotes(originalRelatedNotes);
-		setLocalRelateNotes(_localRelatedNotes);
+		setLocalRelatedNotes(_localRelatedNotes);
 
 		if(isInEdit){
 			let rowsObject = {};
@@ -60,24 +60,22 @@ export const RelatedNotesDialog = ({
 		let _editingRows = { ...editingRows };
 		delete _editingRows[event.index];
 		setEditingRows(_editingRows);
-		let _localRelateNotes = [...localRelateNotes];//add new note support
+		let _localRelatedNotes = [...localRelatedNotes];//add new note support
 		if(originalRelatedNotes && originalRelatedNotes[event.index]){
-			let dataKey = _localRelateNotes[event.index].dataKey;
-			_localRelateNotes[event.index] = global.structuredClone(originalRelatedNotes[event.index]);
-			_localRelateNotes[event.index].dataKey = dataKey;
-			setLocalRelateNotes(_localRelateNotes);
-		}else{
-
+			let dataKey = _localRelatedNotes[event.index].dataKey;
+			_localRelatedNotes[event.index] = global.structuredClone(originalRelatedNotes[event.index]);
+			_localRelatedNotes[event.index].dataKey = dataKey;
+			setLocalRelatedNotes(_localRelatedNotes);
 		}
 		const errorMessagesCopy = errorMessages;
 		errorMessagesCopy[event.index] = {};
 		setErrorMessages(errorMessagesCopy);
-		if(hasEdited && hasEdited.current === false)
-			compareChangesInNotes(event.data,event.index);
+		compareChangesInNotes(event.data,event.index);
 	};
 
 	const compareChangesInNotes = (data,index) => {
 		if(originalRelatedNotes && originalRelatedNotes[index]) {
+			hasEdited.current = false;
 			if (data.noteType.name !== originalRelatedNotes[index].noteType.name) {
 				hasEdited.current = true;
 			}
@@ -90,12 +88,36 @@ export const RelatedNotesDialog = ({
 		}
 	};
 
-	const onRowEditSave = (event) => {
-		rowsInEdit.current--;
-		let _localRelateNotes = [...localRelateNotes];
-		_localRelateNotes[event.index] = event.data;
-		setLocalRelateNotes(_localRelateNotes);
-		compareChangesInNotes(event.data,event.index);
+	const onRowEditSave = async(event) => {
+		const result = await validateNote(localRelatedNotes[event.index]);
+		const errorMessagesCopy = [...errorMessages];
+		errorMessagesCopy[event.index] = {};
+		let _editingRows = { ...editingRows };
+		if (result.isError) {
+			let reported = false;
+			Object.keys(result.data).forEach((field) => {
+				let messageObject = {
+					severity: "error",
+					message: result.data[field]
+				};
+				errorMessagesCopy[event.index][field] = messageObject;
+				if(!reported) {
+					toast_topright.current.show([
+						{ life: 7000, severity: 'error', summary: 'Update error: ',
+						detail: 'Could not update note [' + localRelatedNotes[event.index].id + ']', sticky: false }
+					]);
+					reported = true;
+				}
+			});
+		} else {
+			delete _editingRows[event.index];
+			compareChangesInNotes(event.data,event.index);
+		}
+		setErrorMessages(errorMessagesCopy);
+		let _localRelatedNotes = [...localRelatedNotes];
+		_localRelatedNotes[event.index] = event.data;
+		setEditingRows(_editingRows);
+		setLocalRelatedNotes(_localRelatedNotes);
 	};
 
 	const hideDialog = () => {
@@ -107,18 +129,14 @@ export const RelatedNotesDialog = ({
 			};
 		});
 		let _localRelatedNotes = [];
-		setLocalRelateNotes(_localRelatedNotes);
+		setLocalRelatedNotes(_localRelatedNotes);
 	};
 
-	const validateNotes = async (notes) => {
-		const validationResultsArray = [];
-		let _notes = global.structuredClone(notes);
-		for (const note of _notes) {
-			delete note.dataKey;
-			const result = await validationService.validate('note', note);
-			validationResultsArray.push(result);
-		}
-		return validationResultsArray;
+	const validateNote = async (note) => {
+		let _note = global.structuredClone(note);
+		delete _note.dataKey;
+		const result = await validationService.validate('note', _note);
+		return result;
 	};
 
 	const cloneNotes = (clonableNotes) => {
@@ -135,8 +153,8 @@ export const RelatedNotesDialog = ({
 	};
 
 	const createNewNoteHandler = (event) => {
-		let cnt = localRelateNotes ? localRelateNotes.length : 0;
-		localRelateNotes.push({
+		let cnt = localRelatedNotes ? localRelatedNotes.length : 0;
+		localRelatedNotes.push({
 			dataKey : cnt,
 			noteType: {
 				name : ""
@@ -145,58 +163,32 @@ export const RelatedNotesDialog = ({
 		let _editingRows = { ...editingRows, ...{ [`${cnt}`]: true } };
 		setEditingRows(_editingRows);
 		rowsInEdit.current++;
-		hasEdited.current = true;
 	};
 
 	const saveDataHandler = async () => {
-		const resultsArray = await validateNotes(localRelateNotes);
-		const errorMessagesCopy = [...errorMessages];
-		let keepDialogOpen = false;
-		let anyErrors = false;
+		setErrorMessages([]);
+		for (const note of localRelatedNotes) {
+			delete note.dataKey;
+		}
+		mainRowProps.rowData.relatedNotes = localRelatedNotes;
+		let updatedAnnotations = [...mainRowProps.props.value];
+		updatedAnnotations[rowIndex].relatedNotes = localRelatedNotes;
 
-		resultsArray.forEach((result, index) => {
-			const { isError, data } = result;
-			if (isError) {
-				errorMessagesCopy[index] = {};
-				Object.keys(data).forEach((field) => {
-					let messageObject = {
-						severity: "error",
-						message: data[field]
-					};
-					errorMessagesCopy[index][field] = messageObject;
-					setErrorMessages(errorMessagesCopy);
-					keepDialogOpen = true;
-					anyErrors = true;
-				});
-			}
-		});
-
-		if (!anyErrors) {
-			setErrorMessages([]);
-			for (const note of localRelateNotes) {
-				delete note.dataKey;
-			}
-			mainRowProps.rowData.relatedNotes = localRelateNotes;
-			let updatedAnnotations = [...mainRowProps.props.value];
-			updatedAnnotations[rowIndex].relatedNotes = localRelateNotes;
-			keepDialogOpen = false;
-
-			if(hasEdited.current){
-				const errorMessagesCopy = errorMessagesMainRow;
-				let messageObject = {
-					severity: "warn",
-					message: "Pending Edits!"
-				};
-				errorMessagesCopy[rowIndex] = {};
-				errorMessagesCopy[rowIndex]["relatedNotes.freeText"] = messageObject;
-				setErrorMessagesMainRow({...errorMessagesCopy});
-			}
-		};
+		if(hasEdited.current){
+			const errorMessagesCopy = errorMessagesMainRow;
+			let messageObject = {
+				severity: "warn",
+				message: "Pending Edits!"
+			};
+			errorMessagesCopy[rowIndex] = {};
+			errorMessagesCopy[rowIndex]["relatedNotes"] = messageObject;
+			setErrorMessagesMainRow({...errorMessagesCopy});
+		}
 
 		setOriginalRelatedNotesData((originalRelatedNotesData) => {
 				return {
 					...originalRelatedNotesData,
-					dialog: keepDialogOpen,
+					dialog: false,
 				}
 			}
 		);
@@ -215,8 +207,8 @@ export const RelatedNotesDialog = ({
 	};
 
 	const onInternalEditorValueChange = (props, event) => {
-		let _localRelateNotes = [...localRelateNotes];
-		_localRelateNotes[props.rowIndex].internal = event.value.name;
+		let _localRelatedNotes = [...localRelatedNotes];
+		_localRelatedNotes[props.rowIndex].internal = event.value.name;
 	}
 
 	const internalEditor = (props) => {
@@ -228,14 +220,14 @@ export const RelatedNotesDialog = ({
 					props={props}
 					field={"internal"}
 				/>
-				<ErrorMessageComponent errorMessages={errorMessages[props.rowIndex]} errorField={"internal"} />
+				<DialogErrorMessageComponent errorMessages={errorMessages[props.rowIndex]} errorField={"internal"} />
 			</>
 		);
 	};
 
 	const onNoteTypeEditorValueChange = (props, event) => {
-		let _localRelateNotes = [...localRelateNotes];
-		_localRelateNotes[props.rowIndex].noteType = event.value;
+		let _localRelatedNotes = [...localRelatedNotes];
+		_localRelatedNotes[props.rowIndex].noteType = event.value;
 	};
 
 	const noteTypeEditor = (props) => {
@@ -249,14 +241,14 @@ export const RelatedNotesDialog = ({
 					showClear={false}
 					dataKey='id'
 				/>
-				<ErrorMessageComponent errorMessages={errorMessages[props.rowIndex]} errorField={"noteType"} />
+				<DialogErrorMessageComponent errorMessages={errorMessages[props.rowIndex]} errorField={"noteType"} />
 			</>
 		);
 	};
 
 	const onFreeTextEditorValueChange = (event, props) => {
-		let _localRelateNotes = [...localRelateNotes];
-		_localRelateNotes[props.rowIndex].freeText = event.target.value;
+		let _localRelatedNotes = [...localRelatedNotes];
+		_localRelatedNotes[props.rowIndex].freeText = event.target.value;
 	};
 
 	const freeTextEditor = (props, fieldName, errorMessages) => {
@@ -271,7 +263,7 @@ export const RelatedNotesDialog = ({
 					rows={5}
 					columns={30}
 				/>
-				<ErrorMessageComponent errorMessages={errorMessages[props.rowIndex]} errorField={fieldName} />
+				<DialogErrorMessageComponent errorMessages={errorMessages[props.rowIndex]} errorField={fieldName} />
 			</>
 		);
 	};
@@ -290,13 +282,13 @@ export const RelatedNotesDialog = ({
 	}
 
 	const handleDeleteRelatedNote = (event, props) => {
-		let _localRelateNotes = global.structuredClone(localRelateNotes); 
+		let _localRelatedNotes = global.structuredClone(localRelatedNotes); 
 		if(props.dataKey){
-			_localRelateNotes.splice(props.dataKey, 1);
+			_localRelatedNotes.splice(props.dataKey, 1);
 		}else {
-			_localRelateNotes.splice(props.rowIndex, 1);
+			_localRelatedNotes.splice(props.rowIndex, 1);
 		}
-		setLocalRelateNotes(_localRelateNotes);
+		setLocalRelatedNotes(_localRelatedNotes);
 		hasEdited.current = true;
 	}
 
@@ -321,7 +313,7 @@ export const RelatedNotesDialog = ({
 			<Toast ref={toast_topright} position="top-right" />
 			<Dialog visible={dialog} className='w-6' modal onHide={hideDialog} closable={!isInEdit} onShow={showDialogHandler} footer={footerTemplate} resizable>
 				<h3>Related Notes</h3>
-				<DataTable value={localRelateNotes} dataKey="dataKey" showGridlines editMode='row' headerColumnGroup={headerGroup}
+				<DataTable value={localRelatedNotes} dataKey="dataKey" showGridlines editMode='row' headerColumnGroup={headerGroup}
 								editingRows={editingRows} onRowEditChange={onRowEditChange} ref={tableRef} onRowEditCancel={onRowEditCancel} onRowEditSave={(props) => onRowEditSave(props)}>
 					<Column rowEditor={isInEdit} style={{maxWidth: '7rem', display: isInEdit ? 'visible' : 'none'}} headerStyle={{width: '7rem', position: 'sticky'}}
 								bodyStyle={{textAlign: 'center'}} frozen headerClassName='surface-0' />

--- a/src/main/java/org/alliancegenome/curation_api/base/dao/BaseSQLDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/base/dao/BaseSQLDAO.java
@@ -103,7 +103,7 @@ public class BaseSQLDAO<E extends BaseEntity> extends BaseEntityDAO<E> {
 		results.setTotalResults(totalResults);
 		return results;
 	}
-
+	
 	@Transactional
 	public E merge(E entity) {
 		log.debug("SqlDAO: merge: " + entity);

--- a/src/main/java/org/alliancegenome/curation_api/dao/ReferenceDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ReferenceDAO.java
@@ -1,11 +1,20 @@
 package org.alliancegenome.curation_api.dao;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.persistence.Query;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 import javax.transaction.Transactional;
 
 import org.alliancegenome.curation_api.base.dao.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.Reference;
+import org.alliancegenome.curation_api.model.input.Pagination;
+import org.alliancegenome.curation_api.response.SearchResponse;
 
 @ApplicationScoped
 public class ReferenceDAO extends BaseSQLDAO<Reference> {
@@ -32,6 +41,31 @@ public class ReferenceDAO extends BaseSQLDAO<Reference> {
 	protected void deleteReferenceForeignKey(String table, String column, String originalCurie) {
 		Query jpqlQuery = entityManager.createNativeQuery("DELETE FROM " + table + " WHERE " + column + " = '" + originalCurie + "'");
 		jpqlQuery.executeUpdate();
+	}
+	
+	public SearchResponse<String> findAllCuries(Pagination pagination) {
+		CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+		CriteriaQuery<Reference> findQuery = cb.createQuery(myClass);
+		Root<Reference> rootEntry = findQuery.from(myClass);
+		CriteriaQuery<Reference> all = findQuery.select(rootEntry);
+
+		CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+		countQuery.select(cb.count(countQuery.from(myClass)));
+		Long totalResults = entityManager.createQuery(countQuery).getSingleResult();
+
+		TypedQuery<Reference> allQuery = entityManager.createQuery(all);
+		if(pagination != null && pagination.getLimit() != null && pagination.getPage() != null) {
+			int first = pagination.getPage() * pagination.getLimit();
+			if(first < 0) first = 0;
+			allQuery.setFirstResult(first);
+			allQuery.setMaxResults(pagination.getLimit());
+		}
+		SearchResponse<String> results = new SearchResponse<String>();
+		
+		List<String> resultCuries = allQuery.getResultStream().map(Reference::getCurie).collect(Collectors.toList());
+		results.setResults(resultCuries);
+		results.setTotalResults(totalResults);
+		return results;
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/ReferenceService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ReferenceService.java
@@ -107,9 +107,9 @@ public class ReferenceService extends BaseCrudService<Reference, ReferenceDAO> {
 		Boolean allSynced = false;
 		while (!allSynced) {
 			pagination.setPage(page);
-			SearchResponse<Reference> response = referenceDAO.findAll(pagination);
-			for (Reference ref : response.getResults()) {
-				synchroniseReference(ref);
+			SearchResponse<String> response = referenceDAO.findAllCuries(pagination);
+			for (String refCurie : response.getResults()) {
+				synchroniseReference(refCurie);
 			}
 			page = page + 1;
 			int nrSynced = limit * page;
@@ -154,16 +154,7 @@ public class ReferenceService extends BaseCrudService<Reference, ReferenceDAO> {
 		return ref;
 	}
 	
-	public void synchroniseReference(Reference ref) {
-		LiteratureReference litRef = fetchLiteratureServiceReference(ref.getCurie());
-		if (litRef == null) {
-			ref.setObsolete(true);
-			referenceDAO.merge(ref);
-		} else {	
-			copyLiteratureReferenceFields(litRef, ref);
-		}
-	}
-	
+	@Transactional
 	public ObjectResponse<Reference> synchroniseReference(String curie) {
 		Reference ref = referenceDAO.find(curie);
 		ObjectResponse<Reference> response = new ObjectResponse<>();
@@ -172,7 +163,6 @@ public class ReferenceService extends BaseCrudService<Reference, ReferenceDAO> {
 		LiteratureReference litRef = fetchLiteratureServiceReference(curie);
 		if (litRef == null) {
 			ref.setObsolete(true);
-			ref = referenceDAO.merge(ref);
 		} else {
 			ref = copyLiteratureReferenceFields(litRef, ref);
 		}

--- a/src/main/java/org/alliancegenome/curation_api/services/ReferenceService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ReferenceService.java
@@ -1,42 +1,22 @@
 package org.alliancegenome.curation_api.services;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.transaction.Transactional;
 
 import org.alliancegenome.curation_api.base.services.BaseCrudService;
-import org.alliancegenome.curation_api.dao.CrossReferenceDAO;
-import org.alliancegenome.curation_api.dao.LiteratureReferenceDAO;
 import org.alliancegenome.curation_api.dao.ReferenceDAO;
-import org.alliancegenome.curation_api.model.document.LiteratureCrossReference;
-import org.alliancegenome.curation_api.model.document.LiteratureReference;
-import org.alliancegenome.curation_api.model.entities.CrossReference;
 import org.alliancegenome.curation_api.model.entities.Reference;
-import org.alliancegenome.curation_api.model.input.Pagination;
 import org.alliancegenome.curation_api.response.ObjectResponse;
-import org.alliancegenome.curation_api.response.SearchResponse;
-import org.alliancegenome.curation_api.services.helpers.validators.ReferenceValidator;
-import org.apache.commons.collections.CollectionUtils;
+import org.alliancegenome.curation_api.services.helpers.references.ReferenceSynchronisationHelper;
 
-import lombok.extern.jbosslog.JBossLog;
-
-@JBossLog
 @RequestScoped
 public class ReferenceService extends BaseCrudService<Reference, ReferenceDAO> {
 
 	@Inject
 	ReferenceDAO referenceDAO;
 	@Inject
-	ReferenceValidator referenceValidator;
-	@Inject
-	LiteratureReferenceDAO literatureReferenceDAO;
-	@Inject
-	CrossReferenceDAO crossReferenceDAO;
+	ReferenceSynchronisationHelper refSyncHelper;
 	
 	@Override
 	@PostConstruct
@@ -44,131 +24,16 @@ public class ReferenceService extends BaseCrudService<Reference, ReferenceDAO> {
 		setSQLDao(referenceDAO);
 	}
 
-	public Reference retrieveFromLiteratureService(String curie) {
-		
-		LiteratureReference litRef = fetchLiteratureServiceReference(curie);
-		
-
-		if (litRef != null) {
-			Reference ref = new Reference();
-			ref = copyLiteratureReferenceFields(litRef, ref);
-		
-			return referenceDAO.merge(ref);
-		}
-		return null;
-	}
-	
-	protected LiteratureReference fetchLiteratureServiceReference(String curie) {
-		HashMap<String, String> searchDetails = new HashMap<>();
-		searchDetails.put("tokenOperator", "AND");
-		searchDetails.put("queryString", curie);
-		
-		HashMap<String, Object> searchField = new HashMap<>();
-		if (curie.startsWith("AGR")) {
-			searchField.put("curie", searchDetails);
-		} else {
-			searchField.put("cross_references.curie", searchDetails);
-		}
-			
-		HashMap<String, Object> filter = new HashMap<>();
-		filter.put("curieFilter", searchField);
-		
-		HashMap<String, Object> params = new HashMap<>();
-		params.put("searchFilters", filter);		
-		
-		Pagination pagination = new Pagination();
-		int limit = 50;
-		pagination.setLimit(limit);
-		int page = 0;
-		pagination.setPage(page);
-		SearchResponse<LiteratureReference> response = literatureReferenceDAO.searchByParams(pagination, params);
-		if (response != null) {
-			for (LiteratureReference result : response.getResults()) {
-				if (result.getCurie().equals(curie))
-					return result;
-				for (LiteratureCrossReference resultXref : result.getCross_references()) {
-					if (resultXref.getCurie().equals(curie))
-						return result;
-				}
-			}
-		} else {
-			return null;
-		}
-		
-		return null;
-	}
-		
-	public void synchroniseReferences() {
-		
-		Pagination pagination = new Pagination();
-		int limit = 500;
-		pagination.setLimit(limit);
-		int page = 0;
-		Boolean allSynced = false;
-		while (!allSynced) {
-			pagination.setPage(page);
-			SearchResponse<String> response = referenceDAO.findAllCuries(pagination);
-			for (String refCurie : response.getResults()) {
-				synchroniseReference(refCurie);
-			}
-			page = page + 1;
-			int nrSynced = limit * page;
-			if (nrSynced > response.getTotalResults().intValue()) {
-				nrSynced = response.getTotalResults().intValue();
-				allSynced = true;
-			}
-			log.info("Synchronised " + nrSynced + " of " + response.getTotalResults() + " Reference objects");
-		}
-	}
-	
-	protected Reference copyLiteratureReferenceFields(LiteratureReference litRef, Reference ref) {
-		String originalCurie = ref.getCurie();
-		if (!litRef.getCurie().equals(originalCurie)) {
-			ref = new Reference();
-			ref.setCurie(litRef.getCurie());
-		}
-		
-		List<CrossReference> xrefs = new ArrayList<CrossReference>();
-		for (LiteratureCrossReference litXref : litRef.getCross_references()) {
-			CrossReference xref = crossReferenceDAO.find(litXref.getCurie());
-			if (xref == null) {
-				xref = new CrossReference();
-				xref.setCurie(litXref.getCurie());
-				xref.setInternal(false);
-				xref.setObsolete(false);
-				xref = crossReferenceDAO.persist(xref);
-			} 
-			xrefs.add(xref);
-		}
-		if (CollectionUtils.isNotEmpty(xrefs))
-			ref.setCrossReferences(xrefs);
-		
-		Reference existingRef = referenceDAO.find(ref.getCurie());
-		if (existingRef == null)
-			ref = referenceDAO.merge(ref);
-		if (!ref.getCurie().equals(originalCurie) && originalCurie != null) {
-			referenceDAO.updateReferenceForeignKeys(originalCurie, ref.getCurie());
-			referenceDAO.remove(originalCurie);
-		}
-		
-		return ref;
-	}
-	
-	@Transactional
 	public ObjectResponse<Reference> synchroniseReference(String curie) {
-		Reference ref = referenceDAO.find(curie);
-		ObjectResponse<Reference> response = new ObjectResponse<>();
-		if (ref == null) return response;
-		
-		LiteratureReference litRef = fetchLiteratureServiceReference(curie);
-		if (litRef == null) {
-			ref.setObsolete(true);
-		} else {
-			ref = copyLiteratureReferenceFields(litRef, ref);
-		}
-		
-		response.setEntity(ref);
-		
-		return response;
+		return refSyncHelper.synchroniseReference(curie);
 	}
+	
+	public void synchroniseReferences() {
+		refSyncHelper.synchroniseReferences();
+	}
+
+	public Reference retrieveFromLiteratureService(String curie) {
+		return refSyncHelper.retrieveFromLiteratureService(curie);
+	}
+	
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/references/ReferenceSynchronisationHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/references/ReferenceSynchronisationHelper.java
@@ -1,0 +1,159 @@
+package org.alliancegenome.curation_api.services.helpers.references;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+
+import org.alliancegenome.curation_api.dao.CrossReferenceDAO;
+import org.alliancegenome.curation_api.dao.LiteratureReferenceDAO;
+import org.alliancegenome.curation_api.dao.ReferenceDAO;
+import org.alliancegenome.curation_api.model.document.LiteratureCrossReference;
+import org.alliancegenome.curation_api.model.document.LiteratureReference;
+import org.alliancegenome.curation_api.model.entities.CrossReference;
+import org.alliancegenome.curation_api.model.entities.Reference;
+import org.alliancegenome.curation_api.model.input.Pagination;
+import org.alliancegenome.curation_api.response.ObjectResponse;
+import org.alliancegenome.curation_api.response.SearchResponse;
+import org.apache.commons.collections.CollectionUtils;
+
+import lombok.extern.jbosslog.JBossLog;
+
+@JBossLog
+@RequestScoped
+public class ReferenceSynchronisationHelper {
+
+	@Inject ReferenceDAO referenceDAO;
+	@Inject LiteratureReferenceDAO literatureReferenceDAO;
+	@Inject CrossReferenceDAO crossReferenceDAO;
+	
+	public Reference retrieveFromLiteratureService(String curie) {
+		
+		LiteratureReference litRef = fetchLiteratureServiceReference(curie);
+		
+		if (litRef != null) {
+			Reference ref = new Reference();
+			ref = copyLiteratureReferenceFields(litRef, ref);
+		
+			return referenceDAO.merge(ref);
+		}
+		return null;
+	}
+	
+	protected LiteratureReference fetchLiteratureServiceReference(String curie) {
+		HashMap<String, String> searchDetails = new HashMap<>();
+		searchDetails.put("tokenOperator", "AND");
+		searchDetails.put("queryString", curie);
+		
+		HashMap<String, Object> searchField = new HashMap<>();
+		if (curie.startsWith("AGR")) {
+			searchField.put("curie", searchDetails);
+		} else {
+			searchField.put("cross_references.curie", searchDetails);
+		}
+			
+		HashMap<String, Object> filter = new HashMap<>();
+		filter.put("curieFilter", searchField);
+		
+		HashMap<String, Object> params = new HashMap<>();
+		params.put("searchFilters", filter);		
+		
+		Pagination pagination = new Pagination();
+		int limit = 50;
+		pagination.setLimit(limit);
+		int page = 0;
+		pagination.setPage(page);
+		SearchResponse<LiteratureReference> response = literatureReferenceDAO.searchByParams(pagination, params);
+		if (response != null) {
+			for (LiteratureReference result : response.getResults()) {
+				if (result.getCurie().equals(curie))
+					return result;
+				for (LiteratureCrossReference resultXref : result.getCross_references()) {
+					if (resultXref.getCurie().equals(curie))
+						return result;
+				}
+			}
+		} else {
+			return null;
+		}
+		
+		return null;
+	}
+		
+	public void synchroniseReferences() {
+		
+		Pagination pagination = new Pagination();
+		int limit = 500;
+		pagination.setLimit(limit);
+		int page = 0;
+		Boolean allSynced = false;
+		while (!allSynced) {
+			pagination.setPage(page);
+			SearchResponse<String> response = referenceDAO.findAllCuries(pagination);
+			for (String refCurie : response.getResults()) {
+				synchroniseReference(refCurie);
+			}
+			page = page + 1;
+			int nrSynced = limit * page;
+			if (nrSynced > response.getTotalResults().intValue()) {
+				nrSynced = response.getTotalResults().intValue();
+				allSynced = true;
+			}
+			log.info("Synchronised " + nrSynced + " of " + response.getTotalResults() + " Reference objects");
+		}
+	}
+	
+	protected Reference copyLiteratureReferenceFields(LiteratureReference litRef, Reference ref) {
+		String originalCurie = ref.getCurie();
+		if (!litRef.getCurie().equals(originalCurie)) {
+			ref = new Reference();
+			ref.setCurie(litRef.getCurie());
+		}
+		
+		List<CrossReference> xrefs = new ArrayList<CrossReference>();
+		for (LiteratureCrossReference litXref : litRef.getCross_references()) {
+			CrossReference xref = crossReferenceDAO.find(litXref.getCurie());
+			if (xref == null) {
+				xref = new CrossReference();
+				xref.setCurie(litXref.getCurie());
+				xref.setInternal(false);
+				xref.setObsolete(false);
+				xref = crossReferenceDAO.persist(xref);
+			} 
+			xrefs.add(xref);
+		}
+		if (CollectionUtils.isNotEmpty(xrefs))
+			ref.setCrossReferences(xrefs);
+		
+		Reference existingRef = referenceDAO.find(ref.getCurie());
+		if (existingRef == null)
+			ref = referenceDAO.merge(ref);
+		if (!ref.getCurie().equals(originalCurie) && originalCurie != null) {
+			referenceDAO.updateReferenceForeignKeys(originalCurie, ref.getCurie());
+			referenceDAO.remove(originalCurie);
+		}
+		
+		return ref;
+	}
+	
+	@Transactional
+	public ObjectResponse<Reference> synchroniseReference(String curie) {
+		Reference ref = referenceDAO.find(curie);
+		ObjectResponse<Reference> response = new ObjectResponse<>();
+		if (ref == null) return response;
+		
+		LiteratureReference litRef = fetchLiteratureServiceReference(curie);
+		if (litRef == null) {
+			ref.setObsolete(true);
+		} else {
+			ref = copyLiteratureReferenceFields(litRef, ref);
+		}
+		
+		response.setEntity(ref);
+		
+		return response;
+	}
+}


### PR DESCRIPTION
Validation occurs on row edit save rather than on clicking 'Keep Edits'.
'Keep Edits' button not enabled unless valid edits in place.
Fixes bugs in display of error messages.
Also fixes bug on conditionRelations editing where the 'Keep Edits' button was enabled when invalid edits were in place, thus bypassing validation.