### PR TITLE
SCRUM-4062 Handle invalid phenotype terms when searching for primary annotation

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/AGMPhenotypeAnnotationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/AGMPhenotypeAnnotationFmsDTOValidator.java
@@ -81,7 +81,7 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 		Reference reference = refResponse.getEntity();
 		String refString = reference == null ? null : reference.getCurie();
 		
-		List<AGMPhenotypeAnnotation> primaryAnnotations = findPrimaryAnnotations(agmPhenotypeAnnotationDAO, dto, primaryAnnotationSubject.getIdentifier(), refString);
+		List<AGMPhenotypeAnnotation> primaryAnnotations = findPrimaryAnnotations(agmPhenotypeAnnotationDAO, dto, primaryAnnotationSubject.getModEntityId(), refString);
 		
 		if (CollectionUtils.isEmpty(primaryAnnotations)) {
 			PhenotypeFmsDTO inferredPrimaryDTO = createPrimaryAnnotationDTO(dto, primaryAnnotationSubject.getIdentifier());

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/AllelePhenotypeAnnotationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/AllelePhenotypeAnnotationFmsDTOValidator.java
@@ -78,7 +78,7 @@ public class AllelePhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotatio
 		Reference reference = refResponse.getEntity();
 		String refString = reference == null ? null : reference.getCurie();
 		
-		List<AllelePhenotypeAnnotation> primaryAnnotations = findPrimaryAnnotations(allelePhenotypeAnnotationDAO, dto, primaryAnnotationSubject.getIdentifier(), refString);
+		List<AllelePhenotypeAnnotation> primaryAnnotations = findPrimaryAnnotations(allelePhenotypeAnnotationDAO, dto, primaryAnnotationSubject.getModEntityId(), refString);
 		
 		if (CollectionUtils.isEmpty(primaryAnnotations)) {
 

--- a/src/test/resources/bulk/fms/03_phenotype_annotation/AS_01_add_secondary_allele_annotation_to_primary_agm_annotation.json
+++ b/src/test/resources/bulk/fms/03_phenotype_annotation/AS_01_add_secondary_allele_annotation_to_primary_agm_annotation.json
@@ -18,24 +18,7 @@
         "curie": "ZFIN:ZDB-PUB-130927-9"
       }
     },
-    "dateAssigned": "2024-01-17T07:26:56-08:00",
-    "conditionRelations": [
-      {
-        "conditionRelationType": "exacerbates",
-        "conditions": [
-          {
-            "conditionClassId": "PATEST:ExpCondTerm0001",
-            "conditionStatement": "condition summary test",
-            "conditionId": "PATEST:ExpCondTerm0002",
-            "conditionQuantity": "Some amount",
-            "anatomicalOntologyId": "PATEST:AnatomyTerm0001",
-            "geneOntologyId": "PATEST:GOTerm0001",
-            "NCBITaxonId": "NCBITaxon:6239",
-            "chemicalOntologyId": "PATEST:ChemicalTerm0001"
-          }
-        ]
-      }
-    ]
+    "dateAssigned": "2024-01-17T07:26:56-08:00"
   },
   {
     "objectId": "PATEST:Allele0001",
@@ -57,24 +40,7 @@
         "curie": "ZFIN:ZDB-PUB-130927-9"
       }
     },
-    "dateAssigned": "2024-01-17T07:26:56-08:00",
-    "conditionRelations": [
-      {
-        "conditionRelationType": "exacerbates",
-        "conditions": [
-          {
-            "conditionClassId": "PATEST:ExpCondTerm0001",
-            "conditionStatement": "condition summary test",
-            "conditionId": "PATEST:ExpCondTerm0002",
-            "conditionQuantity": "Some amount",
-            "anatomicalOntologyId": "PATEST:AnatomyTerm0001",
-            "geneOntologyId": "PATEST:GOTerm0001",
-            "NCBITaxonId": "NCBITaxon:6239",
-            "chemicalOntologyId": "PATEST:ChemicalTerm0001"
-          }
-        ]
-      }
-    ]
+    "dateAssigned": "2024-01-17T07:26:56-08:00"
   },
   {
     "objectId": "PATEST:Gene0001",
@@ -96,23 +62,6 @@
         "curie": "ZFIN:ZDB-PUB-130927-9"
       }
     },
-    "dateAssigned": "2024-01-17T07:26:56-08:00",
-    "conditionRelations": [
-      {
-        "conditionRelationType": "exacerbates",
-        "conditions": [
-          {
-            "conditionClassId": "PATEST:ExpCondTerm0001",
-            "conditionStatement": "condition summary test",
-            "conditionId": "PATEST:ExpCondTerm0002",
-            "conditionQuantity": "Some amount",
-            "anatomicalOntologyId": "PATEST:AnatomyTerm0001",
-            "geneOntologyId": "PATEST:GOTerm0001",
-            "NCBITaxonId": "NCBITaxon:6239",
-            "chemicalOntologyId": "PATEST:ChemicalTerm0001"
-          }
-        ]
-      }
-    ]
+    "dateAssigned": "2024-01-17T07:26:56-08:00"
   }
 ]

--- a/src/test/resources/bulk/fms/03_phenotype_annotation/AS_02_add_secondary_gene_annotation_to_primary_allele_annotation.json
+++ b/src/test/resources/bulk/fms/03_phenotype_annotation/AS_02_add_secondary_gene_annotation_to_primary_allele_annotation.json
@@ -57,23 +57,6 @@
           "curie": "ZFIN:ZDB-PUB-130927-9"
         }
       },
-      "dateAssigned": "2024-01-17T07:26:56-08:00",
-      "conditionRelations": [
-        {
-          "conditionRelationType": "exacerbates",
-          "conditions": [
-            {
-              "conditionClassId": "PATEST:ExpCondTerm0001",
-              "conditionStatement": "condition summary test",
-              "conditionId": "PATEST:ExpCondTerm0002",
-              "conditionQuantity": "Some amount",
-              "anatomicalOntologyId": "PATEST:AnatomyTerm0001",
-              "geneOntologyId": "PATEST:GOTerm0001",
-              "NCBITaxonId": "NCBITaxon:6239",
-              "chemicalOntologyId": "PATEST:ChemicalTerm0001"
-            }
-          ]
-        }
-      ]
+      "dateAssigned": "2024-01-17T07:26:56-08:00"
     }
   ]


### PR DESCRIPTION
We ignore invalid phenotypeTerms when loading due to FMS submission inconsistencies (and the fact they aren't loaded in Neo4j anyway).  Search for primary annotations corresponding to secondary annotations needs to take this into account.