### PR TITLE
v0.35.5 Hotfix - Clean up expression_atlas xrefs

### DIFF
--- a/src/main/resources/db/migration/v0.37.0.65__expression_atlas_cleanup.sql
+++ b/src/main/resources/db/migration/v0.37.0.65__expression_atlas_cleanup.sql
@@ -1,0 +1,19 @@
+UPDATE bulkscheduledload SET scheduleactive = false WHERE id IN (
+	SELECT id FROM bulkload WHERE backendbulkloadtype = 'EXPRESSION_ATLAS'
+);
+
+DELETE FROM dataprovider WHERE crossreference_id IN (
+	SELECT id FROM crossreference WHERE resourcedescriptorpage_id IN (
+		SELECT id FROM resourcedescriptorpage WHERE name = 'expression_atlas'
+	)
+);
+
+DELETE FROM genomicentity_crossreference WHERE crossreferences_id IN (
+	SELECT id FROM crossreference WHERE resourcedescriptorpage_id IN (
+		SELECT id FROM resourcedescriptorpage WHERE name = 'expression_atlas'
+	)
+);
+
+DELETE FROM crossreference WHERE resourcedescriptorpage_id IN (
+	SELECT id FROM resourcedescriptorpage WHERE name = 'expression_atlas'
+);


### PR DESCRIPTION
Will need to follow with separate hotfix to beta to fix migration order as v0.37.0.65 already exists