### PR TITLE
SCRUM-2223 Fix discrepancy in publication curies used for DA and CR uniqueId fields

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/DiseaseAnnotationCurie.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/DiseaseAnnotationCurie.java
@@ -26,19 +26,19 @@ public abstract class DiseaseAnnotationCurie {
 		return curie.getCurie();
 	}
 	
-	public static String getConditionRelationUnique(ConditionRelationDTO dto) {
+	public static String getConditionRelationUnique(ConditionRelationDTO dto, String refCurie) {
 		CurieGeneratorHelper curie = new CurieGeneratorHelper();
 		if (dto.getConditionRelationType() != null)
 			curie.add(dto.getConditionRelationType());
 		curie.add(dto.getHandle());
-		if (dto.getSingleReference() != null)
-			curie.add(dto.getSingleReference());
+		if (refCurie != null)
+			curie.add(refCurie);
 		if (CollectionUtils.isNotEmpty(dto.getConditions()))
 			dto.getConditions().forEach(experimentalCondition -> curie.add(getExperimentalConditionCurie(experimentalCondition)));
 		return curie.getCurie();
 	}
 
-	public abstract String getCurieID(DiseaseAnnotationDTO annotationDTO);
+	public abstract String getCurieID(DiseaseAnnotationDTO annotationDTO, String refCurie);
 	public abstract String getCurieID(DiseaseAnnotation annotation);
 
 	/**
@@ -56,7 +56,8 @@ public abstract class DiseaseAnnotationCurie {
 		curie.add(object);
 		if (associationType != null)
 			curie.add(associationType);
-		curie.add(getEvidenceCurie(evidenceCodes, reference));
+		if (reference != null)
+			curie.add(getEvidenceCurie(evidenceCodes, reference));
 		if (CollectionUtils.isNotEmpty(conditionRelations)) {
 			curie.add(conditionRelations.stream()
 					.map(condition -> {

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/FlyDiseaseAnnotationCurie.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/FlyDiseaseAnnotationCurie.java
@@ -19,11 +19,11 @@ public class FlyDiseaseAnnotationCurie extends DiseaseAnnotationCurie {
 	 * @return curie string
 	 */
 	@Override
-	public String getCurieID(DiseaseAnnotationDTO annotationDTO) {
+	public String getCurieID(DiseaseAnnotationDTO annotationDTO, String refCurie) {
 		CurieGeneratorHelper curie = new CurieGeneratorHelper();
 		curie.add(annotationDTO.getSubject());
 		curie.add(annotationDTO.getObject());
-		curie.add(annotationDTO.getSingleReference());
+		curie.add(refCurie);
 		curie.add(StringUtils.join(annotationDTO.getEvidenceCodes(), "::"));
 		curie.add(annotationDTO.getDiseaseRelation());
 		return curie.getCurie();

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/MGIDiseaseAnnotationCurie.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/MGIDiseaseAnnotationCurie.java
@@ -15,11 +15,11 @@ public class MGIDiseaseAnnotationCurie extends DiseaseAnnotationCurie {
 	 * @return curie string
 	 */
 	@Override
-	public String getCurieID(DiseaseAnnotationDTO annotationDTO) {
+	public String getCurieID(DiseaseAnnotationDTO annotationDTO, String refCurie) {
 		CurieGeneratorHelper curie = new CurieGeneratorHelper();
 		curie.add(annotationDTO.getSubject());
 		curie.add(annotationDTO.getObject());
-		curie.add(annotationDTO.getSingleReference());
+		curie.add(refCurie);
 		return curie.getCurie();
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/RGDDiseaseAnnotationCurie.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/RGDDiseaseAnnotationCurie.java
@@ -19,11 +19,11 @@ public class RGDDiseaseAnnotationCurie extends DiseaseAnnotationCurie {
 	 * @return curie string
 	 */
 	@Override
-	public String getCurieID(DiseaseAnnotationDTO annotationDTO) {
+	public String getCurieID(DiseaseAnnotationDTO annotationDTO, String refCurie) {
 		CurieGeneratorHelper curie = new CurieGeneratorHelper();
 		curie.add(annotationDTO.getSubject());
 		curie.add(annotationDTO.getObject());
-		curie.add(annotationDTO.getSingleReference());
+		curie.add(refCurie);
 		curie.add(StringUtils.join(annotationDTO.getEvidenceCodes(), "::"));
 		return curie.getCurie();
 	}

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/SGDDiseaseAnnotationCurie.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/SGDDiseaseAnnotationCurie.java
@@ -19,11 +19,11 @@ public class SGDDiseaseAnnotationCurie extends DiseaseAnnotationCurie {
 	 * @return curie string
 	 */
 	@Override
-	public String getCurieID(DiseaseAnnotationDTO annotationDTO) {
+	public String getCurieID(DiseaseAnnotationDTO annotationDTO, String refCurie) {
 		CurieGeneratorHelper curie = new CurieGeneratorHelper();
 		curie.add(annotationDTO.getSubject());
 		curie.add(annotationDTO.getObject());
-		curie.add(annotationDTO.getSingleReference());
+		curie.add(refCurie);
 		curie.add(StringUtils.join(annotationDTO.getEvidenceCodes(), "::"));
 		curie.add(annotationDTO.getDiseaseRelation());
 		curie.add(getWithCuries(annotationDTO));

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/WormDiseaseAnnotationCurie.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/WormDiseaseAnnotationCurie.java
@@ -15,11 +15,11 @@ public class WormDiseaseAnnotationCurie extends DiseaseAnnotationCurie {
 	 * @return curie string
 	 */
 	@Override
-	public String getCurieID(DiseaseAnnotationDTO annotationDTO) {
+	public String getCurieID(DiseaseAnnotationDTO annotationDTO, String refCurie) {
 		CurieGeneratorHelper curie = new CurieGeneratorHelper();
 		curie.add(annotationDTO.getSubject());
 		curie.add(annotationDTO.getObject());
-		curie.add(annotationDTO.getSingleReference());
+		curie.add(refCurie);
 		return curie.getCurie();
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/ZFINDiseaseAnnotationCurie.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/ZFINDiseaseAnnotationCurie.java
@@ -19,11 +19,11 @@ public class ZFINDiseaseAnnotationCurie extends DiseaseAnnotationCurie {
 	 * @return curie string
 	 */
 	@Override
-	public String getCurieID(DiseaseAnnotationDTO annotationDTO) {
+	public String getCurieID(DiseaseAnnotationDTO annotationDTO, String refCurie) {
 		CurieGeneratorHelper curie = new CurieGeneratorHelper();
 		curie.add(annotationDTO.getSubject());
 		curie.add(annotationDTO.getObject());
-		curie.add(annotationDTO.getSingleReference());
+		curie.add(refCurie);
 		curie.add(StringUtils.join(annotationDTO.getEvidenceCodes(), "::"));
 
 		if(CollectionUtils.isNotEmpty(annotationDTO.getConditionRelations())) {

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AGMDiseaseAnnotationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AGMDiseaseAnnotationDTOValidator.java
@@ -19,6 +19,7 @@ import org.alliancegenome.curation_api.model.entities.AGMDiseaseAnnotation;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
 import org.alliancegenome.curation_api.model.entities.Allele;
 import org.alliancegenome.curation_api.model.entities.Gene;
+import org.alliancegenome.curation_api.model.entities.Reference;
 import org.alliancegenome.curation_api.model.entities.VocabularyTerm;
 import org.alliancegenome.curation_api.model.ingest.dto.AGMDiseaseAnnotationDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -40,7 +41,14 @@ public class AGMDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOValida
 		
 		AGMDiseaseAnnotation annotation = new AGMDiseaseAnnotation();
 		AffectedGenomicModel agm;
+		
 		ObjectResponse<AGMDiseaseAnnotation> adaResponse = new ObjectResponse<AGMDiseaseAnnotation>();
+		
+		ObjectResponse<AGMDiseaseAnnotation> refResponse = validateReference(annotation, dto);
+		adaResponse.addErrorMessages(refResponse.getErrorMessages());
+		Reference validatedReference = refResponse.getEntity().getSingleReference();
+		String refCurie = validatedReference == null ? null : validatedReference.getCurie();
+		
 		if (StringUtils.isBlank(dto.getSubject())) {
 			adaResponse.addErrorMessage("subject", ValidationConstants.REQUIRED_MESSAGE);
 		} else {
@@ -50,7 +58,7 @@ public class AGMDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOValida
 			} else {
 				String annotationId = dto.getModEntityId();
 				if (StringUtils.isBlank(annotationId)) {
-					annotationId = DiseaseAnnotationCurieManager.getDiseaseAnnotationCurie(agm.getTaxon().getCurie()).getCurieID(dto);
+					annotationId = DiseaseAnnotationCurieManager.getDiseaseAnnotationCurie(agm.getTaxon().getCurie()).getCurieID(dto, refCurie);
 				}
 		
 				SearchResponse<AGMDiseaseAnnotation> annotationList = agmDiseaseAnnotationDAO.findByField("uniqueId", annotationId);
@@ -62,6 +70,7 @@ public class AGMDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOValida
 				}
 			}
 		}
+		annotation.setSingleReference(validatedReference);
 		
 		ObjectResponse<AGMDiseaseAnnotation> daResponse = validateAnnotationDTO(annotation, dto);
 		annotation = daResponse.getEntity();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/DiseaseAnnotationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/DiseaseAnnotationDTOValidator.java
@@ -69,16 +69,7 @@ public class DiseaseAnnotationDTOValidator extends BaseDTOValidator {
 				daResponse.addErrorMessage("object", ValidationConstants.INVALID_MESSAGE);
 			annotation.setObject(disease);
 		}
-
-		if (StringUtils.isBlank(dto.getSingleReference())) {
-			daResponse.addErrorMessage("singleReference", ValidationConstants.REQUIRED_MESSAGE);
-		} else {
-			Reference reference = referenceService.retrieveFromDbOrLiteratureService(dto.getSingleReference());
-			if (reference == null)
-				daResponse.addErrorMessage("singleReference", ValidationConstants.INVALID_MESSAGE);
-			annotation.setSingleReference(reference);
-		}	
-				
+		
 		if (CollectionUtils.isEmpty(dto.getEvidenceCodes())) {
 			daResponse.addErrorMessage("evidenceCodes", ValidationConstants.REQUIRED_MESSAGE);
 		} else {
@@ -225,6 +216,23 @@ public class DiseaseAnnotationDTOValidator extends BaseDTOValidator {
 			annotation.setConditionRelations(null);
 		}
 
+		daResponse.setEntity(annotation);
+		return daResponse;
+	}
+	
+	public <E extends DiseaseAnnotation, D extends DiseaseAnnotationDTO> ObjectResponse<E> validateReference (E annotation, D dto) {
+		ObjectResponse<E> daResponse = new ObjectResponse<E>();
+		
+		Reference reference = null;
+		if (StringUtils.isBlank(dto.getSingleReference())) {
+			daResponse.addErrorMessage("singleReference", ValidationConstants.REQUIRED_MESSAGE);
+		} else {
+			reference = referenceService.retrieveFromDbOrLiteratureService(dto.getSingleReference());
+			if (reference == null)
+				daResponse.addErrorMessage("singleReference", ValidationConstants.INVALID_MESSAGE);
+		}	
+		annotation.setSingleReference(reference);
+		
 		daResponse.setEntity(annotation);
 		return daResponse;
 	}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDiseaseAnnotationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDiseaseAnnotationDTOValidator.java
@@ -15,6 +15,7 @@ import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.GeneDiseaseAnnotation;
+import org.alliancegenome.curation_api.model.entities.Reference;
 import org.alliancegenome.curation_api.model.entities.VocabularyTerm;
 import org.alliancegenome.curation_api.model.ingest.dto.GeneDiseaseAnnotationDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -36,7 +37,14 @@ public class GeneDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOValid
 		
 		GeneDiseaseAnnotation annotation = new GeneDiseaseAnnotation();
 		Gene gene;
+		
 		ObjectResponse<GeneDiseaseAnnotation> gdaResponse = new ObjectResponse<GeneDiseaseAnnotation>();
+		
+		ObjectResponse<GeneDiseaseAnnotation> refResponse = validateReference(annotation, dto);
+		gdaResponse.addErrorMessages(refResponse.getErrorMessages());
+		Reference validatedReference = refResponse.getEntity().getSingleReference();
+		String refCurie = validatedReference == null ? null : validatedReference.getCurie();
+		
 		if (StringUtils.isBlank(dto.getSubject())) {
 			gdaResponse.addErrorMessage("subject", ValidationConstants.REQUIRED_MESSAGE);
 		} else {
@@ -46,7 +54,7 @@ public class GeneDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOValid
 			} else {
 				String annotationId = dto.getModEntityId();
 				if (StringUtils.isBlank(annotationId)) {
-					annotationId = DiseaseAnnotationCurieManager.getDiseaseAnnotationCurie(gene.getTaxon().getCurie()).getCurieID(dto);
+					annotationId = DiseaseAnnotationCurieManager.getDiseaseAnnotationCurie(gene.getTaxon().getCurie()).getCurieID(dto, refCurie);
 				}
 		
 				SearchResponse<GeneDiseaseAnnotation> annotationList = geneDiseaseAnnotationDAO.findByField("uniqueId", annotationId);
@@ -58,6 +66,7 @@ public class GeneDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOValid
 				}
 			}
 		}
+		annotation.setSingleReference(validatedReference);
 		
 		AffectedGenomicModel sgdStrainBackground = null;
 		if (StringUtils.isNotBlank(dto.getSgdStrainBackground())) {

--- a/src/main/resources/db/migration/v0.12.0.4__agr_curation_api.sql
+++ b/src/main/resources/db/migration/v0.12.0.4__agr_curation_api.sql
@@ -1,0 +1,5 @@
+DELETE FROM diseaseannotation_conditionrelation;
+
+DELETE FROM conditionrelation_experimentalcondition;
+		
+DELETE FROM conditionrelation;

--- a/src/test/java/org/alliancegenome/curation_api/bulkupload/DiseaseAnnotationBulkUploadITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/bulkupload/DiseaseAnnotationBulkUploadITCase.java
@@ -132,6 +132,7 @@ public class DiseaseAnnotationBulkUploadITCase {
 			body("results[0].conditionRelations[0].conditionRelationType.name", is("exacerbated_by")).
 			body("results[0].conditionRelations[0].internal", is(false)).
 			body("results[0].conditionRelations[0].obsolete", is(false)).
+			body("results[0].conditionRelations[0].uniqueId", is("exacerbated_by|test_handle|" + requiredReference + "|DATEST:ExpCondTerm0001|DATEST:ExpCondTerm0002|DATEST:AnatomyTerm0001|DATEST:ChemicalTerm0001|DATEST:GOTerm0001|NCBITaxon:6239|Some amount|Free text")).
 			body("results[0].conditionRelations[0].conditions", hasSize(1)).
 			body("results[0].conditionRelations[0].conditions[0].conditionClass.curie", is("DATEST:ExpCondTerm0001")).
 			body("results[0].conditionRelations[0].conditions[0].conditionId.curie", is("DATEST:ExpCondTerm0002")).
@@ -205,6 +206,7 @@ public class DiseaseAnnotationBulkUploadITCase {
 			body("results[0].conditionRelations[0].conditionRelationType.name", is("exacerbated_by")).
 			body("results[0].conditionRelations[0].internal", is(false)).
 			body("results[0].conditionRelations[0].obsolete", is(false)).
+			body("results[0].conditionRelations[0].uniqueId", is("exacerbated_by|test_handle|" + requiredReference + "|DATEST:ExpCondTerm0001|DATEST:ExpCondTerm0002|DATEST:AnatomyTerm0001|DATEST:ChemicalTerm0001|DATEST:GOTerm0001|NCBITaxon:6239|Some amount|Free text")).
 			body("results[0].conditionRelations[0].conditions", hasSize(1)).
 			body("results[0].conditionRelations[0].conditions[0].conditionClass.curie", is("DATEST:ExpCondTerm0001")).
 			body("results[0].conditionRelations[0].conditions[0].conditionId.curie", is("DATEST:ExpCondTerm0002")).
@@ -279,6 +281,7 @@ public class DiseaseAnnotationBulkUploadITCase {
 			body("results[0].conditionRelations[0].conditionRelationType.name", is("exacerbated_by")).
 			body("results[0].conditionRelations[0].internal", is(false)).
 			body("results[0].conditionRelations[0].obsolete", is(false)).
+			body("results[0].conditionRelations[0].uniqueId", is("exacerbated_by|test_handle|" + requiredReference + "|DATEST:ExpCondTerm0001|DATEST:ExpCondTerm0002|DATEST:AnatomyTerm0001|DATEST:ChemicalTerm0001|DATEST:GOTerm0001|NCBITaxon:6239|Some amount|Free text")).
 			body("results[0].conditionRelations[0].conditions", hasSize(1)).
 			body("results[0].conditionRelations[0].conditions[0].conditionClass.curie", is("DATEST:ExpCondTerm0001")).
 			body("results[0].conditionRelations[0].conditions[0].conditionId.curie", is("DATEST:ExpCondTerm0002")).
@@ -336,7 +339,7 @@ public class DiseaseAnnotationBulkUploadITCase {
 			statusCode(200).
 			body("totalResults", is(1)). // Replace 1 WB gene disease annotation with 1
 			body("results", hasSize(1)).
-			body("results[0].uniqueId", is("DATEST:Gene0001|DATEST:Disease0001|" + requiredReferenceXref));
+			body("results[0].uniqueId", is("DATEST:Gene0001|DATEST:Disease0001|" + requiredReference));
 	}
 	
 	@Test
@@ -2482,7 +2485,7 @@ public class DiseaseAnnotationBulkUploadITCase {
 			then().
 			statusCode(200).
 			body("totalResults", is(1)).
-			body("results[0].uniqueId", is("DATEST:Gene0001|DATEST:Disease0001|" + requiredReferenceXref));
+			body("results[0].uniqueId", is("DATEST:Gene0001|DATEST:Disease0001|" + requiredReference));
 	}
 	
 	@Test


### PR DESCRIPTION
Uses AGR reference curie for generating uniqueIds via bulk uploads.

Reload of disease annotations required as DB migration removes all condition relations.