### PR TITLE
Increase uniqueId width further

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Annotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Annotation.java
@@ -56,7 +56,7 @@ public class Annotation extends SingleReferenceAssociation {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "uniqueId_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@Column(length = 3000)
+	@Column(length = 3500)
 	@JsonView({ View.FieldsOnly.class })
 	@EqualsAndHashCode.Include
 	protected String uniqueId;

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/base/UniqueIdAuditedObject.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/base/UniqueIdAuditedObject.java
@@ -23,7 +23,7 @@ public class UniqueIdAuditedObject extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "uniqueId_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@Column(unique = true, length = 3000)
+	@Column(unique = true, length = 3500)
 	@JsonView({ View.FieldsOnly.class })
 	@EqualsAndHashCode.Include
 	protected String uniqueId;

--- a/src/main/resources/db/migration/v0.32.0.5__bigger_column_width_increase.sql
+++ b/src/main/resources/db/migration/v0.32.0.5__bigger_column_width_increase.sql
@@ -1,0 +1,3 @@
+ALTER TABLE experimentalcondition ALTER COLUMN uniqueid TYPE VARCHAR(3500);
+ALTER TABLE conditionrelation ALTER COLUMN uniqueid TYPE VARCHAR(3500);
+ALTER TABLE annotation ALTER COLUMN uniqueid TYPE VARCHAR(3500);


### PR DESCRIPTION
This will deal with the single WB phenotype annotation that's exceeding the current width limits.  May have to bump the size again once all data issues are resolved by DQMs, but I suspect that won't be the case.