### PR TITLE
Fix null pointer error for old DAs with no data provider

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/DiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/DiseaseAnnotationService.java
@@ -84,7 +84,8 @@ public class DiseaseAnnotationService extends BaseEntityCrudService<DiseaseAnnot
 			if (authenticatedPerson.getOktaEmail() != null) {
 				annotation.setUpdatedBy(loggedInPersonService.findLoggedInPersonByOktaEmail(authenticatedPerson.getOktaEmail()));
 			} else {
-				annotation.setUpdatedBy(personService.fetchByUniqueIdOrCreate(annotation.getDataProvider().getAbbreviation() + " " + loadType + " bulk upload"));
+				String dataProviderAbbreviation = annotation.getDataProvider() != null ? annotation.getDataProvider().getAbbreviation() + " " : "";		
+				annotation.setUpdatedBy(personService.fetchByUniqueIdOrCreate(dataProviderAbbreviation + loadType + " bulk upload"));
 			}
 			annotation.setDateUpdated(OffsetDateTime.now());
 			diseaseAnnotationDAO.persist(annotation);


### PR DESCRIPTION
Fixes null pointer error thrown when setting updatedBy during deprecation of old DAs with no data provider