### PR TITLE
SCRUM-3953: ignore the entry -Other- for Uberon terms

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GeneExpressionAnnotationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GeneExpressionAnnotationFmsDTOValidator.java
@@ -250,11 +250,13 @@ public class GeneExpressionAnnotationFmsDTOValidator {
 				List<UberonSlimTermDTO> anatomicalStructureUberonSlimTermIds = geneExpressionFmsDTO.getWhereExpressed().getAnatomicalStructureUberonSlimTermIds();
 				List<UBERONTerm> uberonTerms = new ArrayList<>();
 				for (UberonSlimTermDTO uberonSlimTermDTO: anatomicalStructureUberonSlimTermIds) {
-					UBERONTerm uberonTerm = uberonTermService.getByCurie(uberonSlimTermDTO.getUberonTerm()).getEntity();
-					if (uberonTerm == null) {
-						response.addErrorMessage("whereExpressed - anatomicalStructureUberonSlimTermId", ValidationConstants.INVALID_MESSAGE + " (" + uberonSlimTermDTO.getUberonTerm() + ")");
-					} else {
-						uberonTerms.add(uberonTerm);
+					if (!uberonSlimTermDTO.getUberonTerm().equals("Other")) {
+						UBERONTerm uberonTerm = uberonTermService.getByCurie(uberonSlimTermDTO.getUberonTerm()).getEntity();
+						if (uberonTerm == null) {
+							response.addErrorMessage("whereExpressed - anatomicalStructureUberonSlimTermId", ValidationConstants.INVALID_MESSAGE + " (" + uberonSlimTermDTO.getUberonTerm() + ")");
+						} else {
+							uberonTerms.add(uberonTerm);
+						}
 					}
 				}
 				anatomicalSite.setAnatomicalStructureUberonTerms(uberonTerms);
@@ -264,11 +266,13 @@ public class GeneExpressionAnnotationFmsDTOValidator {
 				List<UberonSlimTermDTO> anatomicalSubStructureUberonSlimTermIds = geneExpressionFmsDTO.getWhereExpressed().getAnatomicalSubStructureUberonSlimTermIds();
 				List<UBERONTerm> uberonTerms = new ArrayList<>();
 				for (UberonSlimTermDTO uberonSlimTermDTO : anatomicalSubStructureUberonSlimTermIds) {
-					UBERONTerm uberonTerm = uberonTermService.getByCurie(uberonSlimTermDTO.getUberonTerm()).getEntity();
-					if (uberonTerm == null) {
-						response.addErrorMessage("whereExpressed - anatomicalStructureUberonSlimTermId", ValidationConstants.INVALID_MESSAGE + " (" + uberonSlimTermDTO.getUberonTerm() + ")");
-					} else {
-						uberonTerms.add(uberonTerm);
+					if (!uberonSlimTermDTO.getUberonTerm().equals("Other")) {
+						UBERONTerm uberonTerm = uberonTermService.getByCurie(uberonSlimTermDTO.getUberonTerm()).getEntity();
+						if (uberonTerm == null) {
+							response.addErrorMessage("whereExpressed - anatomicalStructureUberonSlimTermId", ValidationConstants.INVALID_MESSAGE + " (" + uberonSlimTermDTO.getUberonTerm() + ")");
+						} else {
+							uberonTerms.add(uberonTerm);
+						}
 					}
 				}
 				anatomicalSite.setAnatomicalSubstructureUberonTerms(uberonTerms);


### PR DESCRIPTION
Some MODs are putting "Other" as an Uberon Term. The ingestion process will ignore them from now on.

See comment:
https://github.com/alliance-genome/agr_curation_schema/blob/0a27a7b8595bc173df097cf3f57269282e89b626/model/schema/expression.yaml#L384