### PR TITLE
SCRUM-4174 (update) Add data provider prefix to modInternalId

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/Gff3DtoValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/Gff3DtoValidator.java
@@ -167,6 +167,17 @@ public class Gff3DtoValidator {
 			}
 		}
 		
+		for (String key : List.of("ID", "Parent")) {
+			if (attributes.containsKey(key)) {
+				String id = attributes.get(key);
+				String[] idParts = id.split(":");
+				if (idParts.length == 1) {
+					id = dataProvider.name() + ':' + idParts[0];
+				}
+				attributes.put(key, id);
+			}
+		}
+		
 		return attributes;
 	}
 

--- a/src/test/java/org/alliancegenome/curation_api/Gff3BulkUploadITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/Gff3BulkUploadITCase.java
@@ -41,9 +41,9 @@ public class Gff3BulkUploadITCase extends BaseITCase {
 	private final String transcriptGetEndpoint = "/api/transcript/";
 	private final String exonGetEndpoint = "/api/exon/";
 	private final String cdsGetEndpoint = "/api/cds/";
-	private final String transcriptId = "Y74C9A.2a.1";
-	private final String exonUniqueId = "Y74C9A.2a_exon|Y74C9A.2a.1|I|1|100|+";
-	private final String cdsUniqueId = "Y74C9A.2a|Y74C9A.2a.1|I|10|100|+";
+	private final String transcriptId = "WB:Y74C9A.2a.1";
+	private final String exonUniqueId = "WB:Y74C9A.2a_exon|WB:Y74C9A.2a.1|I|1|100|+";
+	private final String cdsUniqueId = "WB:Y74C9A.2a|WB:Y74C9A.2a.1|I|10|100|+";
 	
 	private void loadRequiredEntities() throws Exception {
 		createSoTerm("SO:0000234", "mRNA", false);


### PR DESCRIPTION
Prefix required as same ID used in GFF files from different data providers