### PR TITLE
Delete existing notes when doing DA bulk upload

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/DiseaseAnnotationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/DiseaseAnnotationDTOValidator.java
@@ -10,6 +10,7 @@ import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.BiologicalEntityDAO;
 import org.alliancegenome.curation_api.dao.ConditionRelationDAO;
+import org.alliancegenome.curation_api.dao.DiseaseAnnotationDAO;
 import org.alliancegenome.curation_api.dao.GeneDAO;
 import org.alliancegenome.curation_api.dao.NoteDAO;
 import org.alliancegenome.curation_api.dao.ReferenceDAO;
@@ -45,6 +46,7 @@ public class DiseaseAnnotationDTOValidator extends BaseDTOValidator {
 	@Inject GeneDAO geneDAO;
 	@Inject BiologicalEntityDAO biologicalEntityDAO;
 	@Inject NoteDAO noteDAO;
+	@Inject DiseaseAnnotationDAO diseaseAnnotationDAO;
 	@Inject ConditionRelationDAO conditionRelationDAO;
 	@Inject ConditionRelationDTOValidator conditionRelationDtoValidator;
 	@Inject NoteDTOValidator noteDtoValidator;
@@ -183,6 +185,9 @@ public class DiseaseAnnotationDTOValidator extends BaseDTOValidator {
 		}	
 		annotation.setGeneticSex(geneticSex);
 		
+		if (CollectionUtils.isNotEmpty(annotation.getRelatedNotes())) {
+			annotation.getRelatedNotes().forEach(note -> {diseaseAnnotationDAO.deleteAttachedNote(note.getId());});
+		}	
 		if (CollectionUtils.isNotEmpty(dto.getRelatedNotes())) {
 			List<Note> notes = new ArrayList<>();
 			for (NoteDTO noteDTO : dto.getRelatedNotes()) {

--- a/src/main/resources/db/migration/v0.12.0.3__agr_curation_api.sql
+++ b/src/main/resources/db/migration/v0.12.0.3__agr_curation_api.sql
@@ -1,0 +1,4 @@
+DELETE from note
+	WHERE id NOT IN (
+		SELECT relatednotes_id FROM diseaseannotation_note
+	);


### PR DESCRIPTION
We were not cleaning up existing notes when doing the DA bulk loads.  Since notes don't get reused and we always create a new note when encountering one in the bulk load, this resulted in a bunch of notes in the database not attached to anything.