### PR TITLE
Added name to the hash check

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Synonym.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Synonym.java
@@ -24,7 +24,7 @@ import lombok.ToString;
 @Entity
 @Data
 @NoArgsConstructor
-@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @Table(indexes = {
 		@Index(name = "synonym_createdby_index", columnList = "createdBy_id"),


### PR DESCRIPTION
@markquintontulloch @cmpich We might consider removing this from a bunch of the other classes. As this is a problem inside lambda's if the auditedobject fields are null.