### PR TITLE
SCRUM-2248 update

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/jobs/BulkLoadURLProcessor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/BulkLoadURLProcessor.java
@@ -20,17 +20,18 @@ public class BulkLoadURLProcessor extends BulkLoadProcessor {
 
 		if (bulkURLLoad.getBulkloadUrl() != null && bulkURLLoad.getBulkloadUrl().length() > 0) {
 			String filePath = fileHelper.saveIncomingURLFile(bulkURLLoad.getBulkloadUrl());
-			String localFilePath = fileHelper.compressInputFile(filePath);
-			
-			if(filePath == null) {
+			if (filePath == null) {
 				log.info("Load: " + bulkURLLoad.getName() + " failed");
 				endLoad(bulkURLLoad, "Load: " + bulkURLLoad.getName() + " failed: to download URL: " + bulkURLLoad.getBulkloadUrl(), JobStatus.FAILED);
-			} else if(localFilePath == null) {
-				log.info("Load: " + bulkURLLoad.getName() + " failed");
-				endLoad(bulkURLLoad, "Load: " + bulkURLLoad.getName() + " failed: to save local file: " + filePath, JobStatus.FAILED);
 			} else {
-				processFilePath(bulkURLLoad, localFilePath);
-				endLoad(bulkURLLoad, null, JobStatus.FINISHED);
+				String localFilePath = fileHelper.compressInputFile(filePath);
+				if(localFilePath == null) {
+					log.info("Load: " + bulkURLLoad.getName() + " failed");
+					endLoad(bulkURLLoad, "Load: " + bulkURLLoad.getName() + " failed: to save local file: " + filePath, JobStatus.FAILED);
+				} else {
+					processFilePath(bulkURLLoad, localFilePath);
+					endLoad(bulkURLLoad, null, JobStatus.FINISHED);
+				}
 			}
 		} else {
 			log.info("Load: " + bulkURLLoad.getName() + " failed: URL is missing");


### PR DESCRIPTION
@oblodgett Needed to stop `compressInputFile()` from running if `filePath` is null otherwise get uncaught NullPointerException and status doesn't get changed to FAILED