### PR TITLE
SCRUM-2481 added error message for duplicate disease annotations

### DIFF
--- a/src/main/cliapp/src/containers/conditionRelationPage/NewRelationForm.js
+++ b/src/main/cliapp/src/containers/conditionRelationPage/NewRelationForm.js
@@ -51,8 +51,14 @@ export const NewRelationForm = ({
 				newRelationDispatch({type: "RESET"});
 			},
 			onError: (error) => {
+
+				const message =
+					error.response.data.errorMessages.uniqueId ?
+					"Page Error: New relation is a duplicate of an existing relation" :
+					error.response.data.errorMessage;
+
 				toast_error.current.show([
-					{life: 7000, severity: 'error', summary: 'Page error: ', detail: error.response.data.errorMessage, sticky: false}
+					{life: 7000, severity: 'error', summary: 'Page error: ', detail: message, sticky: false}
 				]);
 				newRelationDispatch({type: "UPDATE_ERROR_MESSAGES", errorMessages: error.response.data.errorMessages});
 			}

--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/NewAnnotationForm.js
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/NewAnnotationForm.js
@@ -138,8 +138,14 @@ export const NewAnnotationForm = ({
 				}
 			},
 			onError: (error) => {
+
+				const message =
+					error.response.data.errorMessages.uniqueId ?
+					"Page Error: New annotation is a duplicate of an existing annotation" :
+					error.response.data.errorMessage;
+
 				toast_error.current.show([
-					{life: 7000, severity: 'error', summary: 'Page error: ', detail: error.response.data.errorMessage, sticky: false}
+					{life: 7000, severity: 'error', summary: 'Page error: ', detail: message, sticky: false}
 				]);
 				if (!error.response.data) return;
 				newAnnotationDispatch({type: "UPDATE_ERROR_MESSAGES", errorType: "errorMessages", errorMessages: error.response.data.errorMessages});

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/NewConditionForm.js
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/NewConditionForm.js
@@ -49,8 +49,14 @@ export const NewConditionForm = ({
 				newConditionDispatch({type: "RESET"});
 			},
 			onError: (error) => {
+
+				const message =
+					error.response.data.errorMessages.uniqueId ?
+					"Page Error: New experimental condition is a duplicate of an existing experimental condition" :
+					error.response.data.errorMessage;
+
 				toast_error.current.show([
-					{life: 7000, severity: 'error', summary: 'Page error: ', detail: error.response.data.errorMessage, sticky: false}
+					{life: 7000, severity: 'error', summary: 'Page error: ', detail: message, sticky: false}
 				]);
 				newConditionDispatch({type: "UPDATE_ERROR_MESSAGES", errorMessages: error.response.data.errorMessages});
 			}


### PR DESCRIPTION
This is a draft PR. I just want to ask if there are any other situations when there would be a UniqueId error or if its a safe assumption that it's existence means that there is a duplication error?