### PR TITLE
SCRUM-2305 Fix blank screen error on saving invalid disease annotation

### DIFF
--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.js
@@ -194,7 +194,7 @@ export const ExperimentalConditionsTable = () => {
 			<>
 			<AutocompleteEditor
 				search={conditionClassSearch}
-				initialValue={props.rowData.conditionClass.curie}
+				initialValue={props.rowData.conditionClass?.curie}
 				rowProps={props}
 				fieldName="conditionClass"
 				onValueChangeHandler={onConditionClassValueChange}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/AGMDiseaseAnnotationValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/AGMDiseaseAnnotationValidator.java
@@ -43,7 +43,7 @@ public class AGMDiseaseAnnotationValidator extends DiseaseAnnotationValidator {
 	
 	public AGMDiseaseAnnotation validateAnnotationUpdate(AGMDiseaseAnnotation uiEntity) {
 		response = new ObjectResponse<>(uiEntity);
-		String errorTitle = "Could not update AGM Disease Annotation: [" + uiEntity.getId() + "]";
+		errorMessage = "Could not update AGM Disease Annotation: [" + uiEntity.getId() + "]";
 
 		Long id = uiEntity.getId();
 		if (id == null) {


### PR DESCRIPTION
Turns out this only affected AGM Disease Annotations and it was due to a missing errorMessage title.

Null pointer fix for ConditionClass on ExperimentalConditions table thrown in!