### PR TITLE
SCRUM-1975 Fix updating non-required fields from non-null to null in bulk loads

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/AGMDiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AGMDiseaseAnnotationService.java
@@ -105,33 +105,39 @@ public class AGMDiseaseAnnotationService extends BaseDTOCrudService<AGMDiseaseAn
 		}
 		annotation.setDiseaseRelation(diseaseRelation);
 
+		Gene inferredGene = null;
 		if (StringUtils.isNotBlank(dto.getInferredGene())) {
-			Gene inferredGene = geneDAO.find(dto.getInferredGene());
+			inferredGene = geneDAO.find(dto.getInferredGene());
 			if (inferredGene == null)
 				throw new ObjectValidationException(dto, "Invalid inferred gene for " + annotationId + " - skipping");
-			annotation.setInferredGene(inferredGene);
 		}
-
+		annotation.setInferredGene(inferredGene);
+		
+		Gene assertedGene = null;
 		if (StringUtils.isNotBlank(dto.getAssertedGene())) {
-			Gene assertedGene = geneDAO.find(dto.getAssertedGene());
+			assertedGene = geneDAO.find(dto.getAssertedGene());
 			if (assertedGene == null)
 				throw new ObjectValidationException(dto, "Invalid asserted gene for " + annotationId + " - skipping");
-			annotation.setAssertedGene(assertedGene);
 		}
-
+		annotation.setAssertedGene(assertedGene);
+		
+		Allele inferredAllele = null;
 		if (StringUtils.isNotBlank(dto.getInferredAllele())) {
-			Allele inferredAllele = alleleDAO.find(dto.getInferredAllele());
+			inferredAllele = alleleDAO.find(dto.getInferredAllele());
 			if (inferredAllele == null)
 				throw new ObjectValidationException(dto, "Invalid inferred allele for " + annotationId + " - skipping");
-			annotation.setInferredAllele(inferredAllele);
 		}
