### PR TITLE
SCRUM-1798 Workaround for null conditionStatement

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/ExperimentalConditionValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/ExperimentalConditionValidator.java
@@ -88,6 +88,8 @@ public class ExperimentalConditionValidator extends AuditedObjectValidator<Exper
 		dbEntity.setConditionFreeText(handleStringField(uiEntity.getConditionFreeText()));
 			
 		dbEntity.setConditionSummary(ExperimentalConditionSummary.getConditionSummary(dbEntity));
+		if (dbEntity.getConditionStatement() == null)
+			dbEntity.setConditionStatement(dbEntity.getConditionSummary());
 		
 		String uniqueId = DiseaseAnnotationCurie.getExperimentalConditionCurie(dbEntity);
 		if (!uniqueId.equals(uiEntity.getUniqueId())) {


### PR DESCRIPTION
New ExperimentalCondition object created in the UI will not have the conditionStatement populated.  However, this is field used to link ExperimentalConditions to DiseaseAnnotations.  This temporary fix will copy the conditionSummary to the conditionStatement if the latter is null, until we are ready to switch out conditionStatement for conditionSummary.

Will not merge until @chris-grove approves approach.