### PR TITLE
Index changes mk2

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Allele.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Allele.java
@@ -53,7 +53,7 @@ public class Allele extends GenomicEntity {
 	@JsonView({View.FieldsOnly.class})
 	private String symbol;
 	
-	@IndexedEmbedded(includeDepth = 2)
+	@IndexedEmbedded(includePaths = {"curie", "crossReferences.curie"})
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToMany
 	@JoinTable(indexes = {
@@ -83,7 +83,7 @@ public class Allele extends GenomicEntity {
 	@OneToMany(mappedBy = "subject", cascade = CascadeType.ALL)
 	private List<AlleleDiseaseAnnotation> alleleDiseaseAnnotations;
 	
-	@IndexedEmbedded(includeDepth = 2)
+	@IndexedEmbedded(includePaths = {"evidence.curie", "mutationTypes.curie", "mutationTypes.name"})
 	@OneToMany(mappedBy = "singleAllele", cascade = CascadeType.ALL)
 	@JsonManagedReference
 	@JsonView({View.FieldsAndLists.class, View.AlleleView.class})

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/SlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/SlotAnnotation.java
@@ -8,7 +8,6 @@ import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
-import javax.persistence.Table;
 
 import org.alliancegenome.curation_api.constants.LinkMLSchemaConstants;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/SlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/SlotAnnotation.java
@@ -33,10 +33,6 @@ import lombok.ToString;
 @Data @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @Inheritance(strategy = InheritanceType.JOINED)
 @Schema(name = "SlotAnnotation", description = "POJO that represents a SlotAnnotation")
-@Table(indexes = {
-	@Index(name = "slotannotation_createdby_index", columnList = "createdBy_id"),
-	@Index(name = "slotannotation_updatedby_index", columnList = "updatedBy_id"),
-})
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min="1.4.0", max=LinkMLSchemaConstants.LATEST_RELEASE, dependencies={AuditedObject.class})
 public class SlotAnnotation extends GeneratedAuditedObject {

--- a/src/main/resources/db/migration/v0.13.0.4__agr_curation_api.sql
+++ b/src/main/resources/db/migration/v0.13.0.4__agr_curation_api.sql
@@ -1,0 +1,2 @@
+DELETE INDEX slotannotation_createdby_index;
+DELETE INDEX slotannotation_updatedby_index;

--- a/src/main/resources/db/migration/v0.13.0.4__agr_curation_api.sql
+++ b/src/main/resources/db/migration/v0.13.0.4__agr_curation_api.sql
@@ -1,2 +1,2 @@
-DELETE INDEX slotannotation_createdby_index;
-DELETE INDEX slotannotation_updatedby_index;
+DROP INDEX slotannotation_createdby_index;
+DROP INDEX slotannotation_updatedby_index;


### PR DESCRIPTION
@oblodgett - What about this approach?  Would this work?

If we specify the specific fields we want to index then the mass indexer won't try to index the AuditedObject fields, avoiding the need for the indexes on those fields for SlotAnnotations.

Seems to speed the allele load a bit on my local system (although not drastically).