### PR TITLE
SCRUM-4174 (update) Fix total record count

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/Gff3Executor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/Gff3Executor.java
@@ -69,7 +69,7 @@ public class Gff3Executor extends LoadFileExecutor {
 			
 			Map<String, List<Long>> previousIds = getPreviouslyLoadedIds(dataProvider);
 			
-			BulkLoadFileHistory history = new BulkLoadFileHistory(gffData.size());
+			BulkLoadFileHistory history = new BulkLoadFileHistory((gffData.size() * 2) + 1);
 			createHistory(history, bulkLoadFile);
 			idsAdded = runLoad(history, gffHeaderData, gffData, idsAdded, dataProvider);
 			runCleanup(transcriptService, history, dataProvider.name(), previousIds.get("Transcript"), idsAdded.get("Transcript"), "GFF transcript", bulkLoadFile.getMd5Sum());


### PR DESCRIPTION
Each non-header GFF line gets processed twice (once for entities, once for associations), and the assembly header line gets processed to update/create the GenomeAssembly.  As such, the sum of records completed and records failed will be equal to ((2 * no. non-header lines) + 1).