### PR TITLE
SCRUM-4114 Handle duplicate interaction refs

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GeneInteractionFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GeneInteractionFmsDTOValidator.java
@@ -217,6 +217,7 @@ public class GeneInteractionFmsDTOValidator extends BaseDTOValidator {
 	protected ObjectResponse<List<Reference>> validateReferences(PsiMiTabDTO dto) {
 		ObjectResponse<List<Reference>> refResponse = new ObjectResponse<>();
 		List<Reference> validatedReferences = new ArrayList<>();
+		List<Long> validatedReferenceIds = new ArrayList<>();
 		if (CollectionUtils.isNotEmpty(dto.getPublicationIds())) {
 			for (String publicationId : dto.getPublicationIds()) {
 				Reference reference = null;
@@ -228,7 +229,10 @@ public class GeneInteractionFmsDTOValidator extends BaseDTOValidator {
 					refResponse.addErrorMessage("publicationIds", ValidationConstants.INVALID_MESSAGE + " (" + publicationId + ")");
 					return refResponse;
 				}
-				validatedReferences.add(reference);
+				if (!validatedReferenceIds.contains(reference.getId())) {
+					validatedReferences.add(reference);
+					validatedReferenceIds.add(reference.getId());
+				}
 			}
 		}
 		if (CollectionUtils.isNotEmpty(validatedReferences)) {

--- a/src/test/java/org/alliancegenome/curation_api/GeneInteractionBulkUploadFmsITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/GeneInteractionBulkUploadFmsITCase.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.curation_api;
 
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
@@ -311,5 +312,18 @@ public class GeneInteractionBulkUploadFmsITCase extends BaseITCase {
 			statusCode(200).
 			body("entity.geneAssociationSubject.modEntityId", is(gene3));
 			
+	}
+	
+	@Test
+	@Order(11)
+	public void geneInteractionHandleDuplicateReferences() throws Exception {
+		checkSuccessfulBulkLoad(geneMolecularInteractionBulkPostEndpoint, geneInteractionTestFilePath + "DR_01_duplicate_references.json");
+		
+		RestAssured.given().
+			when().
+			get(geneMolecularInteractionGetEndpoint + geneMolecularInteractionId).
+			then().
+			statusCode(200).
+			body("entity.evidence", hasSize(1));
 	}
 }

--- a/src/test/resources/bulk/fms/04_gene_interaction/DR_01_duplicate_references.json
+++ b/src/test/resources/bulk/fms/04_gene_interaction/DR_01_duplicate_references.json
@@ -1,0 +1,20 @@
+[
+	{
+		"interactorAIdentifier": "wormbase:GITestGene0001",
+		"interactorBIdentifier": "wormbase:GITestGene0002",
+		"interactionDetectionMethods": ["psi-mi:\"MI:Test0007\"(Test MITerm 7)"],
+		"authors": ["Deplancke B et al. (2006)"],
+		"publicationIds": ["pubmed:25920554", "pubmed:25920554"],
+		"interactorATaxonId": "taxid:6239(caeel)|taxid:6239(Caenorhabditis elegans)",
+		"interactorBTaxonId": "taxid:6239(caeel)|taxid:6239(Caenorhabditis elegans)",
+		"interactionTypes": ["psi-mi:\"MI:Test0002\"(Test MITerm 2)"],
+		"sourceDatabaseIds": ["psi-mi:\"MI:Test0001\"(Test MITerm 1)"],
+		"interactionIds": ["wormbase:WBInteraction0001"],
+		"experimentalRoleA": "psi-mi:\"MI:Test0003\"(Test MITerm 3)",
+		"experimentalRoleB": "psi-mi:\"MI:Test0004\"(Test MITerm 4)",
+		"interactorAType": "psi-mi:\"MI:Test0005\"(Test MITerm 5)",
+		"interactorBType": "psi-mi:\"MI:Test0006\"(Test MITerm 6)",
+		"creationDate": "2024/01/17",
+		"updateDate": "2024/01/18"
+	}
+]


### PR DESCRIPTION
Single entries in input file can contain lists of references where curies are different xrefs of same reference.