### PR TITLE
SCRUM-4175 (update) Remove reverse associations

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AssemblyComponent.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AssemblyComponent.java
@@ -1,12 +1,7 @@
 package org.alliancegenome.curation_api.model.entities;
 
-import java.util.List;
-
 import org.alliancegenome.curation_api.constants.LinkMLSchemaConstants;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
-import org.alliancegenome.curation_api.model.entities.associations.codingSequenceAssociations.CodingSequenceGenomicLocationAssociation;
-import org.alliancegenome.curation_api.model.entities.associations.exonAssociations.ExonGenomicLocationAssociation;
-import org.alliancegenome.curation_api.model.entities.associations.transcriptAssociations.TranscriptGenomicLocationAssociation;
 import org.alliancegenome.curation_api.view.View;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
@@ -16,11 +11,9 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDe
 
 import com.fasterxml.jackson.annotation.JsonView;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -30,7 +23,7 @@ import lombok.ToString;
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@ToString(exclude = {"transcriptGenomicLocationAssociations", "exonGenomicLocationAssociations", "codingSequenceGenomicLocationAssociations"}, callSuper = true)
+@ToString(callSuper = true)
 @Schema(name = "AssemblyComponent", description = "POJO that represents the AssemblyComponent")
 @AGRCurationSchemaVersion(min = "2.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { GenomicEntity.class })
 @Table(
@@ -54,17 +47,5 @@ public class AssemblyComponent extends GenomicEntity {
 	@ManyToOne
 	@JsonView({ View.FieldsOnly.class })
 	private Chromosome mapsToChromosome;
-	
-	@OneToMany(mappedBy = "transcriptGenomicLocationAssociationObject", cascade = CascadeType.ALL, orphanRemoval = true)
-	@JsonView({ View.FieldsAndLists.class })
-	private List<TranscriptGenomicLocationAssociation> transcriptGenomicLocationAssociations;
-	
-	@OneToMany(mappedBy = "exonGenomicLocationAssociationObject", cascade = CascadeType.ALL, orphanRemoval = true)
-	@JsonView({ View.FieldsAndLists.class })
-	private List<ExonGenomicLocationAssociation> exonGenomicLocationAssociations;
-	
-	@OneToMany(mappedBy = "codingSequenceGenomicLocationAssociationObject", cascade = CascadeType.ALL, orphanRemoval = true)
-	@JsonView({ View.FieldsAndLists.class })
-	private List<CodingSequenceGenomicLocationAssociation> codingSequenceGenomicLocationAssociations;
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/codingSequenceAssociations/CodingSequenceGenomicLocationAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/codingSequenceAssociations/CodingSequenceGenomicLocationAssociation.java
@@ -13,9 +13,11 @@ import org.hibernate.search.engine.backend.types.Aggregable;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -61,11 +63,7 @@ public class CodingSequenceGenomicLocationAssociation extends LocationAssociatio
 	})
 	@ManyToOne
 	@JsonView({ View.FieldsOnly.class })
-	@JsonIgnoreProperties({
-		"codingSequenceGenomicLocationAssociations",
-		"exonGenomicLocationAssociations",
-		"transcriptGenomicLocationAssociations"
-	})
+	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@Fetch(FetchMode.JOIN)
 	private AssemblyComponent codingSequenceGenomicLocationAssociationObject;
 	

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/exonAssociations/ExonGenomicLocationAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/exonAssociations/ExonGenomicLocationAssociation.java
@@ -12,8 +12,10 @@ import org.hibernate.annotations.FetchMode;
 import org.hibernate.search.engine.backend.types.Aggregable;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -59,11 +61,7 @@ public class ExonGenomicLocationAssociation extends LocationAssociation {
 	})
 	@ManyToOne
 	@JsonView({ View.FieldsOnly.class })
-	@JsonIgnoreProperties({
-		"codingSequenceGenomicLocationAssociations",
-		"exonGenomicLocationAssociations",
-		"transcriptGenomicLocationAssociations"
-	})
+	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@Fetch(FetchMode.JOIN)
 	private AssemblyComponent exonGenomicLocationAssociationObject;
 	

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/transcriptAssociations/TranscriptGenomicLocationAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/transcriptAssociations/TranscriptGenomicLocationAssociation.java
@@ -13,9 +13,11 @@ import org.hibernate.search.engine.backend.types.Aggregable;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -61,11 +63,7 @@ public class TranscriptGenomicLocationAssociation extends LocationAssociation {
 	})
 	@ManyToOne
 	@JsonView({ View.FieldsOnly.class })
