### PR TITLE
Add curie and keyword paths for genes and alleles in DA indexes

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AGMDiseaseAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AGMDiseaseAnnotation.java
@@ -49,26 +49,30 @@ public class AGMDiseaseAnnotation extends DiseaseAnnotation {
 	@JsonView({ View.FieldsOnly.class })
 	private AffectedGenomicModel subject;
 
-	@IndexedEmbedded(includePaths = { "geneSymbol.displayText", "geneFullName.displayText", "geneSystematicName.displayText", "geneSynonyms.displayText" })
+	@IndexedEmbedded(includePaths = { "curie", "geneSymbol.displayText", "geneFullName.displayText", "geneSystematicName.displayText", "geneSynonyms.displayText",
+			"curie_keyword", "geneSymbol.displayText_keyword", "geneFullName.displayText_keyword", "geneSystematicName.displayText_keyword", "geneSynonyms.displayText_keyword" })
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
 	@JsonView({ View.FieldsOnly.class })
 	private Gene inferredGene;
 
-	@IndexedEmbedded(includePaths = { "alleleSymbol.displayText", "alleleFullName.displayText", "alleleSynonyms.displayText" })
+	@IndexedEmbedded(includePaths = { "curie", "alleleSymbol.displayText", "alleleFullName.displayText", "alleleSynonyms.displayText",
+			"curie_keyword", "alleleSymbol.displayText_keyword", "alleleFullName.displayText_keyword", "alleleSynonyms.displayText_keyword" })
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
 	@JsonView({ View.FieldsOnly.class })
 	private Allele inferredAllele;
 
-	@IndexedEmbedded(includePaths = { "geneSymbol.displayText", "geneFullName.displayText", "geneSystematicName.displayText", "geneSynonyms.displayText" })
+	@IndexedEmbedded(includePaths = { "curie", "geneSymbol.displayText", "geneFullName.displayText", "geneSystematicName.displayText", "geneSynonyms.displayText",
+			"curie_keyword", "geneSymbol.displayText_keyword", "geneFullName.displayText_keyword", "geneSystematicName.displayText_keyword", "geneSynonyms.displayText_keyword" })
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToMany
 	@JoinTable(indexes = @Index(columnList = "agmdiseaseannotation_id"))
 	@JsonView({ View.FieldsAndLists.class, View.DiseaseAnnotation.class })
 	private List<Gene> assertedGenes;
 
-	@IndexedEmbedded(includePaths = { "alleleSymbol.displayText", "alleleFullName.displayText", "alleleSynonyms.displayText" })
+	@IndexedEmbedded(includePaths = { "curie", "alleleSymbol.displayText", "alleleFullName.displayText", "alleleSynonyms.displayText",
+			"curie_keyword", "alleleSymbol.displayText_keyword", "alleleFullName.displayText_keyword", "alleleSynonyms.displayText_keyword" })
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
 	@JsonView({ View.FieldsOnly.class })

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AlleleDiseaseAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AlleleDiseaseAnnotation.java
@@ -54,13 +54,15 @@ public class AlleleDiseaseAnnotation extends DiseaseAnnotation {
 	@JsonView({ View.FieldsOnly.class })
 	private Allele subject;
 
-	@IndexedEmbedded(includePaths = { "geneSymbol.displayText", "geneFullName.displayText", "geneSystematicName.displayText", "geneSynonyms.displayText" })
+	@IndexedEmbedded(includePaths = { "curie", "geneSymbol.displayText", "geneFullName.displayText", "geneSystematicName.displayText", "geneSynonyms.displayText",
+			"curie_keyword", "geneSymbol.displayText_keyword", "geneFullName.displayText_keyword", "geneSystematicName.displayText_keyword", "geneSynonyms.displayText_keyword" })
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
 	@JsonView({ View.FieldsOnly.class })
 	private Gene inferredGene;
 
-	@IndexedEmbedded(includePaths = { "geneSymbol.displayText", "geneFullName.displayText", "geneSystematicName.displayText", "geneSynonyms.displayText" })
+	@IndexedEmbedded(includePaths = { "curie", "geneSymbol.displayText", "geneFullName.displayText", "geneSystematicName.displayText", "geneSynonyms.displayText",
+			"curie_keyword", "geneSymbol.displayText_keyword", "geneFullName.displayText_keyword", "geneSystematicName.displayText_keyword", "geneSynonyms.displayText_keyword" })
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToMany
 	@JoinTable(indexes = @Index(columnList = "allelediseaseannotation_id"))

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/DiseaseAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/DiseaseAnnotation.java
@@ -109,7 +109,8 @@ public abstract class DiseaseAnnotation extends Association {
 	@JsonView({ View.FieldsAndLists.class, View.DiseaseAnnotation.class })
 	private List<ConditionRelation> conditionRelations;
 
-	@IndexedEmbedded(includePaths = { "geneSymbol.displayText", "geneFullName.displayText", "geneSystematicName.displayText", "geneSynonyms.displayText" })
+	@IndexedEmbedded(includePaths = { "curie", "geneSymbol.displayText", "geneFullName.displayText", "geneSystematicName.displayText", "geneSynonyms.displayText",
+			"curie_keyword", "geneSymbol.displayText_keyword", "geneFullName.displayText_keyword", "geneSystematicName.displayText_keyword", "geneSynonyms.displayText_keyword"})
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToMany
 	@JoinTable(indexes = @Index(columnList = "diseaseannotation_id"))


### PR DESCRIPTION
Fixes 500 error on sorting/filtering on DA table with, inferredGene, inferredAllele, assertedGenes, and assertedAllele columns