### PR TITLE
SCRUM-3316 update rowData directly to fix dropdown bug

### DIFF
--- a/src/main/cliapp/src/containers/allelesPage/fullName/FullNameForm.js
+++ b/src/main/cliapp/src/containers/allelesPage/fullName/FullNameForm.js
@@ -31,6 +31,8 @@ export const FullNameForm = ({ labelColumnSize, state, dispatch }) => {
   };
 
   const nameTypeOnChangeHandler = (props, event) => {
+    //termporary solution -- replace with props.editorCallback() after PrimeReact upgrade 
+    props.rowData.nameType = event.target.value;
     dispatch({ 
       type: 'EDIT_OBJECT', 
       entityType: 'alleleFullName', 
@@ -40,6 +42,8 @@ export const FullNameForm = ({ labelColumnSize, state, dispatch }) => {
   };
 
   const internalOnChangeHandler = (props, event) => {
+    //termporary solution -- replace with props.editorCallback() after PrimeReact upgrade 
+    props.rowData.internal = event.target.value;
     dispatch({ 
       type: 'EDIT_OBJECT', 
       entityType: 'alleleFullName', 
@@ -49,6 +53,8 @@ export const FullNameForm = ({ labelColumnSize, state, dispatch }) => {
   };
 
   const synonymScopeOnChangeHandler = (props, event) => {
+    //termporary solution -- replace with props.editorCallback() after PrimeReact upgrade 
+    props.rowData.synonymScope = event.target.value;
     dispatch({ 
       type: 'EDIT_OBJECT', 
       entityType: 'alleleFullName', 

--- a/src/main/cliapp/src/containers/allelesPage/functionalImpacts/FunctionalImpactsForm.js
+++ b/src/main/cliapp/src/containers/allelesPage/functionalImpacts/FunctionalImpactsForm.js
@@ -63,9 +63,11 @@ export const FunctionalImpactsForm = ({ state, dispatch }) => {
     });
   };
   const internalOnChangeHandler = (props, event) => {
+    //termporary solution -- replace with props.editorCallback() after PrimeReact upgrade 
+    props.rowData.internal = event.target.value;
     dispatch({
       type: 'EDIT_ROW',
-      entityType: 'alleleFunctionalImacts',
+      entityType: 'alleleFunctionalImpacts',
       index: props.rowIndex,
       field: "internal",
       value: event.target?.value?.name

--- a/src/main/cliapp/src/containers/allelesPage/inheritanceModes/InheritanceModesForm.js
+++ b/src/main/cliapp/src/containers/allelesPage/inheritanceModes/InheritanceModesForm.js
@@ -31,6 +31,8 @@ export const InheritanceModesForm = ({ state, dispatch }) => {
   };
 
   const inheritanceModeOnChangeHandler = (props, event) => {
+    //termporary solution -- replace with props.editorCallback() after PrimeReact upgrade 
+    props.rowData.inheritanceMode = event.target.value;
     dispatch({ 
       type: 'EDIT_ROW', 
       entityType: 'alleleInheritanceModes', 
@@ -55,6 +57,8 @@ export const InheritanceModesForm = ({ state, dispatch }) => {
   }
 
   const internalOnChangeHandler = (props, event) => {
+    //termporary solution -- replace with props.editorCallback() after PrimeReact upgrade 
+    props.rowData.internal = event.target.value;
     dispatch({ 
       type: 'EDIT_ROW', 
       entityType: 'alleleInheritanceModes', 

--- a/src/main/cliapp/src/containers/allelesPage/mutationTypes/MutationTypesForm.js
+++ b/src/main/cliapp/src/containers/allelesPage/mutationTypes/MutationTypesForm.js
@@ -38,6 +38,8 @@ export const MutationTypesForm = ({ state, dispatch }) => {
   }
 
   const internalOnChangeHandler = (props, event) => {
+    //termporary solution -- replace with props.editorCallback() after PrimeReact upgrade 
+    props.rowData.internal = event.target.value;
     dispatch({ 
       type: 'EDIT_ROW', 
       entityType: 'alleleMutationTypes', 

--- a/src/main/cliapp/src/containers/allelesPage/secondaryIds/SecondaryIdsForm.js
+++ b/src/main/cliapp/src/containers/allelesPage/secondaryIds/SecondaryIdsForm.js
@@ -28,6 +28,8 @@ export const SecondaryIdsForm = ({ state, dispatch }) => {
   };
 
   const internalOnChangeHandler = (props, event) => {
+    //termporary solution -- replace with props.editorCallback() after PrimeReact upgrade 
+    props.rowData.internal = event.target.value;
     dispatch({ 
       type: 'EDIT_ROW', 
       entityType: 'alleleSecondaryIds', 

--- a/src/main/cliapp/src/containers/allelesPage/synonyms/SynonymsForm.js
+++ b/src/main/cliapp/src/containers/allelesPage/synonyms/SynonymsForm.js
@@ -31,6 +31,8 @@ export const SynonymsForm = ({ labelColumnSize, state, dispatch }) => {
   };
 
   const nameTypeOnChangeHandler = (props, event) => {
+    //termporary solution -- replace with props.editorCallback() after PrimeReact upgrade 
+    props.rowData.nameType = event.target.value;
     dispatch({ 
       type: 'EDIT_ROW', 
       entityType: 'alleleSynonyms', 
@@ -41,6 +43,8 @@ export const SynonymsForm = ({ labelColumnSize, state, dispatch }) => {
   };
 
   const internalOnChangeHandler = (props, event) => {
+    //termporary solution -- replace with props.editorCallback() after PrimeReact upgrade 
+    props.rowData.internal = event.target.value;
     dispatch({ 
       type: 'EDIT_ROW', 
       entityType: 'alleleSynonyms', 
@@ -51,6 +55,8 @@ export const SynonymsForm = ({ labelColumnSize, state, dispatch }) => {
   };
 
   const synonymScopeOnChangeHandler = (props, event) => {
+    //termporary solution -- replace with props.editorCallback() after PrimeReact upgrade 
+    props.rowData.synonymScope = event.target.value;
     dispatch({ 
       type: 'EDIT_ROW', 
       entityType: 'alleleSynonyms', 


### PR DESCRIPTION
@markquintontulloch We're going to have to go with your solution from  earlier today for now. The DataTable component props provides an editorCallback that is used to update the editor state. The problem is, it fails in tables that use row edit and open in edit mode.  I put together a demo and asked the PrimeReact people about it this morning and they said that it's a bug in PrimeReact version 8.x but is fixed in 9.6.2. However, that upgrade will have to wait. I've added comments as a reminder for now. 