### PR TITLE
SCRUM-3641 Fix DA retrieval and cleanup logic

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/constants/EntityFieldConstants.java
+++ b/src/main/java/org/alliancegenome/curation_api/constants/EntityFieldConstants.java
@@ -3,6 +3,7 @@ package org.alliancegenome.curation_api.constants;
 public final class EntityFieldConstants {
 
 	public static final String DATA_PROVIDER = "dataProvider.sourceOrganization.abbreviation";
+	public static final String SECONDARY_DATA_PROVIDER = "secondaryDataProvider.sourceOrganization.abbreviation";
 	public static final String SUBJECT_DATA_PROVIDER = "subject." + DATA_PROVIDER;
 	public static final String SUBJECT_TAXON = "subject.taxon.curie";
 	public static final String TAXON = "taxon.curie";

--- a/src/main/java/org/alliancegenome/curation_api/services/AGMDiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AGMDiseaseAnnotationService.java
@@ -1,12 +1,7 @@
 package org.alliancegenome.curation_api.services;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
-import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.AGMDiseaseAnnotationDAO;
 import org.alliancegenome.curation_api.dao.ConditionRelationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
@@ -18,7 +13,6 @@ import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.base.BaseDTOCrudService;
 import org.alliancegenome.curation_api.services.validation.AGMDiseaseAnnotationValidator;
 import org.alliancegenome.curation_api.services.validation.dto.AGMDiseaseAnnotationDTOValidator;
-import org.apache.commons.lang.StringUtils;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
@@ -99,14 +93,6 @@ public class AGMDiseaseAnnotationService extends BaseDTOCrudService<AGMDiseaseAn
 	public void removeOrDeprecateNonUpdated(String curie, String loadDescription) { }
 
 	public List<Long> getAnnotationIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
-		if(StringUtils.equals(dataProvider.sourceOrganization, "RGD"))
-			params.put(EntityFieldConstants.SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
-		List<String> annotationIdStrings = agmDiseaseAnnotationDAO.findFilteredIds(params);
-		annotationIdStrings.removeIf(Objects::isNull);
-		List<Long> annotationIds = annotationIdStrings.stream().map(Long::parseLong).collect(Collectors.toList());
-		
-		return annotationIds;
+		return diseaseAnnotationService.getAnnotationIdsByDataProvider(agmDiseaseAnnotationDAO, dataProvider);
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/AlleleDiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AlleleDiseaseAnnotationService.java
@@ -1,12 +1,7 @@
 package org.alliancegenome.curation_api.services;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
-import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.AlleleDiseaseAnnotationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
@@ -17,7 +12,6 @@ import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.base.BaseDTOCrudService;
 import org.alliancegenome.curation_api.services.validation.AlleleDiseaseAnnotationValidator;
 import org.alliancegenome.curation_api.services.validation.dto.AlleleDiseaseAnnotationDTOValidator;
-import org.apache.commons.lang.StringUtils;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
@@ -96,14 +90,6 @@ public class AlleleDiseaseAnnotationService extends BaseDTOCrudService<AlleleDis
 	public void removeOrDeprecateNonUpdated(String curie, String loadDescription) { }
 
 	public List<Long> getAnnotationIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
-		if(StringUtils.equals(dataProvider.sourceOrganization, "RGD"))
-			params.put(EntityFieldConstants.SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
-		List<String> annotationIdStrings = alleleDiseaseAnnotationDAO.findFilteredIds(params);
-		annotationIdStrings.removeIf(Objects::isNull);
-		List<Long> annotationIds = annotationIdStrings.stream().map(Long::parseLong).collect(Collectors.toList());
-		
-		return annotationIds;
+		return diseaseAnnotationService.getAnnotationIdsByDataProvider(alleleDiseaseAnnotationDAO, dataProvider);
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/DiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/DiseaseAnnotationService.java
@@ -2,11 +2,17 @@ package org.alliancegenome.curation_api.services;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.DiseaseAnnotationDAO;
 import org.alliancegenome.curation_api.dao.PersonDAO;
+import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
+import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.ConditionRelation;
 import org.alliancegenome.curation_api.model.entities.DiseaseAnnotation;
@@ -16,6 +22,7 @@ import org.alliancegenome.curation_api.services.base.BaseEntityCrudService;
 import org.alliancegenome.curation_api.services.helpers.diseaseAnnotations.DiseaseAnnotationUniqueIdUpdateHelper;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
@@ -128,6 +135,29 @@ public class DiseaseAnnotationService extends BaseEntityCrudService<DiseaseAnnot
 		pdh.finishProcess();
 		
 		return conditionRelationIds;
+	}
+	
+	protected <D extends BaseSQLDAO<?>> List<Long> getAnnotationIdsByDataProvider(D dao, BackendBulkDataProvider dataProvider) {
+		Map<String, Object> params = new HashMap<>();
+		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
+		
+		if(StringUtils.equals(dataProvider.sourceOrganization, "RGD"))
+			params.put(EntityFieldConstants.SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
+		
+		List<String> annotationIdStrings = dao.findFilteredIds(params);
+		annotationIdStrings.removeIf(Objects::isNull);
+		
+		if (StringUtils.equals(dataProvider.toString(), "HUMAN")) {
+			Map<String, Object> newParams = new HashMap<>();
+			newParams.put(EntityFieldConstants.SECONDARY_DATA_PROVIDER, dataProvider.sourceOrganization);
+			newParams.put(EntityFieldConstants.SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
+			List<String> additionalIdStrings = dao.findFilteredIds(newParams);
+			annotationIdStrings.addAll(additionalIdStrings);
+		}
+		
+		List<Long> annotationIds = annotationIdStrings.stream().map(Long::parseLong).collect(Collectors.toList());
+		
+		return annotationIds;
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneDiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneDiseaseAnnotationService.java
@@ -1,12 +1,7 @@
 package org.alliancegenome.curation_api.services;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
-import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.GeneDiseaseAnnotationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
@@ -17,7 +12,6 @@ import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.base.BaseDTOCrudService;
 import org.alliancegenome.curation_api.services.validation.GeneDiseaseAnnotationValidator;
 import org.alliancegenome.curation_api.services.validation.dto.GeneDiseaseAnnotationDTOValidator;
-import org.apache.commons.lang.StringUtils;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
@@ -96,14 +90,6 @@ public class GeneDiseaseAnnotationService extends BaseDTOCrudService<GeneDisease
 	public void removeOrDeprecateNonUpdated(String curie, String loadDescription) { }
 
 	public List<Long> getAnnotationIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
-		if(StringUtils.equals(dataProvider.sourceOrganization, "RGD"))
-			params.put(EntityFieldConstants.SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
-		List<String> annotationIdStrings = geneDiseaseAnnotationDAO.findFilteredIds(params);
-		annotationIdStrings.removeIf(Objects::isNull);
-		List<Long> annotationIds = annotationIdStrings.stream().map(Long::parseLong).collect(Collectors.toList());
-		
-		return annotationIds;
+		return diseaseAnnotationService.getAnnotationIdsByDataProvider(geneDiseaseAnnotationDAO, dataProvider);
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/DiseaseAnnotationRetrievalHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/diseaseAnnotations/DiseaseAnnotationRetrievalHelper.java
@@ -1,0 +1,21 @@
+package org.alliancegenome.curation_api.services.helpers.diseaseAnnotations;
+
+import org.alliancegenome.curation_api.model.entities.DiseaseAnnotation;
+import org.alliancegenome.curation_api.response.SearchResponse;
+import org.apache.commons.collections.CollectionUtils;
+
+public abstract class DiseaseAnnotationRetrievalHelper {
+
+	public static <E extends DiseaseAnnotation> E getCurrentDiseaseAnnotation(E annotation, SearchResponse<E> annotationList) {
+		if (annotationList == null || CollectionUtils.isEmpty(annotationList.getResults()))
+			return annotation;
+		
+		for (E annotationInList : annotationList.getResults()) {
+			if (!annotationInList.getObsolete())
+				return annotationInList;
+		}
+		
+		return annotationList.getResults().get(0);
+	}
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AGMDiseaseAnnotationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AGMDiseaseAnnotationDTOValidator.java
@@ -22,6 +22,7 @@ import org.alliancegenome.curation_api.model.ingest.dto.AGMDiseaseAnnotationDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.VocabularyTermService;
+import org.alliancegenome.curation_api.services.helpers.diseaseAnnotations.DiseaseAnnotationRetrievalHelper;
 import org.alliancegenome.curation_api.services.helpers.diseaseAnnotations.DiseaseAnnotationUniqueIdHelper;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -80,9 +81,7 @@ public class AGMDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOValida
 				}
 
 				SearchResponse<AGMDiseaseAnnotation> annotationList = agmDiseaseAnnotationDAO.findByField(identifyingField, annotationId);
-				if (annotationList != null && annotationList.getResults().size() > 0) {
-					annotation = annotationList.getResults().get(0);
-				}
+				annotation = DiseaseAnnotationRetrievalHelper.getCurrentDiseaseAnnotation(annotation, annotationList);
 				annotation.setUniqueId(uniqueId);
 				annotation.setSubject(agm);
 				

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AlleleDiseaseAnnotationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AlleleDiseaseAnnotationDTOValidator.java
@@ -19,6 +19,7 @@ import org.alliancegenome.curation_api.model.ingest.dto.AlleleDiseaseAnnotationD
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.VocabularyTermService;
+import org.alliancegenome.curation_api.services.helpers.diseaseAnnotations.DiseaseAnnotationRetrievalHelper;
 import org.alliancegenome.curation_api.services.helpers.diseaseAnnotations.DiseaseAnnotationUniqueIdHelper;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -74,9 +75,7 @@ public class AlleleDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOVal
 				}
 
 				SearchResponse<AlleleDiseaseAnnotation> annotationList = alleleDiseaseAnnotationDAO.findByField(identifyingField, annotationId);
-				if (annotationList != null && annotationList.getResults().size() > 0) {
-					annotation = annotationList.getResults().get(0);
-				}
+				annotation = DiseaseAnnotationRetrievalHelper.getCurrentDiseaseAnnotation(annotation, annotationList);
 				annotation.setUniqueId(uniqueId);
 				annotation.setSubject(allele);
 				

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDiseaseAnnotationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDiseaseAnnotationDTOValidator.java
@@ -18,6 +18,7 @@ import org.alliancegenome.curation_api.model.ingest.dto.GeneDiseaseAnnotationDTO
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.VocabularyTermService;
+import org.alliancegenome.curation_api.services.helpers.diseaseAnnotations.DiseaseAnnotationRetrievalHelper;
 import org.alliancegenome.curation_api.services.helpers.diseaseAnnotations.DiseaseAnnotationUniqueIdHelper;
 import org.apache.commons.lang3.StringUtils;
 
@@ -76,9 +77,7 @@ public class GeneDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOValid
 				}
 
 				SearchResponse<GeneDiseaseAnnotation> annotationList = geneDiseaseAnnotationDAO.findByField(identifyingField, annotationId);
-				if (annotationList != null && annotationList.getResults().size() > 0) {
-					annotation = annotationList.getResults().get(0);
-				}
+				annotation = DiseaseAnnotationRetrievalHelper.getCurrentDiseaseAnnotation(annotation, annotationList);
 				annotation.setUniqueId(uniqueId);
 				annotation.setSubject(gene);
 				


### PR DESCRIPTION
Hotfix to fix issue that resulted in duplicate disease annotations - reload of human DAs after fix will deprecate duplicates