### PR TITLE
SCRUM-2600: Upgrade to Node 18

### DIFF
--- a/.github/workflows/github-actions-PR-validation.yml
+++ b/.github/workflows/github-actions-PR-validation.yml
@@ -75,10 +75,10 @@ jobs:
         run: |
           git fetch -q origin ${{ github.base_ref }} ${{ github.head_ref }}
           git diff --name-only origin/${{ github.base_ref }} origin/${{ github.head_ref }}
-      - name: Setup Node.js (v16)
+      - name: Setup Node.js (v18)
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Report Node version
         run: |
           node -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG OVERWRITE_VERSION
 
 ### Stage 1: build UI
-FROM node:16 AS BUILD_UI_STAGE
+FROM node:18 AS BUILD_UI_STAGE
 
 WORKDIR /agr_curation
 COPY src/main/cliapp ./cliapp

--- a/src/main/cliapp/package.json
+++ b/src/main/cliapp/package.json
@@ -9,6 +9,7 @@
     },
     "license": "MIT",
     "dependencies": {
+	"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
         "@fullcalendar/core": "^5.7.2",
         "@fullcalendar/daygrid": "^5.7.2",
         "@fullcalendar/interaction": "^5.7.2",

--- a/src/main/cliapp/package.json
+++ b/src/main/cliapp/package.json
@@ -9,7 +9,7 @@
     },
     "license": "MIT",
     "dependencies": {
-        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@fullcalendar/core": "^5.7.2",
         "@fullcalendar/daygrid": "^5.7.2",
         "@fullcalendar/interaction": "^5.7.2",
@@ -62,7 +62,7 @@
         "not op_mini all"
     ],
     "devDependencies": {
-        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "msw": "^0.48.1"
     }
 }

--- a/src/main/cliapp/package.json
+++ b/src/main/cliapp/package.json
@@ -9,7 +9,7 @@
     },
     "license": "MIT",
     "dependencies": {
-	"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
         "@fullcalendar/core": "^5.7.2",
         "@fullcalendar/daygrid": "^5.7.2",
         "@fullcalendar/interaction": "^5.7.2",
@@ -62,6 +62,7 @@
         "not op_mini all"
     ],
     "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
         "msw": "^0.48.1"
     }
 }

--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/NewAnnotationForm.js
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/NewAnnotationForm.js
@@ -448,7 +448,7 @@ export const NewAnnotationForm = ({
 		<div>
 			<Toast ref={toast_error} position="top-left" />
 			<Toast ref={toast_success} position="top-right" />
-			<Dialog visible={newAnnotationDialog} style={{ width: '900px' }} header={dialogHeader} modal className="p-fluid" footer={dialogFooter} onHide={hideDialog} resizeable="true" >
+			<Dialog visible={newAnnotationDialog} style={{ width: '900px' }} header={dialogHeader} modal className="p-fluid" footer={dialogFooter} onHide={hideDialog} resizeable>
 				<ErrorBoundary>
 				<form>
 					<div className="grid">


### PR DESCRIPTION
- Adding babel/plugin-proposal-private-property-in-object silences a long warning in the UI tests, maybe it can be removed later in a ticket to upgrade/remove dependencies
