### PR TITLE
SCRUM-4228 Remove error rate column from data loads page

### DIFF
--- a/src/main/cliapp/src/containers/dataLoadsPage/DataLoadsComponent.js
+++ b/src/main/cliapp/src/containers/dataLoadsPage/DataLoadsComponent.js
@@ -493,10 +493,6 @@ export const DataLoadsComponent = () => {
 		return <Button label={latestStatus} tooltip={latestError} className={`p-button-rounded ${styleClass}`} />;
 	};
 
-	const percentage = (row) => {
-		return Math.round(row.errorRate * 100).toFixed(1) + '%';
-	};
-
 	const historyTable = (file) => {
 		let sortedHistory = file.history.sort(function (a, b) {
 			const start1 = new Date(a.loadStarted);
@@ -510,7 +506,6 @@ export const DataLoadsComponent = () => {
 					<Column field="loadFinished" header="Load Finished" />
 					<Column field="completedRecords" header="Records Completed" />
 					<Column field="failedRecords" header="Records Failed" />
-					<Column body={percentage} header="Error Rate / 1000" />
 					<Column field="totalRecords" header="Total Records" />
 					<Column field="deletedRecords" header="Deletes Completed" />
 					<Column field="deleteFailedRecords" header="Deletes Failed" />


### PR DESCRIPTION
Reported error rate is misleading, especially for loads with error rate cutoff turned off