### PR TITLE
Release/v0.19.1

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,11 @@
 
 https://agr-jira.atlassian.net/wiki/spaces/ATEAM/overview
 
+## v0.19.1
+ * Fixes
+ 	* Fix cleanup of biological entities associated with disease annotation genetic modifiers (SCRUM-2918)
+ 	* Fix duplication of slot annotations on reload of bulk file (SCRUM-2949)
+
 ## v0.19.0
  * New features
     * Synchronizes to LinkML v1.7.1 release (SCRUM-2836)

--- a/src/main/java/org/alliancegenome/curation_api/dao/AffectedGenomicModelDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/AffectedGenomicModelDAO.java
@@ -1,5 +1,6 @@
 package org.alliancegenome.curation_api.dao;
 
+import java.math.BigInteger;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -22,13 +23,14 @@ public class AffectedGenomicModelDAO extends BaseSQLDAO<AffectedGenomicModel> {
 	}
 
 	public List<Long> findReferencingDiseaseAnnotations(String agmCurie) {
-		Query jpqlQuery = entityManager.createQuery("SELECT da.id FROM DiseaseAnnotation da WHERE da.diseaseGeneticModifier.curie = :agmCurie");
+		Query jpqlQuery = entityManager.createQuery("SELECT ada.id FROM AGMDiseaseAnnotation ada WHERE ada.subject.curie = :agmCurie");
 		jpqlQuery.setParameter("agmCurie", agmCurie);
 		List<Long> results = (List<Long>) jpqlQuery.getResultList();
-
-		jpqlQuery = entityManager.createQuery("SELECT ada.id FROM AGMDiseaseAnnotation ada WHERE ada.subject.curie = :agmCurie");
+		
+		jpqlQuery = entityManager.createNativeQuery("SELECT diseaseannotation_id FROM diseaseannotation_biologicalentity db WHERE diseasegeneticmodifiers_curie = :agmCurie");
 		jpqlQuery.setParameter("agmCurie", agmCurie);
-		results.addAll((List<Long>) jpqlQuery.getResultList());
+		for(BigInteger nativeResult : (List<BigInteger>) jpqlQuery.getResultList())
+			results.add(nativeResult.longValue());
 
 		return results;
 	}

--- a/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
@@ -1,5 +1,6 @@
 package org.alliancegenome.curation_api.dao;
 
+import java.math.BigInteger;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -22,17 +23,18 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 	}
 
 	public List<Long> findReferencingDiseaseAnnotationIds(String alleleCurie) {
-		Query jpqlQuery = entityManager.createQuery("SELECT da.id FROM DiseaseAnnotation da WHERE da.diseaseGeneticModifier.curie = :alleleCurie");
+		Query jpqlQuery = entityManager.createQuery("SELECT ada.id FROM AlleleDiseaseAnnotation ada WHERE ada.subject.curie = :alleleCurie");
 		jpqlQuery.setParameter("alleleCurie", alleleCurie);
 		List<Long> results = (List<Long>) jpqlQuery.getResultList();
-
-		jpqlQuery = entityManager.createQuery("SELECT ada.id FROM AlleleDiseaseAnnotation ada WHERE ada.subject.curie = :alleleCurie");
-		jpqlQuery.setParameter("alleleCurie", alleleCurie);
-		results.addAll((List<Long>) jpqlQuery.getResultList());
 
 		jpqlQuery = entityManager.createQuery("SELECT ada.id FROM AGMDiseaseAnnotation ada WHERE ada.inferredAllele.curie = :alleleCurie OR ada.assertedAllele.curie = :alleleCurie");
 		jpqlQuery.setParameter("alleleCurie", alleleCurie);
 		results.addAll((List<Long>) jpqlQuery.getResultList());
+		
+		jpqlQuery = entityManager.createNativeQuery("SELECT diseaseannotation_id FROM diseaseannotation_biologicalentity db WHERE diseasegeneticmodifiers_curie = :alleleCurie");
+		jpqlQuery.setParameter("alleleCurie", alleleCurie);
+		for(BigInteger nativeResult : (List<BigInteger>) jpqlQuery.getResultList())
+			results.add(nativeResult.longValue());
 
 		return results;
 	}

