### PR TITLE
SCRUM-3507 - Possible fix for 'failed to initialize collection...' error

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/PersonService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/PersonService.java
@@ -43,6 +43,8 @@ public class PersonService extends BaseEntityCrudService<Person, PersonDAO> {
 			} else {
 				Log.debug("Person not cached, caching uniqueId: (" + uniqueId + ")");
 				person = findPersonByUniqueIdOrCreateDB(uniqueId);
+				if (person != null)
+					person.getEmails().size();
 				personCacheMap.put(uniqueId, person);
 			}
 		} else {

--- a/src/main/java/org/alliancegenome/curation_api/services/PersonService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/PersonService.java
@@ -10,6 +10,7 @@ import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.base.BaseEntityCrudService;
 import org.alliancegenome.curation_api.services.validation.PersonValidator;
+import org.hibernate.Hibernate;
 
 import io.quarkus.logging.Log;
 import jakarta.annotation.PostConstruct;
@@ -43,8 +44,10 @@ public class PersonService extends BaseEntityCrudService<Person, PersonDAO> {
 			} else {
 				Log.debug("Person not cached, caching uniqueId: (" + uniqueId + ")");
 				person = findPersonByUniqueIdOrCreateDB(uniqueId);
-				if (person != null)
-					person.getEmails().size();
+				if (person != null) {
+					Hibernate.initialize(person.getOldEmails());
+					Hibernate.initialize(person.getEmails());
+				}
 				personCacheMap.put(uniqueId, person);
 			}
 		} else {


### PR DESCRIPTION
Note sure this will work as cannot reproduce the error locally, but we had the same error for VocabularyTerm synonyms and fixed it like this.

Current error:
`failed to lazily initialize a collection of role: org.alliancegenome.curation_api.model.entities.Person.emails: could not initialize proxy - no Session (through reference chain: org.alliancegenome.curation_api.response.ObjectResponse["entity"]->org.alliancegenome.curation_api.model.entities.VocabularyTerm["vocabulary"]->org.alliancegenome.curation_api.model.entities.Vocabulary["updatedBy"]->org.alliancegenome.curation_api.model.entities.Person["emails"])
Nov 15 23:02:23 [agr.curation.alpha.api.server](http://logs.alliancegenome.org:5601/app/logtrail) : 	at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:361)`