-
+		annotation.setInferredAllele(inferredAllele);
+		
+		Allele assertedAllele = null;
 		if (StringUtils.isNotBlank(dto.getAssertedAllele())) {
-			Allele assertedAllele = alleleDAO.find(dto.getAssertedAllele());
+			assertedAllele = alleleDAO.find(dto.getAssertedAllele());
 			if (assertedAllele == null)
 				throw new ObjectValidationException(dto, "Invalid asserted allele for " + annotationId + " - skipping");
-			annotation.setAssertedAllele(assertedAllele);
-		}
+		} 
+		annotation.setAssertedAllele(assertedAllele);
+		
+		
 		return annotation;
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/services/AffectedGenomicModelService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AffectedGenomicModelService.java
@@ -132,7 +132,7 @@ public class AffectedGenomicModelService extends BaseDTOCrudService<AffectedGeno
 	
 	private AffectedGenomicModel validateAffectedGenomicModelDTO(AffectedGenomicModelDTO dto) throws ObjectValidationException {
 		// Check for required fields
-		if (StringUtils.isBlank(dto.getCurie()) || StringUtils.isBlank(dto.getTaxon())) {
+		if (StringUtils.isBlank(dto.getCurie()) || StringUtils.isBlank(dto.getTaxon()) || dto.getInternal() == null) {
 			throw new ObjectValidationException(dto, "Entry for agm " + dto.getCurie() + " missing required fields - skipping");
 		}
 
@@ -160,11 +160,13 @@ public class AffectedGenomicModelService extends BaseDTOCrudService<AffectedGeno
 			agm.setUpdatedBy(modifiedBy);
 		}
 		
-		if (agm.getInternal() != null)
-			agm.setInternal(dto.getInternal());
+		agm.setInternal(dto.getInternal());
+		
+		Boolean obsolete = false;
 		if (agm.getObsolete() != null)
-			agm.setObsolete(dto.getObsolete());
-
+			obsolete = dto.getObsolete();
+		agm.setObsolete(obsolete);
+		
 		if (StringUtils.isNotBlank(dto.getDateUpdated())) {
 			OffsetDateTime dateLastModified;
 			try {

--- a/src/main/java/org/alliancegenome/curation_api/services/AlleleDiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AlleleDiseaseAnnotationService.java
@@ -111,19 +111,21 @@ public class AlleleDiseaseAnnotationService extends BaseDTOCrudService<AlleleDis
 		}
 		annotation.setDiseaseRelation(diseaseRelation);
 		
+		Gene inferredGene = null;
 		if (StringUtils.isNotBlank(dto.getInferredGene())) {
-			Gene inferredGene = geneDAO.find(dto.getInferredGene());
+			inferredGene = geneDAO.find(dto.getInferredGene());
 			if (inferredGene == null)
 				throw new ObjectValidationException(dto, "Invalid inferred gene for " + annotationId + " - skipping");
-			annotation.setInferredGene(inferredGene);
 		}
-
+		annotation.setInferredGene(inferredGene);
+		
+		Gene assertedGene = null;
 		if (StringUtils.isNotBlank(dto.getAssertedGene())) {
-			Gene assertedGene = geneDAO.find(dto.getAssertedGene());
+			assertedGene = geneDAO.find(dto.getAssertedGene());
 			if (assertedGene == null)
 				throw new ObjectValidationException(dto, "Invalid asserted gene for " + annotationId + " - skipping");
-			annotation.setAssertedGene(assertedGene);
 		}
+		annotation.setAssertedGene(assertedGene);
 		
 		return annotation;
 	}

--- a/src/main/java/org/alliancegenome/curation_api/services/AlleleService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AlleleService.java
@@ -97,7 +97,7 @@ public class AlleleService extends BaseDTOCrudService<Allele, AlleleDTO, AlleleD
 	
 	private Allele validateAlleleDTO(AlleleDTO dto) throws ObjectValidationException {
 		// Check for required fields
-		if (StringUtils.isBlank(dto.getCurie()) || StringUtils.isBlank(dto.getTaxon())) {
+		if (StringUtils.isBlank(dto.getCurie()) || StringUtils.isBlank(dto.getTaxon()) || StringUtils.isBlank(dto.getName()) || dto.getInternal() == null) {
 			throw new ObjectValidationException(dto, "Entry for allele " + dto.getCurie() + " missing required fields - skipping");
 		}
 
@@ -114,9 +114,12 @@ public class AlleleService extends BaseDTOCrudService<Allele, AlleleDTO, AlleleD
 		}
 		allele.setTaxon(taxonResponse.getEntity());
 		
-		if (StringUtils.isNotBlank(dto.getSymbol())) allele.setSymbol(dto.getSymbol());
+		String symbol = null;
+		if (StringUtils.isNotBlank(dto.getSymbol())) 
+			symbol = dto.getSymbol();
+		allele.setSymbol(symbol);
 		
-		if (StringUtils.isNotBlank(dto.getName())) allele.setName(dto.getName());
+		allele.setName(dto.getName());
 		
 		if (StringUtils.isNotBlank(dto.getCreatedBy())) {
 			Person createdBy = personService.fetchByUniqueIdOrCreate(dto.getCreatedBy());
@@ -127,10 +130,12 @@ public class AlleleService extends BaseDTOCrudService<Allele, AlleleDTO, AlleleD
 			allele.setUpdatedBy(updatedBy);
 		}
 		
-		if (dto.getInternal() != null)
-			allele.setInternal(dto.getInternal());
+		allele.setInternal(dto.getInternal());
+		
+		Boolean obsolete = false;
 		if (dto.getObsolete() != null)
-			allele.setObsolete(dto.getObsolete());
+			obsolete = dto.getObsolete();
+		allele.setObsolete(obsolete);
 
 		if (StringUtils.isNotBlank(dto.getDateUpdated())) {
 			OffsetDateTime dateLastModified;

--- a/src/main/java/org/alliancegenome/curation_api/services/ExperimentalConditionService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ExperimentalConditionService.java
@@ -93,20 +93,25 @@ public class ExperimentalConditionService extends BaseEntityCrudService<Experime
 			experimentalCondition = searchResponse.getSingleResult();
 		}
 		
+		ChemicalTerm conditionChemical = null;
 		if (StringUtils.isNotBlank(dto.getConditionChemical())) {
-			ChemicalTerm term = chemicalTermDAO.find(dto.getConditionChemical());
-			if (term == null) {
+			conditionChemical = chemicalTermDAO.find(dto.getConditionChemical());
+			if (conditionChemical == null) {
 				throw new ObjectValidationException(dto, "Invalid ChemicalOntologyId - skipping annotation");
 			}
-			experimentalCondition.setConditionChemical(term);
+			
 		}
+		experimentalCondition.setConditionChemical(conditionChemical);
+		
+		ExperimentalConditionOntologyTerm conditionId = null;
 		if (StringUtils.isNotBlank(dto.getConditionId())) {
-			ExperimentalConditionOntologyTerm term = experimentalConditionOntologyTermDAO.find(dto.getConditionId());
-			if (term == null) {
+			conditionId = experimentalConditionOntologyTermDAO.find(dto.getConditionId());
+			if (conditionId == null) {
 				throw new ObjectValidationException(dto, "Invalid ConditionId - skipping annotation");
 			}
-			experimentalCondition.setConditionId(term);
 		}
+		experimentalCondition.setConditionId(conditionId);
+
 		if (StringUtils.isNotBlank(dto.getConditionClass())) {
 			ZECOTerm term = zecoTermDAO.find(dto.getConditionClass());
 			if (term == null || term.getSubsets().isEmpty() || !term.getSubsets().contains(OntologyConstants.ZECO_AGR_SLIM_SUBSET)) {
@@ -118,43 +123,57 @@ public class ExperimentalConditionService extends BaseEntityCrudService<Experime
 			throw new ObjectValidationException(dto, "ConditionClassId is a required field - skipping annotation");
 		}
 		
+		AnatomicalTerm conditionAnatomy = null;
 		if (StringUtils.isNotBlank(dto.getConditionAnatomy())) {
-			AnatomicalTerm term = anatomicalTermDAO.find(dto.getConditionAnatomy());
-			if (term == null) {
+			conditionAnatomy = anatomicalTermDAO.find(dto.getConditionAnatomy());
+			if (conditionAnatomy == null) {
 				throw new ObjectValidationException(dto, "Invalid AnatomicalOntologyId - skipping annotation");
 			}
-			experimentalCondition.setConditionAnatomy(term);
 		}
+		experimentalCondition.setConditionAnatomy(conditionAnatomy);
+		
+		NCBITaxonTerm conditionTaxon = null;
 		if (StringUtils.isNotBlank(dto.getConditionTaxon())) {
-			NCBITaxonTerm term = ncbiTaxonTermDAO.find(dto.getConditionTaxon());
-			if (term == null) {
-				term = ncbiTaxonTermDAO.downloadAndSave(dto.getConditionTaxon());
+			conditionTaxon = ncbiTaxonTermDAO.find(dto.getConditionTaxon());
+			if (conditionTaxon == null) {
+				conditionTaxon = ncbiTaxonTermDAO.downloadAndSave(dto.getConditionTaxon());
 			}
-			if (term == null) {
+			if (conditionTaxon == null) {
 				throw new ObjectValidationException(dto, "Invalid NCBITaxonId - skipping annotation");
 			}
-			experimentalCondition.setConditionTaxon(term);
 		}
+		experimentalCondition.setConditionTaxon(conditionTaxon);
+
+		GOTerm conditionGeneOntology = null;
 		if (StringUtils.isNotBlank(dto.getConditionGeneOntology())) {
-			GOTerm term = goTermDAO.find(dto.getConditionGeneOntology());
-			if (term == null) {
+			conditionGeneOntology = goTermDAO.find(dto.getConditionGeneOntology());
+			if (conditionGeneOntology == null) {
 				throw new ObjectValidationException(dto, "Invalid GeneOntologyId - skipping annotation");
 			}
-			experimentalCondition.setConditionGeneOntology(term);
 		}
+		experimentalCondition.setConditionGeneOntology(conditionGeneOntology);
+		
+		String conditionQuantity = null;
 		if (StringUtils.isNotBlank(dto.getConditionQuantity()))
-			experimentalCondition.setConditionQuantity(dto.getConditionQuantity());
+			conditionQuantity = dto.getConditionQuantity();
+		experimentalCondition.setConditionQuantity(conditionQuantity);
+		
+		String conditionFreeText = null;
 		if (StringUtils.isNotBlank(dto.getConditionFreeText()))
-			experimentalCondition.setConditionFreeText(dto.getConditionFreeText());
+			conditionFreeText = dto.getConditionFreeText();
+		experimentalCondition.setConditionFreeText(conditionFreeText);
+		
 		if (StringUtils.isBlank(dto.getConditionStatement())) {
 			throw new ObjectValidationException(dto, "ConditionStatement is a required field - skipping annotation");
 		}
 		experimentalCondition.setConditionStatement(dto.getConditionStatement());
 		
-		if (experimentalCondition.getInternal() != null)
-			experimentalCondition.setInternal(dto.getInternal());
+		experimentalCondition.setInternal(dto.getInternal());
+		
+		Boolean obsolete = false;
 		if (experimentalCondition.getObsolete() != null)
-			experimentalCondition.setObsolete(dto.getObsolete());
+			obsolete = dto.getObsolete();
+		experimentalCondition.setObsolete(obsolete);
 		
 		if (StringUtils.isNotBlank(dto.getCreatedBy())) {
 			Person createdBy = personService.fetchByUniqueIdOrCreate(dto.getCreatedBy());

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneDiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneDiseaseAnnotationService.java
@@ -108,16 +108,17 @@ public class GeneDiseaseAnnotationService extends BaseDTOCrudService<GeneDisease
 			annotation = annotationList.getResults().get(0);
 		}
 		
+		AffectedGenomicModel sgdStrainBackground = null;
 		if (StringUtils.isNotBlank(dto.getSgdStrainBackground())) {
-			AffectedGenomicModel sgdStrainBackground = affectedGenomicModelDAO.find(dto.getSgdStrainBackground());
+			sgdStrainBackground = affectedGenomicModelDAO.find(dto.getSgdStrainBackground());
 			if (sgdStrainBackground == null) {
 				throw new ObjectValidationException(dto, "Invalid AGM (" + dto.getSgdStrainBackground() + ") in 'sgd_strain_background' field in " + annotation.getUniqueId() + " - skipping annotation");
 			}
 			if (!sgdStrainBackground.getTaxon().getCurie().equals("NCBITaxon:559292")) {
 				throw new ObjectValidationException(dto, "Non-SGD AGM (" + dto.getSgdStrainBackground() + ") found in 'sgdStrainBackground' field in " + annotation.getUniqueId() + " - skipping annotation");
 			}
-			annotation.setSgdStrainBackground(sgdStrainBackground);
 		}
+		annotation.setSgdStrainBackground(sgdStrainBackground);
 		
 		annotation = (GeneDiseaseAnnotation) diseaseAnnotationService.validateAnnotationDTO(annotation, dto);
 		if (annotation == null) return null;

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
@@ -118,7 +118,7 @@ public class GeneService extends BaseDTOCrudService<Gene, GeneDTO, GeneDAO> {
 	
 	private Gene validateGeneDTO(GeneDTO dto) throws ObjectValidationException {
 		// Check for required fields
-		if (StringUtils.isBlank(dto.getCurie()) || StringUtils.isBlank(dto.getTaxon()) || StringUtils.isBlank(dto.getSymbol())) {
+		if (StringUtils.isBlank(dto.getCurie()) || StringUtils.isBlank(dto.getTaxon()) || StringUtils.isBlank(dto.getSymbol()) || dto.getInternal() == null) {
 			throw new ObjectValidationException(dto, "Entry for gene " + dto.getCurie() + " missing required fields - skipping");
 		}
 
@@ -137,7 +137,10 @@ public class GeneService extends BaseDTOCrudService<Gene, GeneDTO, GeneDAO> {
 		
 		gene.setSymbol(dto.getSymbol());
 		
-		if (StringUtils.isNotBlank(dto.getName())) gene.setName(dto.getName());
+		String name = null;
+		if (StringUtils.isNotBlank(dto.getName())) 
+			name = dto.getName();
+		gene.setName(name);
 		
 		if (StringUtils.isNotBlank(dto.getCreatedBy())) {
 			Person createdBy = personService.fetchByUniqueIdOrCreate(dto.getCreatedBy());
@@ -148,10 +151,12 @@ public class GeneService extends BaseDTOCrudService<Gene, GeneDTO, GeneDAO> {
 			gene.setUpdatedBy(updatedBy);
 		}
 		
-		if (dto.getInternal() != null)
-			gene.setInternal(dto.getInternal());
+		gene.setInternal(dto.getInternal());
+		
+		Boolean obsolete = false;
 		if (dto.getObsolete() != null)
-			gene.setObsolete(dto.getObsolete());
+			obsolete = dto.getObsolete();
+		gene.setObsolete(obsolete);
 
 		if (StringUtils.isNotBlank(dto.getDateUpdated())) {
 			OffsetDateTime dateLastModified;

--- a/src/main/java/org/alliancegenome/curation_api/services/NoteService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/NoteService.java
@@ -64,7 +64,11 @@ public class NoteService extends BaseEntityCrudService<Note, NoteDAO> {
 		}
 		note.setFreeText(dto.getFreeText());
 		note.setInternal(dto.getInternal());
-		note.setObsolete(dto.getObsolete());
+		
+		Boolean obsolete = false;
+		if (dto.getObsolete() != null)
+			obsolete = dto.getObsolete();
+		note.setObsolete(obsolete);
 		
 		VocabularyTerm noteType = vocabularyTermDAO.getTermInVocabulary(dto.getNoteType(), note_type_vocabulary);
 		if (noteType == null) {
@@ -85,8 +89,8 @@ public class NoteService extends BaseEntityCrudService<Note, NoteDAO> {
 				}
 				noteReferences.add(reference);
 			}
-			note.setReferences(noteReferences);
 		}
+		note.setReferences(noteReferences);
 		
 		if (StringUtils.isNotBlank(dto.getCreatedBy())) {
 			Person createdBy = personService.fetchByUniqueIdOrCreate(dto.getCreatedBy());

--- a/src/test/java/org/alliancegenome/curation_api/bulkupload/AlleleBulkUploadITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/bulkupload/AlleleBulkUploadITCase.java
@@ -126,9 +126,7 @@ public class AlleleBulkUploadITCase {
 			post("/api/allele/find?limit=10&page=0").
 			then().
 			statusCode(200).
-			body("totalResults", is(1)).
-			body("results", hasSize(1)).
-			body("results[0].curie", is("ALLELETEST:Allele0003"));
+			body("totalResults", is(0));
 	}
 	
 	@Test
@@ -517,9 +515,7 @@ public class AlleleBulkUploadITCase {
 			post("/api/allele/find?limit=10&page=0").
 			then().
 			statusCode(200).
-			body("totalResults", is(1)).
-			body("results", hasSize(1)).
-			body("results[0].curie", is("ALLELETEST:Allele0017"));
+			body("totalResults", is(0));
 	}
 	
 	@Test


### PR DESCRIPTION
When a new bulk load is run, if an annotation is to be updated and a field is null that was not previously null that field was not being set to be null.

This was widespread throughout the DTO validation code.