--- a/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
@@ -27,13 +27,9 @@ public class GeneDAO extends BaseSQLDAO<Gene> {
 	}
 
 	public List<Long> findReferencingDiseaseAnnotations(String geneCurie) {
-		Query jpqlQuery = entityManager.createQuery("SELECT da.id FROM DiseaseAnnotation da WHERE da.diseaseGeneticModifier.curie = :geneCurie");
+		Query jpqlQuery = entityManager.createQuery("SELECT gda.id FROM GeneDiseaseAnnotation gda WHERE gda.subject.curie = :geneCurie");
 		jpqlQuery.setParameter("geneCurie", geneCurie);
 		List<Long> results = (List<Long>) jpqlQuery.getResultList();
-
-		jpqlQuery = entityManager.createQuery("SELECT gda.id FROM GeneDiseaseAnnotation gda WHERE gda.subject.curie = :geneCurie");
-		jpqlQuery.setParameter("geneCurie", geneCurie);
-		results.addAll((List<Long>) jpqlQuery.getResultList());
 
 		jpqlQuery = entityManager.createQuery("SELECT ada.id FROM AGMDiseaseAnnotation ada WHERE ada.inferredGene.curie = :geneCurie");
 		jpqlQuery.setParameter("geneCurie", geneCurie);
@@ -57,7 +53,12 @@ public class GeneDAO extends BaseSQLDAO<Gene> {
 		jpqlQuery.setParameter("geneCurie", geneCurie);
 		for(BigInteger nativeResult : (List<BigInteger>) jpqlQuery.getResultList())
 			results.add(nativeResult.longValue());
-
+		
+		jpqlQuery = entityManager.createNativeQuery("SELECT diseaseannotation_id FROM diseaseannotation_biologicalentity db WHERE diseasegeneticmodifiers_curie = :geneCurie");
+		jpqlQuery.setParameter("geneCurie", geneCurie);
+		for(BigInteger nativeResult : (List<BigInteger>) jpqlQuery.getResultList())
+			results.add(nativeResult.longValue());
+		
 		return results;
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/slotAnnotations/SlotAnnotationIdentityHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/slotAnnotations/SlotAnnotationIdentityHelper.java
@@ -1,12 +1,15 @@
 package org.alliancegenome.curation_api.services.helpers.slotAnnotations;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 
 import org.alliancegenome.curation_api.model.entities.InformationContentEntity;
+import org.alliancegenome.curation_api.model.entities.Reference;
 import org.alliancegenome.curation_api.model.entities.ontology.SOTerm;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.NameSlotAnnotation;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.SecondaryIdSlotAnnotation;
@@ -18,12 +21,15 @@ import org.alliancegenome.curation_api.model.ingest.dto.AlleleMutationTypeSlotAn
 import org.alliancegenome.curation_api.model.ingest.dto.NameSlotAnnotationDTO;
 import org.alliancegenome.curation_api.model.ingest.dto.SecondaryIdSlotAnnotationDTO;
 import org.alliancegenome.curation_api.model.ingest.dto.SlotAnnotationDTO;
+import org.alliancegenome.curation_api.services.ReferenceService;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 
 @RequestScoped
 public class SlotAnnotationIdentityHelper {
-
+	
+	@Inject ReferenceService refService;
+	
 	public static String alleleMutationTypesIdentity(AlleleMutationTypeSlotAnnotation annotation) {
 		String identity = "";
 		if (CollectionUtils.isNotEmpty(annotation.getMutationTypes())) {
@@ -34,7 +40,7 @@ public class SlotAnnotationIdentityHelper {
 		return identity + "|" + slotAnnotationIdentity(annotation);
 	}
 	
-	public static String alleleMutationTypesDtoIdentity(AlleleMutationTypeSlotAnnotationDTO dto) {
+	public String alleleMutationTypesDtoIdentity(AlleleMutationTypeSlotAnnotationDTO dto) {
 		String identity = "";
 		List<String> mutationTypeCuries = dto.getMutationTypeCuries();
 		if (CollectionUtils.isNotEmpty(mutationTypeCuries)) {
@@ -53,7 +59,7 @@ public class SlotAnnotationIdentityHelper {
 		return StringUtils.join(List.of(inheritanceMode, phenotypeTerm, phenotypeStatement, slotAnnotationIdentity(annotation)), "|");
 	}
 	
-	public static String alleleInheritanceModeDtoIdentity(AlleleInheritanceModeSlotAnnotationDTO dto) {
+	public String alleleInheritanceModeDtoIdentity(AlleleInheritanceModeSlotAnnotationDTO dto) {
 		String inheritanceMode = StringUtils.isBlank(dto.getInheritanceModeName()) ? "" : dto.getInheritanceModeName();
 		String phenotypeTerm = StringUtils.isBlank(dto.getPhenotypeTermCurie()) ? "" : dto.getPhenotypeTermCurie();
 		String phenotypeStatement = StringUtils.isBlank(dto.getPhenotypeStatement()) ? "" : dto.getPhenotypeStatement();
@@ -68,7 +74,7 @@ public class SlotAnnotationIdentityHelper {
 		return StringUtils.join(List.of(displayText, formatText, slotAnnotationIdentity(annotation)), "|");
 	}
 
-	public static String nameSlotAnnotationDtoIdentity(NameSlotAnnotationDTO dto) {
+	public String nameSlotAnnotationDtoIdentity(NameSlotAnnotationDTO dto) {
 		String displayText = StringUtils.isBlank(dto.getDisplayText()) ? "" : dto.getDisplayText();
 		String formatText = StringUtils.isBlank(dto.getFormatText()) ? "" : dto.getFormatText();
 		
@@ -81,7 +87,7 @@ public class SlotAnnotationIdentityHelper {
 		return StringUtils.join(List.of(secondaryId, slotAnnotationIdentity(annotation)), "|");
 	}
 	
-	public static String secondaryIdDtoIdentity(SecondaryIdSlotAnnotationDTO dto) {
+	public String secondaryIdDtoIdentity(SecondaryIdSlotAnnotationDTO dto) {
 		String secondaryId = StringUtils.isBlank(dto.getSecondaryId()) ? "" : dto.getSecondaryId();
 		
 		return StringUtils.join(List.of(secondaryId, slotAnnotationDtoIdentity(dto)), "|");
@@ -98,13 +104,22 @@ public class SlotAnnotationIdentityHelper {
 		return identity;
 	}
 	
-	private static String slotAnnotationDtoIdentity(SlotAnnotationDTO dto) {
+	private String slotAnnotationDtoIdentity(SlotAnnotationDTO dto) {
 		List<String> evidenceCuries = dto.getEvidenceCuries();
 		if (CollectionUtils.isEmpty(evidenceCuries))
 			return "";
 		
-		Collections.sort(evidenceCuries);
-		return StringUtils.join(evidenceCuries, ":");
+		List<String> agrEvidenceCuries = new ArrayList<>();
+		for (String curie : evidenceCuries) {
+			Reference ref = refService.retrieveFromDbOrLiteratureService(curie);
+			if (ref != null)
+				agrEvidenceCuries.add(ref.getCurie());
+		}
+		
+		if (CollectionUtils.isEmpty(agrEvidenceCuries))
+			return "";
+		Collections.sort(agrEvidenceCuries);
+		return StringUtils.join(agrEvidenceCuries, ":");
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AlleleDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AlleleDTOValidator.java
@@ -83,6 +83,8 @@ public class AlleleDTOValidator extends BaseDTOValidator {
 	AlleleSynonymSlotAnnotationDTOValidator alleleSynonymDtoValidator;
 	@Inject
 	AlleleSecondaryIdSlotAnnotationDTOValidator alleleSecondaryIdDtoValidator;
+	@Inject
+	SlotAnnotationIdentityHelper identityHelper;
 
 	@Transactional
 	public Allele validateAlleleDTO(AlleleDTO dto) throws ObjectValidationException {
@@ -140,27 +142,28 @@ public class AlleleDTOValidator extends BaseDTOValidator {
 		}
 		
 		List<AlleleMutationTypeSlotAnnotation> mutationTypes = new ArrayList<>();
-		List<String> mutationTypeIdentities = new ArrayList<>();
+		List<Long> mutationTypeIdsToKeep = new ArrayList<>();
 		if (CollectionUtils.isNotEmpty(dto.getAlleleMutationTypeDtos())) {
 			for (AlleleMutationTypeSlotAnnotationDTO mutationTypeDTO : dto.getAlleleMutationTypeDtos()) {
-				ObjectResponse<AlleleMutationTypeSlotAnnotation> mutationTypeResponse = alleleMutationTypeDtoValidator.validateAlleleMutationTypeSlotAnnotationDTO(existingMutationTypes.get(SlotAnnotationIdentityHelper.alleleMutationTypesDtoIdentity(mutationTypeDTO)), mutationTypeDTO);
+				ObjectResponse<AlleleMutationTypeSlotAnnotation> mutationTypeResponse = alleleMutationTypeDtoValidator.validateAlleleMutationTypeSlotAnnotationDTO(existingMutationTypes.get(identityHelper.alleleMutationTypesDtoIdentity(mutationTypeDTO)), mutationTypeDTO);
 				if (mutationTypeResponse.hasErrors()) {
 					alleleResponse.addErrorMessage("allele_mutation_type_dtos", mutationTypeResponse.errorMessagesString());
 				} else {
 					AlleleMutationTypeSlotAnnotation mutationType = mutationTypeResponse.getEntity();
 					mutationTypes.add(mutationType);
-					mutationTypeIdentities.add(SlotAnnotationIdentityHelper.alleleMutationTypesIdentity(mutationType));
+					if (mutationType.getId() != null)
+						mutationTypeIdsToKeep.add(mutationType.getId());
 				}
 			}
 		}
 		
-		if (!existingMutationTypes.isEmpty()) {
-			existingMutationTypes.forEach((k,v) -> {
-				if (!mutationTypeIdentities.contains(k)) {
-					v.setSingleAllele(null);
-					alleleMutationTypeDAO.remove(v.getId());
+		if (CollectionUtils.isNotEmpty(allele.getAlleleMutationTypes())) {
+			for (AlleleMutationTypeSlotAnnotation amt : allele.getAlleleMutationTypes()) {
+				if (!mutationTypeIdsToKeep.contains(amt.getId())) {
+					amt.setSingleAllele(null);
+					alleleMutationTypeDAO.remove(amt.getId());
 				}
-			});
+			}
 		}
 		
 		Map<String, AlleleInheritanceModeSlotAnnotation> existingInheritanceModes = new HashMap<>();
@@ -171,27 +174,28 @@ public class AlleleDTOValidator extends BaseDTOValidator {
 		}
 		
 		List<AlleleInheritanceModeSlotAnnotation> inheritanceModes = new ArrayList<>();
-		List<String> inheritanceModeIdentities = new ArrayList<>();
+		List<Long> inheritanceModeIdsToKeep = new ArrayList<>();
 		if (CollectionUtils.isNotEmpty(dto.getAlleleInheritanceModeDtos())) {
 			for (AlleleInheritanceModeSlotAnnotationDTO inheritanceModeDTO : dto.getAlleleInheritanceModeDtos()) {
-				ObjectResponse<AlleleInheritanceModeSlotAnnotation> inheritanceModeResponse = alleleInheritanceModeDtoValidator.validateAlleleInheritanceModeSlotAnnotationDTO(existingInheritanceModes.get(SlotAnnotationIdentityHelper.alleleInheritanceModeDtoIdentity(inheritanceModeDTO)), inheritanceModeDTO);
+				ObjectResponse<AlleleInheritanceModeSlotAnnotation> inheritanceModeResponse = alleleInheritanceModeDtoValidator.validateAlleleInheritanceModeSlotAnnotationDTO(existingInheritanceModes.get(identityHelper.alleleInheritanceModeDtoIdentity(inheritanceModeDTO)), inheritanceModeDTO);
 				if (inheritanceModeResponse.hasErrors()) {
 					alleleResponse.addErrorMessage("allele_inheritance_mode_dtos", inheritanceModeResponse.errorMessagesString());
 				} else {
 					AlleleInheritanceModeSlotAnnotation inheritanceMode = inheritanceModeResponse.getEntity();
 					inheritanceModes.add(inheritanceMode);
-					inheritanceModeIdentities.add(SlotAnnotationIdentityHelper.alleleInheritanceModeIdentity(inheritanceMode));
+					if (inheritanceMode.getId() != null)
+						inheritanceModeIdsToKeep.add(inheritanceMode.getId());
 				}
 			}
 		}
 		
-		if (!existingInheritanceModes.isEmpty()) {
-			existingInheritanceModes.forEach((k,v) -> {
-				if (!inheritanceModeIdentities.contains(k)) {
-					v.setSingleAllele(null);
-					alleleInheritanceModeDAO.remove(v.getId());
+		if (CollectionUtils.isNotEmpty(allele.getAlleleInheritanceModes())) {
+			for (AlleleInheritanceModeSlotAnnotation aim : allele.getAlleleInheritanceModes()) {
+				if (!inheritanceModeIdsToKeep.contains(aim.getId())) {
+					aim.setSingleAllele(null);
+					alleleInheritanceModeDAO.remove(aim.getId());
 				}
-			});
+			}
 		}
 
 		AlleleSymbolSlotAnnotation symbol = allele.getAlleleSymbol();
@@ -231,27 +235,28 @@ public class AlleleDTOValidator extends BaseDTOValidator {
 		}
 		
 		List<AlleleSynonymSlotAnnotation> synonyms = new ArrayList<>();
-		List<String> synonymIdentities = new ArrayList<>();
+		List<Long> synonymIdsToKeep = new ArrayList<>();
 		if (CollectionUtils.isNotEmpty(dto.getAlleleSynonymDtos())) {
 			for (NameSlotAnnotationDTO synonymDTO : dto.getAlleleSynonymDtos()) {
-				ObjectResponse<AlleleSynonymSlotAnnotation> synonymResponse = alleleSynonymDtoValidator.validateAlleleSynonymSlotAnnotationDTO(existingSynonyms.get(SlotAnnotationIdentityHelper.nameSlotAnnotationDtoIdentity(synonymDTO)), synonymDTO);
+				ObjectResponse<AlleleSynonymSlotAnnotation> synonymResponse = alleleSynonymDtoValidator.validateAlleleSynonymSlotAnnotationDTO(existingSynonyms.get(identityHelper.nameSlotAnnotationDtoIdentity(synonymDTO)), synonymDTO);
 				if (synonymResponse.hasErrors()) {
 					alleleResponse.addErrorMessage("allele_synonym_dtos", synonymResponse.errorMessagesString());
 				} else {
 					AlleleSynonymSlotAnnotation synonym = synonymResponse.getEntity();
 					synonyms.add(synonym);
-					synonymIdentities.add(SlotAnnotationIdentityHelper.nameSlotAnnotationIdentity(synonym));
+					if (synonym.getId() != null)
+						synonymIdsToKeep.add(synonym.getId());
 				}
 			}
 		}
 		
-		if (!existingSynonyms.isEmpty()) {
-			existingSynonyms.forEach((k,v) -> {
-				if (!synonymIdentities.contains(k)) {
-					v.setSingleAllele(null);
-					alleleSynonymDAO.remove(v.getId());
+		if (CollectionUtils.isNotEmpty(allele.getAlleleSynonyms())) {
+			for (AlleleSynonymSlotAnnotation syn : allele.getAlleleSynonyms()) {
+				if (!synonymIdsToKeep.contains(syn.getId())) {
+					syn.setSingleAllele(null);
+					alleleSynonymDAO.remove(syn.getId());
 				}
-			});
+			}
 		}
 
 		Map<String, AlleleSecondaryIdSlotAnnotation> existingSecondaryIds = new HashMap<>();
@@ -262,32 +267,32 @@ public class AlleleDTOValidator extends BaseDTOValidator {
 		}
 		
 		List<AlleleSecondaryIdSlotAnnotation> secondaryIds = new ArrayList<>();
-		List<String> secondaryIdIdentities = new ArrayList<>();
+		List<Long> secondaryIdIdsToKeep = new ArrayList<>();
 		if (CollectionUtils.isNotEmpty(dto.getAlleleSecondaryIdDtos())) {
 			for (SecondaryIdSlotAnnotationDTO secondaryIdDTO : dto.getAlleleSecondaryIdDtos()) {
-				ObjectResponse<AlleleSecondaryIdSlotAnnotation> secondaryIdResponse = alleleSecondaryIdDtoValidator.validateAlleleSecondaryIdSlotAnnotationDTO(existingSecondaryIds.get(SlotAnnotationIdentityHelper.secondaryIdDtoIdentity(secondaryIdDTO)), secondaryIdDTO);
+				ObjectResponse<AlleleSecondaryIdSlotAnnotation> secondaryIdResponse = alleleSecondaryIdDtoValidator.validateAlleleSecondaryIdSlotAnnotationDTO(existingSecondaryIds.get(identityHelper.secondaryIdDtoIdentity(secondaryIdDTO)), secondaryIdDTO);
 				if (secondaryIdResponse.hasErrors()) {
 					alleleResponse.addErrorMessage("allele_secondary_id_dtos", secondaryIdResponse.errorMessagesString());
 				} else {
 					AlleleSecondaryIdSlotAnnotation secondaryId = secondaryIdResponse.getEntity();
 					secondaryIds.add(secondaryId);
-					secondaryIdIdentities.add(SlotAnnotationIdentityHelper.secondaryIdIdentity(secondaryId));
+					if (secondaryId.getId() != null)
+						secondaryIdIdsToKeep.add(secondaryId.getId());
 				}
 			}
 		}
 		
-		if (!existingSecondaryIds.isEmpty()) {
-			existingSecondaryIds.forEach((k,v) -> {
-				if (!secondaryIdIdentities.contains(k)) {
-					v.setSingleAllele(null);
-					alleleSecondaryIdDAO.remove(v.getId());
+		if (CollectionUtils.isNotEmpty(allele.getAlleleSecondaryIds())) {
+			for (AlleleSecondaryIdSlotAnnotation sid : allele.getAlleleSecondaryIds()) {
+				if (!secondaryIdIdsToKeep.contains(sid.getId())) {
+					sid.setSingleAllele(null);
+					alleleSecondaryIdDAO.remove(sid.getId());
 				}
-			});
+			}
 		}
 
-		if (alleleResponse.hasErrors()) {
+		if (alleleResponse.hasErrors())
 			throw new ObjectValidationException(dto, alleleResponse.errorMessagesString());
-		}
 
 		allele = alleleDAO.persist(allele);
 


### PR DESCRIPTION
Fixes duplication of slot annotations on reload (SCRUM-2949) and cleanup of biological entities referenced in the disease annotation genetic modifiers field (SCRUM-2918).