### PR TITLE
SCRUM-3040 Fix enabling of Keep Edits button for Allele synonyms

### DIFF
--- a/src/main/cliapp/src/containers/allelesPage/SynonymsDialog.js
+++ b/src/main/cliapp/src/containers/allelesPage/SynonymsDialog.js
@@ -115,7 +115,7 @@ export const SynonymsDialog = ({
 			}
 		}
 		
-		if (localSynonyms.length > originalSynonyms?.length || !originalSynonyms[0]) {
+		if (localSynonyms.length > originalSynonyms?.length || !originalSynonyms) {
 			rowsEdited.current++;
 		}
 	};


### PR DESCRIPTION
Keep Edits button was not being enabled when adding a synonym to an Allele that previously did not have any synonyms