### PR TITLE
SCRUM-3073 Clean up disease annotations based on subject DataProvider

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/AGMDiseaseAnnotationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/AGMDiseaseAnnotationDAO.java
@@ -16,7 +16,7 @@ public class AGMDiseaseAnnotationDAO extends BaseSQLDAO<AGMDiseaseAnnotation> {
 	}
 
 	public List<Long> findAllAnnotationIdsByDataProvider(String dataProvider) {
-		Query jpqlQuery = entityManager.createQuery("SELECT annotation.id FROM AGMDiseaseAnnotation annotation WHERE annotation.dataProvider.sourceOrganization.abbreviation = :dataProvider");
+		Query jpqlQuery = entityManager.createQuery("SELECT annotation.id FROM AGMDiseaseAnnotation annotation WHERE annotation.subject.dataProvider.sourceOrganization.abbreviation = :dataProvider");
 		jpqlQuery.setParameter("dataProvider", dataProvider);
 		return (List<Long>) jpqlQuery.getResultList();
 	}

--- a/src/main/java/org/alliancegenome/curation_api/dao/AlleleDiseaseAnnotationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/AlleleDiseaseAnnotationDAO.java
@@ -16,7 +16,7 @@ public class AlleleDiseaseAnnotationDAO extends BaseSQLDAO<AlleleDiseaseAnnotati
 	}
 
 	public List<Long> findAllAnnotationIdsByDataProvider(String dataProvider) {
-		Query jpqlQuery = entityManager.createQuery("SELECT annotation.id FROM AlleleDiseaseAnnotation annotation WHERE annotation.dataProvider.sourceOrganization.abbreviation = :dataProvider");
+		Query jpqlQuery = entityManager.createQuery("SELECT annotation.id FROM AlleleDiseaseAnnotation annotation WHERE annotation.subject.dataProvider.sourceOrganization.abbreviation = :dataProvider");
 		jpqlQuery.setParameter("dataProvider", dataProvider);
 		return (List<Long>) jpqlQuery.getResultList();
 	}

--- a/src/main/java/org/alliancegenome/curation_api/dao/GeneDiseaseAnnotationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/GeneDiseaseAnnotationDAO.java
@@ -16,7 +16,7 @@ public class GeneDiseaseAnnotationDAO extends BaseSQLDAO<GeneDiseaseAnnotation> 
 	}
 
 	public List<Long> findAllAnnotationIdsByDataProvider(String dataProvider) {
-		Query jpqlQuery = entityManager.createQuery("SELECT annotation.id FROM GeneDiseaseAnnotation annotation WHERE annotation.dataProvider.sourceOrganization.abbreviation = :dataProvider");
+		Query jpqlQuery = entityManager.createQuery("SELECT annotation.id FROM GeneDiseaseAnnotation annotation WHERE annotation.subject.dataProvider.sourceOrganization.abbreviation = :dataProvider");
 		jpqlQuery.setParameter("dataProvider", dataProvider);
 		return (List<Long>) jpqlQuery.getResultList();
 	}


### PR DESCRIPTION
Human disease annotation submissions contain entries with both RGD and OMIM as the primary data provider - this was causing errors on cleanup as RGD loads were deleting/deprecating human annotations as this was based on the disease annotation data provider.