### PR TITLE
SCRUM-3290 Fix 500 error on saving row in Experiments table

### DIFF
--- a/src/main/cliapp/src/containers/conditionRelationPage/ConditionRelationTable.js
+++ b/src/main/cliapp/src/containers/conditionRelationPage/ConditionRelationTable.js
@@ -67,14 +67,14 @@ export const ConditionRelationTable = () => {
 		return (
 			<>
 				<ControlledVocabularyDropdown
-					field="conditionRelationType.name"
+					field="conditionRelationType"
 					options={conditionRelationTypeTerms}
 					editorChange={onConditionRelationTypeValueChange}
 					props={props}
 					showClear={false}
 					placeholderText={props.rowData.conditionRelationType.name}
 				/>
-				<ErrorMessageComponent errorMessages={errorMessagesRef.current[props.rowIndex]} errorField={"conditionRelationType.name"}/>
+				<ErrorMessageComponent errorMessages={errorMessagesRef.current[props.rowIndex]} errorField={"conditionRelationType"}/>
 			</>
 		);
 	};
@@ -266,7 +266,6 @@ export const ConditionRelationTable = () => {
 				initialTableState={initialTableState}
 				isEditable={true}
 				curieFields={["singleReference"]}
-				idFields={["conditionRelationType"]}
 				mutation={mutation}
 				isEnabled={isEnabled}
 				setIsEnabled={setIsEnabled}


### PR DESCRIPTION
Validation code needs whole object to be sent for the VocabularyTerm of the `conditionRelationType` field as it does a lookup based on the `vocabularyLabel` field.  The use of `idFields` in the GenericDataTable meant that only the id was being sent.