### PR TITLE
SCRUM-3255 Display validation errors of hidden fields in row edit mode

### DIFF
--- a/src/main/cliapp/src/components/GenericDataTable/GenericDataTable.js
+++ b/src/main/cliapp/src/components/GenericDataTable/GenericDataTable.js
@@ -65,6 +65,7 @@ export const GenericDataTable = (props) => {
 		exceptionMessage,
 	} = useGenericDataTable(props);
 
+	const toast_topleft = useRef(null);
 	const toast_topright = useRef(null);
 	const [deleteDialog, setDeleteDialog] = useState(false);
 	const [deprecateDialog, setDeprecateDialog] = useState(false);
@@ -251,6 +252,7 @@ export const GenericDataTable = (props) => {
 
 	return (
 			<div className="card">
+				<Toast ref={toast_topleft} position="top-left" />
 				<Toast ref={toast_topright} position="top-right" />
 				<DataTable dataKey={dataKey} value={entities} header={header} ref={dataTable}
 					filterDisplay="row" scrollHeight="62vh" scrollable= {true} tableClassName='p-datatable-md'

--- a/src/main/cliapp/src/components/GenericDataTable/useGenericDataTable.js
+++ b/src/main/cliapp/src/components/GenericDataTable/useGenericDataTable.js
@@ -231,6 +231,16 @@ export const useGenericDataTable = ({
 					toast_topright.current.show([
 						{ life: 7000, severity: 'error', summary: 'Update error: ', detail: errorMessage, sticky: false }
 					]);
+					if (error.response.data.errorMessages && Object.keys(error.response.data.errorMessages).length > 0) {
+						let messages = [];
+						for (let errorField in error.response.data.errorMessages) {
+							messages.push(errorField + ": " + error.response.data.errorMessages[errorField].message);
+						}
+						let messageSummary = messages.join(" / ");
+						toast_topleft.current.show([
+							{ life: 7000, severity: 'error', summary: 'Errors found: ', detail: messageSummary, sticky: false }
+						]);
+					}
 				}
 				else if(error.response.data !== undefined) {
 					setExceptionMessage(error.response.data);

--- a/src/main/cliapp/src/components/GenericDataTable/useGenericDataTable.js
+++ b/src/main/cliapp/src/components/GenericDataTable/useGenericDataTable.js
@@ -234,7 +234,7 @@ export const useGenericDataTable = ({
 					if (error.response.data.errorMessages && Object.keys(error.response.data.errorMessages).length > 0) {
 						let messages = [];
 						for (let errorField in error.response.data.errorMessages) {
-							messages.push(errorField + ": " + error.response.data.errorMessages[errorField].message);
+							messages.push(errorField + ": " + error.response.data.errorMessages[errorField]);
 						}
 						let messageSummary = messages.join(" / ");
 						toast_topleft.current.show([


### PR DESCRIPTION
All errors found when attempting to save row shown in top-left toast, thus avoiding the issue of hidden or off-screen fields 