### PR TITLE
SCRUM-3844 Possible fix for failing ontology loads

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/jobs/JobScheduler.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/JobScheduler.java
@@ -63,6 +63,7 @@ public class JobScheduler {
 	@ConfigProperty(name = "reindex.schedulingEnabled", defaultValue = "false") Boolean reindexSchedulingEnabled;
 
 	private ZonedDateTime lastCheck = null;
+	private Boolean checksInProgress = false;
 
 	@PostConstruct
 	public void init() {
@@ -103,8 +104,10 @@ public class JobScheduler {
 
 	@Scheduled(every = "1s")
 	public void scheduleCronGroupJobs() {
-		if (loadSchedulingEnabled) {
+		if (loadSchedulingEnabled && !checksInProgress) {
 			ZonedDateTime start = ZonedDateTime.now();
+			Log.info("START: " + start);
+			checksInProgress = true;
 			// log.info("scheduleGroupJobs: Scheduling Enabled: " + loadSchedulingEnabled);
 			SearchResponse<BulkLoadGroup> groups = groupDAO.findAll();
 			for (BulkLoadGroup g : groups.getResults()) {
@@ -145,6 +148,7 @@ public class JobScheduler {
 				}
 			}
 			lastCheck = start;
+			checksInProgress = false;
 		}
 	}
 

--- a/src/main/resources/db/migration/v0.32.0.1__reactivate_scheduled_jobs.sql
+++ b/src/main/resources/db/migration/v0.32.0.1__reactivate_scheduled_jobs.sql
@@ -1,0 +1,1 @@
+UPDATE bulkscheduledload SET scheduleactive = true;


### PR DESCRIPTION
@oblodgett I think this should fix the issue of failing loads that we're seeing on beta now that the scheduled loads have been reenabled (not sure how to test scheduled stuff locally).  If you look at the logs then you'll see that the failing loads are getting kicked off multiple times within the space of a few seconds.  My theory is that the loop is taking > 1 second to run so the lastCheck time doesn't get updated before the next scheduled check, and the load gets kicked off again.