### PR TITLE
Attempt 1 to fix gh-actions EB deployment using AWS roles

### DIFF
--- a/.github/workflows/alpha-build-and-deploy.yml
+++ b/.github/workflows/alpha-build-and-deploy.yml
@@ -117,6 +117,7 @@ jobs:
     - name: Deploy to EB
       uses: einaregilsson/beanstalk-deploy@v21
       with:
+        aws_session_token: ${{env.AWS_SESSION_TOKEN}}
         application_name: curation-app
         environment_name: curation-alpha
         version_label: ${{ env.tagname }}

--- a/.github/workflows/github-release-build-and-deploy.yml
+++ b/.github/workflows/github-release-build-and-deploy.yml
@@ -91,6 +91,7 @@ jobs:
     - name: Deploy to EB
       uses: einaregilsson/beanstalk-deploy@v21
       with:
+        aws_session_token: ${{env.AWS_SESSION_TOKEN}}
         application_name: curation-app
         environment_name: curation-production
         version_label: ${{ github.event.release.tag_name }}
@@ -123,6 +124,7 @@ jobs:
     - name: Deploy to EB
       uses: einaregilsson/beanstalk-deploy@v21
       with:
+        aws_session_token: ${{env.AWS_SESSION_TOKEN}}
         application_name: curation-app
         environment_name: curation-beta
         version_label: ${{ github.event.release.tag_name }}

--- a/.github/workflows/github-release-build-and-deploy.yml
+++ b/.github/workflows/github-release-build-and-deploy.yml
@@ -121,6 +121,7 @@ jobs:
       with:
         role-to-assume: ${{secrets.GH_ACTIONS_AWS_ROLE}}
         role-session-name: gh-actions-${{github.run_id}}.${{github.run_number}}.${{github.run_attempt}}-eb-deploy-beta
+        aws-region: us-east-1
     - name: Deploy to EB
       uses: einaregilsson/beanstalk-deploy@v21
       with:


### PR DESCRIPTION
Attempt to fix gh-actions EB deployment with roles assumed through `aws-actions/configure-aws-credentials`.