### PR TITLE
SCRUM-199 (update no. 2) Load and display constructs

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/ConstructService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ConstructService.java
@@ -42,8 +42,6 @@ public class ConstructService extends BaseDTOCrudService<Construct, ConstructDTO
 	@Inject
 	PersonService personService;
 	@Inject
-	NoteDAO noteDAO;
-	@Inject
 	ConstructComponentSlotAnnotationDAO constructComponentDAO;
 
 	@Override
@@ -159,9 +157,12 @@ public class ConstructService extends BaseDTOCrudService<Construct, ConstructDTO
 		if (CollectionUtils.isNotEmpty(construct.getConstructComponents())) {
 			construct.getConstructComponents().forEach(cc -> {
 				List<Note> notesToDelete = cc.getRelatedNotes();
-				constructComponentDAO.remove(cc.getId());
 				if (CollectionUtils.isNotEmpty(notesToDelete))
-					notesToDelete.forEach(note -> {noteDAO.remove(note.getId());});
+					notesToDelete.forEach(note -> {
+						constructComponentDAO.deleteAttachedNote(note.getId());
+						
+					});
+				constructComponentDAO.remove(cc.getId());
 			});
 		}
 	}

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/constructs/ConstructUniqueIdHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/constructs/ConstructUniqueIdHelper.java
@@ -3,10 +3,8 @@ package org.alliancegenome.curation_api.services.helpers.constructs;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.model.entities.Construct;
-import org.alliancegenome.curation_api.model.entities.Reference;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.constructSlotAnnotations.ConstructComponentSlotAnnotation;
 import org.alliancegenome.curation_api.model.ingest.dto.ConstructDTO;
 import org.alliancegenome.curation_api.model.ingest.dto.slotAnnotions.constructSlotAnnotations.ConstructComponentSlotAnnotationDTO;
@@ -17,16 +15,11 @@ public abstract class ConstructUniqueIdHelper {
 
 	public static final String DELIMITER = "|";
 
-	public static String getConstructUniqueId(ConstructDTO constructDTO, List<String> refCuries) {
+	public static String getConstructUniqueId(ConstructDTO constructDTO) {
 		UniqueIdGeneratorHelper uniqueId = new UniqueIdGeneratorHelper();
 		uniqueId.add(constructDTO.getName());
 		uniqueId.add(constructDTO.getTaxonCurie());
 
-		if (CollectionUtils.isNotEmpty(refCuries)) {
-			Collections.sort(refCuries);
-			uniqueId.addAll(refCuries);
-		}
-		
 		if (CollectionUtils.isNotEmpty(constructDTO.getConstructComponentDtos())) {
 			List<String> componentIds = new ArrayList<>();
 			for (ConstructComponentSlotAnnotationDTO componentDTO : constructDTO.getConstructComponentDtos()) {
@@ -44,13 +37,6 @@ public abstract class ConstructUniqueIdHelper {
 		uniqueId.add(construct.getName());
 		if (construct.getTaxon() != null)
 			uniqueId.add(construct.getTaxon().getCurie());
-		
-		if (CollectionUtils.isNotEmpty(construct.getReferences())) {
-			List<String> refCuries = construct.getReferences().stream().map(Reference::getCurie)
-		              .collect(Collectors.toList());
-			Collections.sort(refCuries);
-			uniqueId.addAll(refCuries);
-		}
 		
 		if (CollectionUtils.isNotEmpty(construct.getConstructComponents())) {
 			List<String> componentIds = new ArrayList<>();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/ConstructDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/ConstructDTOValidator.java
@@ -27,9 +27,6 @@ import org.alliancegenome.curation_api.services.validation.dto.slotAnnotations.c
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import lombok.extern.jbosslog.JBossLog;
-
-@JBossLog
 @RequestScoped
 public class ConstructDTOValidator extends ReagentDTOValidator {
 
@@ -128,10 +125,9 @@ public class ConstructDTOValidator extends ReagentDTOValidator {
 			}
 		}
 
-		if (constructResponse.hasErrors()) {
-			log.info("ERROR: " + constructResponse.errorMessagesString());
+		if (constructResponse.hasErrors())
 			throw new ObjectValidationException(dto, constructResponse.errorMessagesString());
-		}
+
 		construct = constructDAO.persist(construct);
 
 		// Attach construct and persist SlotAnnotation objects

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/ConstructDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/ConstructDTOValidator.java
@@ -48,25 +48,9 @@ public class ConstructDTOValidator extends ReagentDTOValidator {
 		ObjectResponse<Construct> constructResponse = new ObjectResponse<Construct>();
 
 		Construct construct = new Construct();
-		
-		List<Reference> references = null;
-		List<String> refCuries = new ArrayList<>();
-		if (CollectionUtils.isNotEmpty(dto.getReferenceCuries())) {
-			references = new ArrayList<>();
-			for (String publicationId : dto.getReferenceCuries()) {
-				Reference reference = referenceService.retrieveFromDbOrLiteratureService(publicationId);
-				if (reference == null) {
-					constructResponse.addErrorMessage("reference_curies", ValidationConstants.INVALID_MESSAGE + " (" + publicationId + ")");
-				} else {
-					references.add(reference);
-					refCuries.add(reference.getCurie());
-				}
-			}
-		} 
-		
 		String constructId;
 		String identifyingField;
-		String uniqueId = ConstructUniqueIdHelper.getConstructUniqueId(dto, refCuries);
+		String uniqueId = ConstructUniqueIdHelper.getConstructUniqueId(dto);
 		
 		if (StringUtils.isNotBlank(dto.getModEntityId())) {
 			constructId = dto.getModEntityId();
@@ -86,7 +70,6 @@ public class ConstructDTOValidator extends ReagentDTOValidator {
 			construct = constructList.getResults().get(0);
 		}
 		construct.setUniqueId(uniqueId);
-		construct.setReferences(references);
 		
 		ObjectResponse<Construct> reagentResponse = validateReagentDTO(construct, dto);
 		constructResponse.addErrorMessages(reagentResponse.getErrorMessages());
@@ -96,6 +79,21 @@ public class ConstructDTOValidator extends ReagentDTOValidator {
 			constructResponse.addErrorMessage("name", ValidationConstants.REQUIRED_MESSAGE);;
 		} else {
 			construct.setName(dto.getName());
+		}
+
+		if (CollectionUtils.isNotEmpty(dto.getReferenceCuries())) {
+			List<Reference> references = new ArrayList<>();
+			for (String publicationId : dto.getReferenceCuries()) {
+				Reference reference = referenceService.retrieveFromDbOrLiteratureService(publicationId);
+				if (reference == null) {
+					constructResponse.addErrorMessage("reference_curies", ValidationConstants.INVALID_MESSAGE + " (" + publicationId + ")");
+				} else {
+					references.add(reference);
+				}
+			}
+			construct.setReferences(references);
+		} else {
+			construct.setReferences(null);
 		}
 		
 		Map<String, ConstructComponentSlotAnnotation> existingComponentIds = new HashMap<>();


### PR DESCRIPTION
Deletion FK fix.
Remove references from uniqueId to prevent super-long IDs.