### PR TITLE
SCRUM-4634: remove entry from migration

### DIFF
--- a/src/main/resources/db/migration/v0.38.0.22__agm_association_loads.sql
+++ b/src/main/resources/db/migration/v0.38.0.22__agm_association_loads.sql
@@ -38,7 +38,6 @@ ALTER TABLE ONLY public.agmsequencetargetingreagentassociation ADD CONSTRAINT ag
 
 --create vocabulary
 
-INSERT INTO vocabulary (id, name, vocabularylabel) VALUES (nextval('vocabulary_seq'), 'AGM Relation', 'agm_relation');
 
 INSERT INTO vocabularyterm (id, name, vocabulary_id) SELECT nextval('vocabularyterm_seq'), 'contains', id FROM vocabulary WHERE vocabulary.vocabularylabel = 'agm_relation';
 


### PR DESCRIPTION
Trying to solve deployment  failure:

` Caused by: org.flywaydb.core.internal.command.DbMigrate$FlywayMigrateException: Script v0.38.0.22__agm_association_loads.sql failed
Feb 12 10:04:48 agr.curation.production.api.server : 	at org.alliancegenome.curation_api.main.Main.main(Main.java:11)
Feb 12 10:04:48 agr.curation.production.api.server : 	at io.quarkus.runtime.Quarkus.run(Quarkus.java:124)
Feb 12 10:04:48 agr.curation.production.api.server : ---------------------------------------------------
Feb 12 10:04:48 agr.curation.production.api.server : Error Code : 0
Feb 12 10:04:48 agr.curation.production.api.server : SQL State  : 23505
Feb 12 10:04:48 agr.curation.production.api.server : Location   : db/migration/v0.38.0.22__agm_association_loads.sql (/agr_curation/file:/agr_curation/agr_curation_api-runner.jar!/db/migration/v0.38.0.22__agm_association_loads.sql)
Feb 12 10:04:48 agr.curation.production.api.server :   Detail: Key (vocabularylabel)=(agm_relation) already exists.
Feb 12 10:04:48 agr.curation.production.api.server : Message    : ERROR: duplicate key value violates unique constraint "vocabulary_vocabularylabel_uk"
Feb 12 10:04:48 agr.curation.production.api.server : Statement  : Run Flyway with -X option to see the actual statement causing the problem`