### PR TITLE
SCRUM-3620 - Fix failing Construct Association loads

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/associations/constructAssociations/ConstructGenomicEntityAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/constructAssociations/ConstructGenomicEntityAssociationService.java
@@ -87,7 +87,7 @@ public class ConstructGenomicEntityAssociationService extends BaseAssociationDTO
 
 	public List<Long> getAssociationsByDataProvider(BackendBulkDataProvider dataProvider) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put("subjectConstruct." + EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
 		List<String> associationIdStrings = constructGenomicEntityAssociationDAO.findFilteredIds(params);
 		associationIdStrings.removeIf(Objects::isNull);
 		List<Long> associationIds = associationIdStrings.stream().map(Long::parseLong).collect(Collectors.toList());


### PR DESCRIPTION
Change will be reverted when LinkML v2.0.0 refactor gets merged.  Only required due to the temporary field name changes to get around issues with Quarkus 3 upgrade.