### PR TITLE
Error code consistency and API/interface fixes

### DIFF
--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/DiseaseAnnotationsTable.js
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/DiseaseAnnotationsTable.js
@@ -873,7 +873,7 @@ export const DiseaseAnnotationsTable = () => {
 			/>
 				<ErrorMessageComponent
 					errorMessages={errorMessagesRef.current[props.rowIndex]}
-					errorField="evidence"
+					errorField="evidenceCodes"
 				/>
 			</>
 		);

--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/DiseaseAnnotationsTable.js
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/DiseaseAnnotationsTable.js
@@ -150,7 +150,7 @@ export const DiseaseAnnotationsTable = () => {
 
 
 	const evidenceTemplate = (rowData) => {
-		if (rowData && rowData.evidenceCodes.length > 0) {
+		if (rowData?.evidenceCodes && rowData.evidenceCodes.length > 0) {
 			const sortedEvidenceCodes = rowData.evidenceCodes.sort((a, b) => (a.abbreviation > b.abbreviation) ? 1 : (a.curie === b.curie) ? 1 : -1);
 			const listTemplate = (item) => {
 				return (

--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/NewAnnotationForm.js
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/NewAnnotationForm.js
@@ -225,17 +225,17 @@ export const NewAnnotationForm = ({
 							<FormErrorMessageComponent errorMessages={errorMessages} errorField={"singleReference"}/>
 						</SplitterPanel>
 						<SplitterPanel style={{paddingRight: '10px'}}>
-							<label htmlFor="evidence"><font color={'red'}>*</font>Evidence Code</label>
+							<label htmlFor="evidenceCodes"><font color={'red'}>*</font>Evidence Code</label>
 							<AutocompleteFormEditor
 								autocompleteFields={["curie", "name", "abbreviation"]}
 								searchService={searchService}
-								name="evidence"
+								name="evidenceCodes"
 								label="Evidence Code"
 								endpoint='ecoterm'
 								filterName='evidenceFilter'
-								fieldName='evidence'
+								fieldName='evidenceCodes'
 								isMultiple={true}
-								value={newAnnotation.evidence}
+								value={newAnnotation.evidenceCodes}
 								onValueChangeHandler={onArrayFieldChange}
 								otherFilters={{
 									obsoleteFilter: {
@@ -251,9 +251,9 @@ export const NewAnnotationForm = ({
 								}}
 								valueDisplayHandler={(item, setAutocompleteSelectedItem, op, query) =>
 									<EvidenceAutocompleteTemplate item={item} setAutocompleteSelectedItem={setAutocompleteSelectedItem} op={op} query={query}/>}
-								classNames={classNames({'p-invalid': submitted && errorMessages.evidence})}
+								classNames={classNames({'p-invalid': submitted && errorMessages.evidenceCodes})}
 							/>
-							<FormErrorMessageComponent errorMessages={errorMessages} errorField={"evidence"}/>
+							<FormErrorMessageComponent errorMessages={errorMessages} errorField={"evidenceCodes"}/>
 						</SplitterPanel>
 						<SplitterPanel style={{paddingRight: '10px'}}>
 							<label htmlFor="with">With</label>

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AGMDiseaseAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AGMDiseaseAnnotationCrudInterface.java
@@ -3,13 +3,21 @@ package org.alliancegenome.curation_api.interfaces.crud;
 
 import java.util.List;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.alliancegenome.curation_api.interfaces.base.*;
+import org.alliancegenome.curation_api.interfaces.base.BaseDTOCrudControllerInterface;
+import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
 import org.alliancegenome.curation_api.model.entities.AGMDiseaseAnnotation;
 import org.alliancegenome.curation_api.model.ingest.dto.AGMDiseaseAnnotationDTO;
-import org.alliancegenome.curation_api.response.*;
+import org.alliancegenome.curation_api.response.APIResponse;
+import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.View;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -30,6 +38,11 @@ public interface AGMDiseaseAnnotationCrudInterface extends BaseIdCrudInterface<A
 	@Path("/")
 	@JsonView(View.DiseaseAnnotationUpdate.class)
 	public ObjectResponse<AGMDiseaseAnnotation> update(AGMDiseaseAnnotation entity);
+	
+	@POST
+	@Path("/")
+	@JsonView(View.DiseaseAnnotationUpdate.class)
+	public ObjectResponse<AGMDiseaseAnnotation> create(AGMDiseaseAnnotation entity);
 	
 	@POST
 	@Path("/bulk/{taxonID}/annotationFile")

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AGMDiseaseAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AGMDiseaseAnnotationCrudInterface.java
@@ -36,12 +36,12 @@ public interface AGMDiseaseAnnotationCrudInterface extends BaseIdCrudInterface<A
 	
 	@PUT
 	@Path("/")
-	@JsonView(View.DiseaseAnnotationUpdate.class)
+	@JsonView(View.DiseaseAnnotation.class)
 	public ObjectResponse<AGMDiseaseAnnotation> update(AGMDiseaseAnnotation entity);
 	
 	@POST
 	@Path("/")
-	@JsonView(View.DiseaseAnnotationCreate.class)
+	@JsonView(View.DiseaseAnnotation.class)
 	public ObjectResponse<AGMDiseaseAnnotation> create(AGMDiseaseAnnotation entity);
 	
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AGMDiseaseAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AGMDiseaseAnnotationCrudInterface.java
@@ -41,7 +41,7 @@ public interface AGMDiseaseAnnotationCrudInterface extends BaseIdCrudInterface<A
 	
 	@POST
 	@Path("/")
-	@JsonView(View.DiseaseAnnotationUpdate.class)
+	@JsonView(View.DiseaseAnnotationCreate.class)
 	public ObjectResponse<AGMDiseaseAnnotation> create(AGMDiseaseAnnotation entity);
 	
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AlleleDiseaseAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AlleleDiseaseAnnotationCrudInterface.java
@@ -36,13 +36,13 @@ public interface AlleleDiseaseAnnotationCrudInterface extends BaseIdCrudInterfac
 	
 	@PUT
 	@Path("/")
-	@JsonView(View.DiseaseAnnotationUpdate.class)
+	@JsonView(View.DiseaseAnnotation.class)
 	public ObjectResponse<AlleleDiseaseAnnotation> update(AlleleDiseaseAnnotation entity);
 	
 
 	@POST
 	@Path("/")
-	@JsonView(View.DiseaseAnnotationCreate.class)
+	@JsonView(View.DiseaseAnnotation.class)
 	public ObjectResponse<AlleleDiseaseAnnotation> create(AlleleDiseaseAnnotation entity);
 	
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AlleleDiseaseAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AlleleDiseaseAnnotationCrudInterface.java
@@ -3,13 +3,21 @@ package org.alliancegenome.curation_api.interfaces.crud;
 
 import java.util.List;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.alliancegenome.curation_api.interfaces.base.*;
+import org.alliancegenome.curation_api.interfaces.base.BaseDTOCrudControllerInterface;
+import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
 import org.alliancegenome.curation_api.model.entities.AlleleDiseaseAnnotation;
 import org.alliancegenome.curation_api.model.ingest.dto.AlleleDiseaseAnnotationDTO;
-import org.alliancegenome.curation_api.response.*;
+import org.alliancegenome.curation_api.response.APIResponse;
+import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.View;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
@@ -30,6 +38,12 @@ public interface AlleleDiseaseAnnotationCrudInterface extends BaseIdCrudInterfac
 	@Path("/")
 	@JsonView(View.DiseaseAnnotationUpdate.class)
 	public ObjectResponse<AlleleDiseaseAnnotation> update(AlleleDiseaseAnnotation entity);
+	
+
+	@POST
+	@Path("/")
+	@JsonView(View.DiseaseAnnotationUpdate.class)
+	public ObjectResponse<AlleleDiseaseAnnotation> create(AlleleDiseaseAnnotation entity);
 	
 	@POST
 	@Path("/bulk/{taxonID}/annotationFile")

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AlleleDiseaseAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AlleleDiseaseAnnotationCrudInterface.java
@@ -42,7 +42,7 @@ public interface AlleleDiseaseAnnotationCrudInterface extends BaseIdCrudInterfac
 
 	@POST
 	@Path("/")
-	@JsonView(View.DiseaseAnnotationUpdate.class)
+	@JsonView(View.DiseaseAnnotationCreate.class)
 	public ObjectResponse<AlleleDiseaseAnnotation> create(AlleleDiseaseAnnotation entity);
 	
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneDiseaseAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneDiseaseAnnotationCrudInterface.java
@@ -27,12 +27,12 @@ public interface GeneDiseaseAnnotationCrudInterface extends BaseIdCrudInterface<
 	
 	@PUT
 	@Path("/")
-	@JsonView(View.DiseaseAnnotationUpdate.class)
+	@JsonView(View.DiseaseAnnotation.class)
 	public ObjectResponse<GeneDiseaseAnnotation> update(GeneDiseaseAnnotation entity);
 
 	@POST
 	@Path("/")
-	@JsonView(View.DiseaseAnnotationCreate.class)
+	@JsonView(View.DiseaseAnnotation.class)
 	public ObjectResponse<GeneDiseaseAnnotation> create(GeneDiseaseAnnotation entity);
 	
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneDiseaseAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneDiseaseAnnotationCrudInterface.java
@@ -32,7 +32,7 @@ public interface GeneDiseaseAnnotationCrudInterface extends BaseIdCrudInterface<
 
 	@POST
 	@Path("/")
-	@JsonView(View.DiseaseAnnotationUpdate.class)
+	@JsonView(View.DiseaseAnnotationCreate.class)
 	public ObjectResponse<GeneDiseaseAnnotation> create(GeneDiseaseAnnotation entity);
 	
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneDiseaseAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneDiseaseAnnotationCrudInterface.java
@@ -29,6 +29,11 @@ public interface GeneDiseaseAnnotationCrudInterface extends BaseIdCrudInterface<
 	@Path("/")
 	@JsonView(View.DiseaseAnnotationUpdate.class)
 	public ObjectResponse<GeneDiseaseAnnotation> update(GeneDiseaseAnnotation entity);
+
+	@POST
+	@Path("/")
+	@JsonView(View.DiseaseAnnotationUpdate.class)
+	public ObjectResponse<GeneDiseaseAnnotation> create(GeneDiseaseAnnotation entity);
 	
 	@POST
 	@Path("/bulk/{taxonID}/annotationFile")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/DiseaseAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/DiseaseAnnotation.java
@@ -77,7 +77,7 @@ public abstract class DiseaseAnnotation extends Association {
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToMany
-	@JsonView({View.FieldsAndLists.class, View.DiseaseAnnotationUpdate.class})
+	@JsonView({View.FieldsAndLists.class, View.DiseaseAnnotationUpdate.class, View.DiseaseAnnotationCreate.class})
 	private List<ECOTerm> evidenceCodes;
 	
 	@IndexedEmbedded(includeDepth = 2)
@@ -90,7 +90,7 @@ public abstract class DiseaseAnnotation extends Association {
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToMany
 	@JoinTable(indexes = @Index( columnList = "diseaseannotation_id"))
-	@JsonView({View.FieldsAndLists.class, View.DiseaseAnnotationUpdate.class})
+	@JsonView({View.FieldsAndLists.class, View.DiseaseAnnotationUpdate.class, View.DiseaseAnnotationCreate.class})
 	private List<Gene> with;
 	
 	@IndexedEmbedded(includeDepth = 2)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/DiseaseAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/DiseaseAnnotation.java
@@ -77,7 +77,7 @@ public abstract class DiseaseAnnotation extends Association {
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToMany
-	@JsonView({View.FieldsAndLists.class, View.DiseaseAnnotationUpdate.class, View.DiseaseAnnotationCreate.class})
+	@JsonView({View.FieldsAndLists.class, View.DiseaseAnnotation.class})
 	private List<ECOTerm> evidenceCodes;
 	
 	@IndexedEmbedded(includeDepth = 2)
@@ -90,7 +90,7 @@ public abstract class DiseaseAnnotation extends Association {
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToMany
 	@JoinTable(indexes = @Index( columnList = "diseaseannotation_id"))
-	@JsonView({View.FieldsAndLists.class, View.DiseaseAnnotationUpdate.class, View.DiseaseAnnotationCreate.class})
+	@JsonView({View.FieldsAndLists.class, View.DiseaseAnnotation.class})
 	private List<Gene> with;
 	
 	@IndexedEmbedded(includeDepth = 2)

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/FlyDiseaseAnnotationCurie.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/FlyDiseaseAnnotationCurie.java
@@ -7,6 +7,7 @@ import org.alliancegenome.curation_api.model.entities.*;
 import org.alliancegenome.curation_api.model.entities.ontology.ECOTerm;
 import org.alliancegenome.curation_api.model.ingest.dto.DiseaseAnnotationDTO;
 import org.alliancegenome.curation_api.services.helpers.CurieGeneratorHelper;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class FlyDiseaseAnnotationCurie extends DiseaseAnnotationCurie {
@@ -34,7 +35,8 @@ public class FlyDiseaseAnnotationCurie extends DiseaseAnnotationCurie {
 		curie.add(annotation.getSubjectCurie());
 		curie.add(annotation.getObject().getCurie());
 		curie.add(annotation.getSingleReference().getCurie());
-		curie.add(StringUtils.join(annotation.getEvidenceCodes().stream().map(ECOTerm::getCurie).collect(Collectors.toList()), "::"));
+		if (CollectionUtils.isNotEmpty(annotation.getEvidenceCodes()))
+			curie.add(StringUtils.join(annotation.getEvidenceCodes().stream().map(ECOTerm::getCurie).collect(Collectors.toList()), "::"));
 		curie.add(annotation.getDiseaseRelation().getName());
 		return curie.getCurie();
 	}

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/RGDDiseaseAnnotationCurie.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/RGDDiseaseAnnotationCurie.java
@@ -7,6 +7,7 @@ import org.alliancegenome.curation_api.model.entities.*;
 import org.alliancegenome.curation_api.model.entities.ontology.ECOTerm;
 import org.alliancegenome.curation_api.model.ingest.dto.DiseaseAnnotationDTO;
 import org.alliancegenome.curation_api.services.helpers.CurieGeneratorHelper;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class RGDDiseaseAnnotationCurie extends DiseaseAnnotationCurie {
@@ -33,7 +34,8 @@ public class RGDDiseaseAnnotationCurie extends DiseaseAnnotationCurie {
 		curie.add(annotation.getSubjectCurie());
 		curie.add(annotation.getObject().getCurie());
 		curie.add(annotation.getSingleReference().getCurie());
-		curie.add(StringUtils.join(annotation.getEvidenceCodes().stream().map(ECOTerm::getCurie).collect(Collectors.toList()), "::"));
+		if (CollectionUtils.isNotEmpty(annotation.getEvidenceCodes()))
+			curie.add(StringUtils.join(annotation.getEvidenceCodes().stream().map(ECOTerm::getCurie).collect(Collectors.toList()), "::"));
 		return curie.getCurie();
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/SGDDiseaseAnnotationCurie.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/SGDDiseaseAnnotationCurie.java
@@ -36,7 +36,8 @@ public class SGDDiseaseAnnotationCurie extends DiseaseAnnotationCurie {
 		curie.add(annotation.getSubjectCurie());
 		curie.add(annotation.getObject().getCurie());
 		curie.add(annotation.getSingleReference().getCurie());
-		curie.add(StringUtils.join(annotation.getEvidenceCodes().stream().map(ECOTerm::getCurie).collect(Collectors.toList()), "::"));
+		if (CollectionUtils.isNotEmpty(annotation.getEvidenceCodes()))
+			curie.add(StringUtils.join(annotation.getEvidenceCodes().stream().map(ECOTerm::getCurie).collect(Collectors.toList()), "::"));
 		curie.add(annotation.getDiseaseRelation().getName());
 		curie.add(getWithCuries(annotation));
 		return curie.getCurie();

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/ZFINDiseaseAnnotationCurie.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/ZFINDiseaseAnnotationCurie.java
@@ -47,7 +47,8 @@ public class ZFINDiseaseAnnotationCurie extends DiseaseAnnotationCurie {
 		curie.add(annotation.getSubjectCurie());
 		curie.add(annotation.getObject().getCurie());
 		curie.add(annotation.getSingleReference().getCurie());
-		curie.add(StringUtils.join(annotation.getEvidenceCodes().stream().map(ECOTerm::getCurie).collect(Collectors.toList()), "::"));
+		if (CollectionUtils.isNotEmpty(annotation.getEvidenceCodes()))
+			curie.add(StringUtils.join(annotation.getEvidenceCodes().stream().map(ECOTerm::getCurie).collect(Collectors.toList()), "::"));
 
 		if(CollectionUtils.isNotEmpty(annotation.getConditionRelations())) {
 			curie.add(annotation.getConditionRelations().stream()

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/AuditedObjectValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/AuditedObjectValidator.java
@@ -36,7 +36,11 @@ public class AuditedObjectValidator<E extends AuditedObject> {
 		
 		dbEntity.setObsolete(uiEntity.getObsolete());
 		
-		dbEntity.setDateCreated(uiEntity.getDateCreated());
+		if (newEntity && uiEntity.getDateCreated() == null) {
+			dbEntity.setDateCreated(OffsetDateTime.now());
+		} else {
+			dbEntity.setDateCreated(uiEntity.getDateCreated());
+		}
 		
 		if (uiEntity.getCreatedBy() != null) {
 			Person createdBy = personService.fetchByUniqueIdOrCreate(uiEntity.getCreatedBy().getUniqueId());

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/DiseaseAnnotationValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/validators/DiseaseAnnotationValidator.java
@@ -89,7 +89,7 @@ public class DiseaseAnnotationValidator extends AuditedObjectValidator<DiseaseAn
 
 
 	public List<ECOTerm> validateEvidenceCodes(DiseaseAnnotation uiEntity, DiseaseAnnotation dbEntity) {
-		String field = "evidence";
+		String field = "evidenceCodes";
 		if (CollectionUtils.isEmpty(uiEntity.getEvidenceCodes())) {
 			addMessageResponse(field, ValidationConstants.REQUIRED_MESSAGE);
 			return null;

--- a/src/main/java/org/alliancegenome/curation_api/view/View.java
+++ b/src/main/java/org/alliancegenome/curation_api/view/View.java
@@ -17,5 +17,6 @@ public class View {
 	public static class ReportHistory extends FieldsOnly { }
 	
 	public static class DiseaseAnnotationUpdate extends FieldsOnly { }
+	public static class DiseaseAnnotationCreate extends FieldsOnly { }
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/view/View.java
+++ b/src/main/java/org/alliancegenome/curation_api/view/View.java
@@ -16,7 +16,8 @@ public class View {
 	public static class BulkLoadFileHistory extends FieldsOnly { }
 	public static class ReportHistory extends FieldsOnly { }
 	
-	public static class DiseaseAnnotationUpdate extends FieldsOnly { }
-	public static class DiseaseAnnotationCreate extends FieldsOnly { }
+	public static class DiseaseAnnotation extends FieldsOnly { }
+	public static class DiseaseAnnotationUpdate extends DiseaseAnnotation { }
+	public static class DiseaseAnnotationCreate extends DiseaseAnnotation { }
 
 }

--- a/src/test/java/org/alliancegenome/curation_api/crud/controllers/DiseaseAnnotationITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/crud/controllers/DiseaseAnnotationITCase.java
@@ -519,7 +519,7 @@ public class DiseaseAnnotationITCase {
 			then().
 			statusCode(400).
 			body("errorMessages", is(aMapWithSize(1))).
-			body("errorMessages.evidence", is(ValidationConstants.OBSOLETE_MESSAGE));
+			body("errorMessages.evidenceCodes", is(ValidationConstants.OBSOLETE_MESSAGE));
 	}
 
 	@Test
@@ -850,7 +850,7 @@ public class DiseaseAnnotationITCase {
 				then().
 				statusCode(400).
 				body("errorMessages", is(aMapWithSize(1))).
-				body("errorMessages.evidence", is(ValidationConstants.INVALID_MESSAGE));
+				body("errorMessages.evidenceCodes", is(ValidationConstants.INVALID_MESSAGE));
 	}
 	
 	@Test
@@ -2115,7 +2115,7 @@ public class DiseaseAnnotationITCase {
 			then().
 			statusCode(400).
 			body("errorMessages", is(aMapWithSize(1))).
-			body("errorMessages.evidence", is(ValidationConstants.OBSOLETE_MESSAGE));
+			body("errorMessages.evidenceCodes", is(ValidationConstants.OBSOLETE_MESSAGE));
 	}
 
 	@Test
@@ -2451,7 +2451,7 @@ public class DiseaseAnnotationITCase {
 				then().
 				statusCode(400).
 				body("errorMessages", is(aMapWithSize(1))).
-				body("errorMessages.evidence", is(ValidationConstants.INVALID_MESSAGE));
+				body("errorMessages.evidenceCodes", is(ValidationConstants.INVALID_MESSAGE));
 	}
 	
 	@Test
@@ -3697,7 +3697,7 @@ public class DiseaseAnnotationITCase {
 				then().
 				statusCode(400).
 				body("errorMessages", is(aMapWithSize(1))).
-				body("errorMessages.evidence", is(ValidationConstants.REQUIRED_MESSAGE));
+				body("errorMessages.evidenceCodes", is(ValidationConstants.REQUIRED_MESSAGE));
 	}
 	
 	@Test
@@ -3733,7 +3733,7 @@ public class DiseaseAnnotationITCase {
 				then().
 				statusCode(400).
 				body("errorMessages", is(aMapWithSize(1))).
-				body("errorMessages.evidence", is(ValidationConstants.REQUIRED_MESSAGE));
+				body("errorMessages.evidenceCodes", is(ValidationConstants.REQUIRED_MESSAGE));
 	}
 	
 	@Test


### PR DESCRIPTION
This sorts out the inconsistency between 'evidence' and 'evidenceCodes'.  It also addresses the following points:

- We were getting a 500 error if required fields were null due to null pointer errors in the curie generation code
- The evidenceCode and with fields were not displaying on saving a new DA (but were being saved to the DB and appearing on refresh).  This was due to the POST interfaces for disease annotations not returning list fields.
- DateCreated was not being automatically populated when creating DAs (nor when creating anything else)