### PR TITLE
Update OpenSearch test container start timeout

### DIFF
--- a/src/test/java/org/alliancegenome/curation_api/resources/OpenSearchContainer.java
+++ b/src/test/java/org/alliancegenome/curation_api/resources/OpenSearchContainer.java
@@ -28,7 +28,7 @@ public class OpenSearchContainer extends GenericContainer<OpenSearchContainer> {
 		setWaitStrategy((new HttpWaitStrategy())
 			.forPort(9200)
 			.forStatusCodeMatching(response -> response == 200 || response == 401)
-			.withStartupTimeout(Duration.ofSeconds(600))
+			.withStartupTimeout(Duration.ofSeconds(900))
 		);
 
 	}

--- a/src/test/java/org/alliancegenome/curation_api/resources/OpenSearchContainer.java
+++ b/src/test/java/org/alliancegenome/curation_api/resources/OpenSearchContainer.java
@@ -28,7 +28,7 @@ public class OpenSearchContainer extends GenericContainer<OpenSearchContainer> {
 		setWaitStrategy((new HttpWaitStrategy())
 			.forPort(9200)
 			.forStatusCodeMatching(response -> response == 200 || response == 401)
-			.withStartupTimeout(Duration.ofSeconds(300))
+			.withStartupTimeout(Duration.ofSeconds(600))
 		);
 
 	}


### PR DESCRIPTION
The PR-validation/verify-test-api gh-actions job has been failing quite a lot recently due to timeout at startup, meaning startup takes longer than the anticipated 5 minutes. I've now increased the timeout to 10 mins, which should hopefully resolve the frequent need to rerun the verify-test-api job (sometime several times) before getting a successful run and be able to merge PRs.