### PR TITLE
SCRUM-3944 Fix deletion FK errors for FMS bulk load cleanup

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AGMPhenotypeAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AGMPhenotypeAnnotation.java
@@ -8,8 +8,6 @@ import org.alliancegenome.curation_api.view.View;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -35,7 +33,6 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @Schema(name = "AGM_Phenotype_Annotation", description = "Annotation class representing a agm phenotype annotation")
 @JsonTypeName("AGMPhenotypeAnnotation")
-@OnDelete(action = OnDeleteAction.CASCADE)
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { PhenotypeAnnotation.class })
 @Table(indexes = {
 	@Index(name = "AGMPhenotypeAnnotation_inferredGene_index", columnList = "inferredGene_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AllelePhenotypeAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AllelePhenotypeAnnotation.java
@@ -8,8 +8,6 @@ import org.alliancegenome.curation_api.view.View;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -35,7 +33,6 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @Schema(name = "Allele_Phenotype_Annotation", description = "Annotation class representing a allele phenotype annotation")
 @JsonTypeName("AllelePhenotypeAnnotation")
-@OnDelete(action = OnDeleteAction.CASCADE)
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { PhenotypeAnnotation.class })
 @Table(indexes = {
 	@Index(name = "AllelePhenotypeAnnotation_inferredGene_index", columnList = "inferredGene_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/EvidenceAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/EvidenceAssociation.java
@@ -24,7 +24,6 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @Schema(name = "evidenceAssociation", description = "POJO that represents an association supported by any number of information content entities")
 @AGRCurationSchemaVersion(min = "1.9.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { Association.class })
-
 public class EvidenceAssociation extends Association {
 
 	@IndexedEmbedded(includeDepth = 2)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GeneGeneticInteraction.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GeneGeneticInteraction.java
@@ -4,13 +4,10 @@ import java.util.List;
 
 import org.alliancegenome.curation_api.constants.LinkMLSchemaConstants;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
-import org.alliancegenome.curation_api.model.entities.ontology.MITerm;
 import org.alliancegenome.curation_api.view.View;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.search.engine.backend.types.Aggregable;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.Sortable;
@@ -39,7 +36,6 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @Schema(name = "Gene_Genetic_Interaction", description = "Class representing an interaction between genes")
-@OnDelete(action = OnDeleteAction.CASCADE)
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { GeneInteraction.class })
 @Table(indexes = {
 	@Index(name = "genegeneticinteraction_interactorageneticperturbarion_index", columnList = "interactorageneticperturbation_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GeneMolecularInteraction.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GeneMolecularInteraction.java
@@ -7,8 +7,6 @@ import org.alliancegenome.curation_api.view.View;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -30,7 +28,6 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @Schema(name = "Gene_Molecular_Interaction", description = "Class representing an interaction between gene products")
-@OnDelete(action = OnDeleteAction.CASCADE)
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { GeneInteraction.class })
 @Table(indexes = {
 	@Index(name = "genemolecularinteraction_aggregationdatabase_index", columnList = "aggregationdatabase_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GenePhenotypeAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GenePhenotypeAnnotation.java
@@ -4,8 +4,6 @@ import org.alliancegenome.curation_api.constants.LinkMLSchemaConstants;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
 import org.alliancegenome.curation_api.view.View;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -29,7 +27,6 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @Schema(name = "Gene_Phenotype_Annotation", description = "Annotation class representing a gene phenotype annotation")
 @JsonTypeName("GenePhenotypeAnnotation")
-@OnDelete(action = OnDeleteAction.CASCADE)
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { PhenotypeAnnotation.class })
 @Table(indexes = {
 	@Index(name = "genephenotypeannotation_phenotypeannotationsubject_index", columnList = "phenotypeannotationsubject_id"),


### PR DESCRIPTION
@oblodgett Not entirely sure why the @OnDelete annotation was causing FK errors when deleting interactions/phenotypes (I thought that was exactly what it was supposed to prevent!), especially since we have the annotation on the child disease annotation entities and it doesn't cause any issues.  However, have tested it and made sure the entries are being removed from all parent/child tables.