### PR TITLE
Remove FBCV terms attached to phenotypeannotations

### DIFF
--- a/src/main/resources/db/migration/v0.36.0.4__remove_fbcv_terms_loaded_as_phenotype_terms.sql
+++ b/src/main/resources/db/migration/v0.36.0.4__remove_fbcv_terms_loaded_as_phenotype_terms.sql
@@ -1,0 +1,3 @@
+DELETE FROM phenotypeannotation_ontologyterm WHERE phenotypeterms_id IN (
+	SELECT id FROM ontologyterm WHERE ontologytermtype = 'FBCVTerm'
+);


### PR DESCRIPTION
DPOTerms were previously loaded in the phenotype annotation load.  These have been replaced by FBCVTerms, which no longer inherit from PhenotypeTerm so need to be removed.