-	@JsonIgnoreProperties({
-		"codingSequenceGenomicLocationAssociations",
-		"exonGenomicLocationAssociations",
-		"transcriptGenomicLocationAssociations"
-	})
+	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@Fetch(FetchMode.JOIN)
 	private AssemblyComponent transcriptGenomicLocationAssociationObject;
 	

--- a/src/main/java/org/alliancegenome/curation_api/services/Gff3Service.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/Gff3Service.java
@@ -124,7 +124,7 @@ public class Gff3Service {
 			ExonGenomicLocationAssociation exonLocation = gff3DtoValidator.validateExonLocation(gffEntry, exon, assemblyId, dataProvider);
 			if (exonLocation != null) {
 				idsAdded.get("ExonGenomicLocationAssociation").add(exonLocation.getId());
-				exonLocationService.addAssociationToSubjectAndObject(exonLocation);
+				exonLocationService.addAssociationToSubject(exonLocation);
 			}
 		} else if (StringUtils.equals(gffEntry.getType(), "CDS")) {
 			String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, attributes, dataProvider);
@@ -136,7 +136,7 @@ public class Gff3Service {
 			CodingSequenceGenomicLocationAssociation cdsLocation = gff3DtoValidator.validateCdsLocation(gffEntry, cds, assemblyId, dataProvider);
 			if (cdsLocation != null) {
 				idsAdded.get("CodingSequenceGenomicLocationAssociation").add(cdsLocation.getId());
-				cdsLocationService.addAssociationToSubjectAndObject(cdsLocation);
+				cdsLocationService.addAssociationToSubject(cdsLocation);
 			}
 		} else if (Gff3Constants.TRANSCRIPT_TYPES.contains(gffEntry.getType())) {
 			if (StringUtils.equals(gffEntry.getType(), "lnc_RNA")) {
@@ -153,7 +153,7 @@ public class Gff3Service {
 			TranscriptGenomicLocationAssociation transcriptLocation = gff3DtoValidator.validateTranscriptLocation(gffEntry, transcript, assemblyId, dataProvider);
 			if (transcriptLocation != null) {
 				idsAdded.get("TranscriptGenomicLocationAssociation").add(transcriptLocation.getId());
-				transcriptLocationService.addAssociationToSubjectAndObject(transcriptLocation);
+				transcriptLocationService.addAssociationToSubject(transcriptLocation);
 			}
 		}
 		

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/codingSequenceAssociations/CodingSequenceGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/codingSequenceAssociations/CodingSequenceGenomicLocationAssociationService.java
@@ -13,7 +13,6 @@ import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.codingSequenceAssociations.CodingSequenceGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
-import org.alliancegenome.curation_api.model.entities.AssemblyComponent;
 import org.alliancegenome.curation_api.model.entities.CodingSequence;
 import org.alliancegenome.curation_api.model.entities.associations.codingSequenceAssociations.CodingSequenceGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.ObjectResponse;

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/codingSequenceAssociations/CodingSequenceGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/codingSequenceAssociations/CodingSequenceGenomicLocationAssociationService.java
@@ -103,7 +103,7 @@ public class CodingSequenceGenomicLocationAssociationService extends BaseEntityC
 		return response;
 	}
 	
-	public void addAssociationToSubjectAndObject(CodingSequenceGenomicLocationAssociation association) {
+	public void addAssociationToSubject(CodingSequenceGenomicLocationAssociation association) {
 		CodingSequence cds = association.getCodingSequenceAssociationSubject();
 		
 		List<CodingSequenceGenomicLocationAssociation> currentSubjectAssociations = cds.getCodingSequenceGenomicLocationAssociations();
@@ -116,20 +116,6 @@ public class CodingSequenceGenomicLocationAssociationService extends BaseEntityC
 		
 		if (!currentSubjectAssociationIds.contains(association.getId())) {
 			currentSubjectAssociations.add(association);
-		}
-		
-		AssemblyComponent assemblyComponent = association.getCodingSequenceGenomicLocationAssociationObject();
-		
-		List<CodingSequenceGenomicLocationAssociation> currentObjectAssociations = assemblyComponent.getCodingSequenceGenomicLocationAssociations();
-		if (currentObjectAssociations == null) {
-			currentObjectAssociations = new ArrayList<>();
-		}
-		
-		List<Long> currentObjectAssociationIds = currentObjectAssociations.stream()
-				.map(CodingSequenceGenomicLocationAssociation::getId).collect(Collectors.toList());
-		
-		if (!currentObjectAssociationIds.contains(association.getId())) {
-			currentObjectAssociations.add(association);
 		}
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/exonAssociations/ExonGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/exonAssociations/ExonGenomicLocationAssociationService.java
@@ -13,7 +13,6 @@ import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.exonAssociations.ExonGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
-import org.alliancegenome.curation_api.model.entities.AssemblyComponent;
 import org.alliancegenome.curation_api.model.entities.Exon;
 import org.alliancegenome.curation_api.model.entities.associations.exonAssociations.ExonGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.ObjectResponse;

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/exonAssociations/ExonGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/exonAssociations/ExonGenomicLocationAssociationService.java
@@ -103,7 +103,7 @@ public class ExonGenomicLocationAssociationService extends BaseEntityCrudService
 		return response;
 	}
 	
-	public void addAssociationToSubjectAndObject(ExonGenomicLocationAssociation association) {
+	public void addAssociationToSubject(ExonGenomicLocationAssociation association) {
 		Exon exon = association.getExonAssociationSubject();
 		
 		List<ExonGenomicLocationAssociation> currentSubjectAssociations = exon.getExonGenomicLocationAssociations();
@@ -116,20 +116,6 @@ public class ExonGenomicLocationAssociationService extends BaseEntityCrudService
 		
 		if (!currentSubjectAssociationIds.contains(association.getId())) {
 			currentSubjectAssociations.add(association);
-		}
-		
-		AssemblyComponent assemblyComponent = association.getExonGenomicLocationAssociationObject();
-		
-		List<ExonGenomicLocationAssociation> currentObjectAssociations = assemblyComponent.getExonGenomicLocationAssociations();
-		if (currentObjectAssociations == null) {
-			currentObjectAssociations = new ArrayList<>();
-		}
-		
-		List<Long> currentObjectAssociationIds = currentObjectAssociations.stream()
-				.map(ExonGenomicLocationAssociation::getId).collect(Collectors.toList());
-		
-		if (!currentObjectAssociationIds.contains(association.getId())) {
-			currentObjectAssociations.add(association);
 		}
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/transcriptAssociations/TranscriptGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/transcriptAssociations/TranscriptGenomicLocationAssociationService.java
@@ -13,7 +13,6 @@ import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.transcriptAssociations.TranscriptGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
-import org.alliancegenome.curation_api.model.entities.AssemblyComponent;
 import org.alliancegenome.curation_api.model.entities.Transcript;
 import org.alliancegenome.curation_api.model.entities.associations.transcriptAssociations.TranscriptGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.ObjectResponse;

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/transcriptAssociations/TranscriptGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/transcriptAssociations/TranscriptGenomicLocationAssociationService.java
@@ -103,7 +103,7 @@ public class TranscriptGenomicLocationAssociationService extends BaseEntityCrudS
 		return response;
 	}
 	
-	public void addAssociationToSubjectAndObject(TranscriptGenomicLocationAssociation association) {
+	public void addAssociationToSubject(TranscriptGenomicLocationAssociation association) {
 		Transcript transcript = association.getTranscriptAssociationSubject();
 		
 		List<TranscriptGenomicLocationAssociation> currentSubjectAssociations = transcript.getTranscriptGenomicLocationAssociations();
@@ -116,20 +116,6 @@ public class TranscriptGenomicLocationAssociationService extends BaseEntityCrudS
 		
 		if (!currentSubjectAssociationIds.contains(association.getId())) {
 			currentSubjectAssociations.add(association);
-		}
-		
-		AssemblyComponent assemblyComponent = association.getTranscriptGenomicLocationAssociationObject();
-		
-		List<TranscriptGenomicLocationAssociation> currentObjectAssociations = assemblyComponent.getTranscriptGenomicLocationAssociations();
-		if (currentObjectAssociations == null) {
-			currentObjectAssociations = new ArrayList<>();
-		}
-		
-		List<Long> currentObjectAssociationIds = currentObjectAssociations.stream()
-				.map(TranscriptGenomicLocationAssociation::getId).collect(Collectors.toList());
-		
-		if (!currentObjectAssociationIds.contains(association.getId())) {
-			currentObjectAssociations.add(association);
 		}
 	}
 }


### PR DESCRIPTION
Reverse associations prevent caching of AssemblyComponent - no current use case for needing to access reverse association, so removing as caching significantly improves load times.