### PR TITLE
SCRUM-4174 (update) Don't store curie as modEntityId as not unique

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/Gff3Service.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/Gff3Service.java
@@ -66,7 +66,7 @@ public class Gff3Service {
 	}
 	
 	public Map<String, List<Long>> loadEntity(BulkLoadFileHistory history, Gff3DTO gffEntry, Map<String, List<Long>> idsAdded, BackendBulkDataProvider dataProvider) throws ObjectUpdateException {
-		if (StringUtils.equals(gffEntry.getType(), "exon")) {
+		if (StringUtils.equals(gffEntry.getType(), "exon") || StringUtils.equals(gffEntry.getType(), "noncoding_exon")) {
 			Exon exon = gff3DtoValidator.validateExonEntry(gffEntry, dataProvider);
 			if (exon != null) {
 				idsAdded.get("Exon").add(exon.getId());

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/Gff3DtoValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/Gff3DtoValidator.java
@@ -135,10 +135,6 @@ public class Gff3DtoValidator {
 	private <E extends GenomicEntity> ObjectResponse<E> validateGffEntity(E entity, Gff3DTO dto, Map<String, String> attributes, BackendBulkDataProvider dataProvider) {
 		ObjectResponse<E> geResponse = new ObjectResponse<E>();
 		
-		if (attributes.containsKey("curie")) {
-			entity.setModEntityId(attributes.get("curie"));
-		}
-		
 		entity.setDataProvider(dataProviderService.createOrganizationDataProvider(dataProvider.sourceOrganization));
 		entity.setTaxon(ncbiTaxonTermService.getByCurie(dataProvider.canonicalTaxonCurie).getEntity());
 		


### PR DESCRIPTION
Will need to discuss with DQMs whether we can sort this out via GFF changes, or if additional slots are required to store the "curies" being submitted in these attributes.  Lots of non-uniqueness and other strange stuff going on in the GFFs. 