### PR TITLE
SCRUM-3507 (Partial?) fix for creating VocabularyTerms

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/PersonService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/PersonService.java
@@ -10,7 +10,6 @@ import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.base.BaseEntityCrudService;
 import org.alliancegenome.curation_api.services.validation.PersonValidator;
-import org.hibernate.Hibernate;
 
 import io.quarkus.logging.Log;
 import jakarta.annotation.PostConstruct;
@@ -44,10 +43,6 @@ public class PersonService extends BaseEntityCrudService<Person, PersonDAO> {
 			} else {
 				Log.debug("Person not cached, caching uniqueId: (" + uniqueId + ")");
 				person = findPersonByUniqueIdOrCreateDB(uniqueId);
-				if (person != null) {
-					Hibernate.initialize(person.getOldEmails());
-					Hibernate.initialize(person.getEmails());
-				}
 				personCacheMap.put(uniqueId, person);
 			}
 		} else {

--- a/src/main/java/org/alliancegenome/curation_api/view/View.java
+++ b/src/main/java/org/alliancegenome/curation_api/view/View.java
@@ -17,7 +17,7 @@ public class View {
 	public static class ConditionRelationUpdateView extends ConditionRelationView {
 	}
 
-	public static class VocabularyTermView extends FieldsAndLists {
+	public static class VocabularyTermView extends FieldsOnly {
 	}
 
 	public static class VocabularyView extends FieldsOnly {


### PR DESCRIPTION
This gets rid of the lazy initialization error.  However, there is still an issue in that you have to reload the table (not reindex) to see new vocabulary terms.  This also seems to be the case on other tables though (e.g. Vocabulary Term Set / Condition) - possibly something to do with the PrimeReact or Quarkus upgrades?  Deletions disappear in realtime without a reload.