### PR TITLE
Fixed GH action URL reporting in slack notifications

### DIFF
--- a/.github/workflows/alpha-build-and-deploy.yml
+++ b/.github/workflows/alpha-build-and-deploy.yml
@@ -59,7 +59,7 @@ jobs:
               "fields": [
                 {
                   "title": "GitHub Actions URL",
-                  "value": "${{ github.event.repository.url }}/actions/runs/${{ github.run_id }}"
+                  "value": "https://github.com/${{ github.event.org.login }}/${{ github.event.repo.name }}/actions/runs/${{ github.run_id }}"
                 }
               ]
             }


### PR DESCRIPTION
It appears `github.event.repository.url` now returns an API URL rather than the website URL it used to, which we used to easily visualize the progress of a deployment through Github actions. This PR fixes this by crafting the URL manually from other event metadata.