### PR TITLE
SCRUM-3132 (update) Deal with removed or non-selected terms

### DIFF
--- a/src/main/cliapp/src/containers/allelesPage/inheritanceModes/InheritanceModesForm.js
+++ b/src/main/cliapp/src/containers/allelesPage/inheritanceModes/InheritanceModesForm.js
@@ -41,13 +41,22 @@ export const InheritanceModesForm = ({ state, dispatch }) => {
   
   const phenotypeTermOnChangeHandler = (event, setFieldValue, props) => {
     //updates value in table input box
-    setFieldValue(event.target.value);
+    let value = null;
+    if (event.target.value !== "") {
+      if (!event.target.value?.curie) {
+        value = {curie: event.target.value};
+      } else {
+        value = event.target.value;
+      }
+
+    }
+    setFieldValue(value);
     dispatch({ 
       type: 'EDIT_ROW', 
       entityType: 'alleleInheritanceModes', 
       index: props.rowIndex, 
       field: "phenotypeTerm", 
-      value: event.target.value
+      value: value
     });
   }
 


### PR DESCRIPTION
@adamgibs Is there a better place for this logic, or an easy way to avoid having to duplicate for other non-required autocomplete fields.  This was put in place to avoid a 400 error when a term was removed from a non-required field and saved in the detail page  - the caused a conversion error on the backend as it as trying to convert and empty string to a PhenotypeTerm.  The same error was being thrown if a valid curie was typed but not selected from the autocomplete list.