### PR TITLE
Remove unnecessary indexes

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/SlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/SlotAnnotation.java
@@ -33,10 +33,6 @@ import lombok.ToString;
 @Data @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @Inheritance(strategy = InheritanceType.JOINED)
 @Schema(name = "SlotAnnotation", description = "POJO that represents a SlotAnnotation")
-@Table(indexes = {
-	@Index(name = "slotannotation_createdby_index", columnList = "createdBy_id"),
-	@Index(name = "slotannotation_updatedby_index", columnList = "updatedBy_id"),
-})
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min="1.4.0", max=LinkMLSchemaConstants.LATEST_RELEASE, dependencies={AuditedObject.class})
 public class SlotAnnotation extends GeneratedAuditedObject {

--- a/src/main/resources/db/migration/v0.13.0.4__agr_curation_api.sql
+++ b/src/main/resources/db/migration/v0.13.0.4__agr_curation_api.sql
@@ -1,0 +1,2 @@
+DELETE INDEX slotannotation_createdby_index;
+DELETE INDEX slotannotation_updatedby_index;

--- a/src/main/resources/db/migration/v0.13.0.4__agr_curation_api.sql
+++ b/src/main/resources/db/migration/v0.13.0.4__agr_curation_api.sql
@@ -1,2 +1,2 @@
-DELETE INDEX slotannotation_createdby_index;
-DELETE INDEX slotannotation_updatedby_index;
+DROP INDEX slotannotation_createdby_index;
+DROP INDEX slotannotation_updatedby_index;


### PR DESCRIPTION
On 2nd thoughts, probably no need for these two indexes given that AlleleMutationTypes are not reused and only created/edited in the context of Alleles