### PR TITLE
Obsolete all references

### DIFF
--- a/src/main/resources/db/migration/v0.12.0.2__agr_curation_api.sql
+++ b/src/main/resources/db/migration/v0.12.0.2__agr_curation_api.sql
@@ -1,0 +1,1 @@
+UPDATE reference SET obsolete = true;


### PR DESCRIPTION
Setting all references as obsolete so that when data loads are redone they will pull references with the new curie format from the Literature Service.