### PR TITLE
SCRUM-4972 - Data file loads are failing in the curation system (Possible Quarkus upgrade effect)

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/loads/BulkScheduledLoadDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/loads/BulkScheduledLoadDAO.java
@@ -1,0 +1,13 @@
+package org.alliancegenome.curation_api.dao.loads;
+
+import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
+import org.alliancegenome.curation_api.model.entities.bulkloads.BulkScheduledLoad;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class BulkScheduledLoadDAO extends BaseSQLDAO<BulkScheduledLoad> {
+	protected BulkScheduledLoadDAO() {
+		super(BulkScheduledLoad.class);
+	}
+}

--- a/src/main/java/org/alliancegenome/curation_api/jobs/JobScheduler.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/JobScheduler.java
@@ -15,6 +15,7 @@ import org.alliancegenome.curation_api.dao.loads.BulkLoadFileDAO;
 import org.alliancegenome.curation_api.dao.loads.BulkLoadFileExceptionDAO;
 import org.alliancegenome.curation_api.dao.loads.BulkLoadFileHistoryDAO;
 import org.alliancegenome.curation_api.dao.loads.BulkLoadGroupDAO;
+import org.alliancegenome.curation_api.dao.loads.BulkScheduledLoadDAO;
 import org.alliancegenome.curation_api.enums.JobStatus;
 import org.alliancegenome.curation_api.jobs.events.PendingBulkLoadJobEvent;
 import org.alliancegenome.curation_api.jobs.events.PendingLoadJobEvent;
@@ -60,6 +61,9 @@ public class JobScheduler {
 	@Inject BulkLoadFileDAO bulkLoadFileDAO;
 	@Inject BulkLoadFileHistoryDAO bulkLoadFileHistoryDAO;
 	@Inject BulkLoadGroupDAO groupDAO;
+	@Inject BulkScheduledLoadDAO bulkScheduledLoadDAO;
+	
+	
 	@Inject BulkLoadDAO bulkLoadDAO;
 	@Inject BulkLoadFileExceptionDAO bulkLoadFileExceptionDAO;
 	@Inject SlackNotifier slackNotifier;
@@ -115,50 +119,45 @@ public class JobScheduler {
 		}
 	}
 
-	@Scheduled(every = "1s")
-	public void scheduleCronGroupJobs() {
+	@Scheduled(every = "1m")
+	public void scheduleCronJobs() {
 		if (loadSchedulingEnabled) {
 			if (sem.tryAcquire()) {
 				ZonedDateTime start = ZonedDateTime.now();
 				// Log.info("scheduleGroupJobs: Scheduling Enabled: " + loadSchedulingEnabled);
-				SearchResponse<BulkLoadGroup> groups = groupDAO.findAll();
-				for (BulkLoadGroup g : groups.getResults()) {
-					if (g.getLoads().size() > 0) {
-						for (BulkLoad b : g.getLoads()) {
-							if (b instanceof BulkScheduledLoad bsl) {
-								if (bsl.getScheduleActive() != null && bsl.getScheduleActive() && bsl.getCronSchedule() != null && !bsl.getBulkloadStatus().isRunning()) {
+				SearchResponse<BulkScheduledLoad> loads = bulkScheduledLoadDAO.findAll();
+				for(BulkScheduledLoad bsl: loads.getResults()) {
+					if (bsl.getScheduleActive() != null && bsl.getScheduleActive() && bsl.getCronSchedule() != null && !bsl.getBulkloadStatus().isRunning()) {
 
-									CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
-									CronParser parser = new CronParser(cronDefinition);
-									try {
-										Cron unixCron = parser.parse(bsl.getCronSchedule());
-										unixCron.validate();
+						CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
+						CronParser parser = new CronParser(cronDefinition);
+						try {
+							Cron unixCron = parser.parse(bsl.getCronSchedule());
+							unixCron.validate();
 
-										if (lastCheck != null) {
-											ExecutionTime executionTime = ExecutionTime.forCron(unixCron);
-											ZonedDateTime nextExecution = executionTime.nextExecution(lastCheck).get();
+							if (lastCheck != null) {
+								ExecutionTime executionTime = ExecutionTime.forCron(unixCron);
+								ZonedDateTime nextExecution = executionTime.nextExecution(lastCheck).get();
 
-											if (lastCheck.isBefore(nextExecution) && start.isAfter(nextExecution)) {
-												Log.info("Need to run Cron: " + bsl.getName());
-												bsl.setSchedulingErrorMessage(null);
-												bsl.setBulkloadStatus(JobStatus.SCHEDULED_PENDING);
-												bulkLoadDAO.merge(bsl);
-												pendingJobEvents.fireAsync(new PendingBulkLoadJobEvent(bsl.getId()));
-											}
-										}
-									} catch (Exception e) {
-										bsl.setSchedulingErrorMessage(e.getLocalizedMessage());
-										bsl.setErrorMessage(e.getLocalizedMessage());
-										bsl.setBulkloadStatus(JobStatus.FAILED);
-										slackNotifier.slackalert(bsl);
-										Log.error(e.getLocalizedMessage());
-										bulkLoadDAO.merge(bsl);
-									}
+								if (lastCheck.isBefore(nextExecution) && start.isAfter(nextExecution)) {
+									Log.info("Need to run Cron: " + bsl.getName());
+									bsl.setSchedulingErrorMessage(null);
+									bsl.setBulkloadStatus(JobStatus.SCHEDULED_PENDING);
+									bulkLoadDAO.merge(bsl);
+									pendingJobEvents.fireAsync(new PendingBulkLoadJobEvent(bsl.getId()));
 								}
 							}
+						} catch (Exception e) {
+							bsl.setSchedulingErrorMessage(e.getLocalizedMessage());
+							bsl.setErrorMessage(e.getLocalizedMessage());
+							bsl.setBulkloadStatus(JobStatus.FAILED);
+							slackNotifier.slackalert(bsl);
+							Log.error(e.getLocalizedMessage());
+							bulkLoadDAO.merge(bsl);
 						}
 					}
 				}
+
 				lastCheck = start;
 				sem.release();
 			} else {

--- a/src/main/java/org/alliancegenome/curation_api/jobs/JobScheduler.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/JobScheduler.java
@@ -62,8 +62,7 @@ public class JobScheduler {
 	@Inject BulkLoadFileHistoryDAO bulkLoadFileHistoryDAO;
 	@Inject BulkLoadGroupDAO groupDAO;
 	@Inject BulkScheduledLoadDAO bulkScheduledLoadDAO;
-	
-	
+
 	@Inject BulkLoadDAO bulkLoadDAO;
 	@Inject BulkLoadFileExceptionDAO bulkLoadFileExceptionDAO;
 	@Inject SlackNotifier slackNotifier;
@@ -126,7 +125,7 @@ public class JobScheduler {
 				ZonedDateTime start = ZonedDateTime.now();
 				// Log.info("scheduleGroupJobs: Scheduling Enabled: " + loadSchedulingEnabled);
 				SearchResponse<BulkScheduledLoad> loads = bulkScheduledLoadDAO.findAll();
-				for(BulkScheduledLoad bsl: loads.getResults()) {
+				for (BulkScheduledLoad bsl : loads.getResults()) {
 					if (bsl.getScheduleActive() != null && bsl.getScheduleActive() && bsl.getCronSchedule() != null && !bsl.getBulkloadStatus().isRunning()) {
 
 						CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
@@ -201,23 +200,12 @@ public class JobScheduler {
 		for (BulkLoad bulkLoad : bulkLoads) {
 			List<BulkLoadFileHistory> histories = bulkLoad.getHistory();
 
-			Map<String, List<BulkLoadFileHistory>> groupedByFile = histories.stream()
-				.collect(Collectors.groupingBy(history -> history.getBulkLoadFile().getMd5Sum()));
+			Map<String, List<BulkLoadFileHistory>> groupedByFile = histories.stream().collect(Collectors.groupingBy(history -> history.getBulkLoadFile().getMd5Sum()));
 
 			Map<String, List<BulkLoadFileHistory>> limitedGroups = groupedByFile.entrySet().stream()
-				.collect(Collectors.toMap(
-					Map.Entry::getKey,
-					e -> e.getValue().stream()
-						.sorted((o1, o2) -> o2.getLoadStarted().compareTo(o1.getLoadStarted()))
-						.filter(history -> !history.getCounts().isEmpty())
-						.limit(2)
-						.collect(Collectors.toList())
-			));
+				.collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().stream().sorted((o1, o2) -> o2.getLoadStarted().compareTo(o1.getLoadStarted())).filter(history -> !history.getCounts().isEmpty()).limit(2).collect(Collectors.toList())));
 
-			List<BulkLoadFileHistory> sortedList = limitedGroups.values().stream()
-				.flatMap(List::stream)
-				.sorted((o1, o2) -> o2.getLoadStarted().compareTo(o1.getLoadStarted()))
-				.collect(Collectors.toList());
+			List<BulkLoadFileHistory> sortedList = limitedGroups.values().stream().flatMap(List::stream).sorted((o1, o2) -> o2.getLoadStarted().compareTo(o1.getLoadStarted())).collect(Collectors.toList());
 
 			Set<String> selectedFiles = new HashSet<>();
 			List<BulkLoadFileHistory> historiesToKeep = new ArrayList<>();
@@ -237,7 +225,7 @@ public class JobScheduler {
 		}
 	}
 
-	//@Scheduled(cron = "0 0 0 ? * SUN")
+	// @Scheduled(cron = "0 0 0 ? * SUN")
 	public void runMassIndexerEverything() {
 		// Not sure what is going to happen when this time's out but should run anyway
 		// Defaults taken from the API endpoint

--- a/src/main/java/org/alliancegenome/curation_api/jobs/exceptions/AsyncExceptionHandler.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/exceptions/AsyncExceptionHandler.java
@@ -1,0 +1,52 @@
+package org.alliancegenome.curation_api.jobs.exceptions;
+
+import org.alliancegenome.curation_api.dao.loads.BulkLoadFileHistoryDAO;
+import org.alliancegenome.curation_api.enums.JobStatus;
+import org.alliancegenome.curation_api.jobs.events.StartedLoadJobEvent;
+import org.alliancegenome.curation_api.jobs.processors.BulkLoadFMSProcessor;
+import org.alliancegenome.curation_api.jobs.processors.BulkLoadURLProcessor;
+import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
+import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
+import org.alliancegenome.curation_api.model.entities.bulkloads.BulkURLLoad;
+
+import io.quarkus.arc.AsyncObserverExceptionHandler;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.EventContext;
+import jakarta.enterprise.inject.spi.ObserverMethod;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class AsyncExceptionHandler implements AsyncObserverExceptionHandler {
+
+	@Inject BulkLoadFileHistoryDAO bulkLoadFileHistoryDAO;
+	@Inject BulkLoadFMSProcessor bulkLoadFMSProcessor;
+	@Inject BulkLoadURLProcessor bulkLoadURLProcessor;
+	
+	@Override
+	public void handle(Throwable throwable, ObserverMethod<?> observerMethod, EventContext<?> eventContext) {
+
+		if(eventContext.getEvent() instanceof StartedLoadJobEvent) {
+			StartedLoadJobEvent event = (StartedLoadJobEvent)eventContext.getEvent();
+			BulkLoadFileHistory bulkLoadFileHistory = bulkLoadFileHistoryDAO.find(event.getId());
+
+			if(bulkLoadFileHistory.getBulkLoad() instanceof BulkFMSLoad bulkFMSLoad) {
+				bulkLoadFMSProcessor.endLoad(bulkLoadFileHistory, "Failed loading: " + bulkFMSLoad.getName() + " please check the logs for more info. " + bulkLoadFileHistory.getErrorMessage(), JobStatus.FAILED);
+			}
+			
+			if(bulkLoadFileHistory.getBulkLoad() instanceof BulkURLLoad bulkURLLoad) {
+				bulkLoadURLProcessor.endLoad(bulkLoadFileHistory, "Failed loading: " + bulkURLLoad.getName() + " please check the logs for more info. " + bulkLoadFileHistory.getErrorMessage(), JobStatus.FAILED);
+			}
+
+			Log.error("Load File: " + bulkLoadFileHistory.getBulkLoad().getName() + " is failed");
+			throwable.printStackTrace();
+
+		} else {
+			Log.error("Error handling missing for error type: " + observerMethod);
+		}
+		
+	}
+
+}
+
+

--- a/src/main/java/org/alliancegenome/curation_api/jobs/exceptions/AsyncExceptionHandler.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/exceptions/AsyncExceptionHandler.java
@@ -22,19 +22,19 @@ public class AsyncExceptionHandler implements AsyncObserverExceptionHandler {
 	@Inject BulkLoadFileHistoryDAO bulkLoadFileHistoryDAO;
 	@Inject BulkLoadFMSProcessor bulkLoadFMSProcessor;
 	@Inject BulkLoadURLProcessor bulkLoadURLProcessor;
-	
+
 	@Override
 	public void handle(Throwable throwable, ObserverMethod<?> observerMethod, EventContext<?> eventContext) {
 
-		if(eventContext.getEvent() instanceof StartedLoadJobEvent) {
-			StartedLoadJobEvent event = (StartedLoadJobEvent)eventContext.getEvent();
+		if (eventContext.getEvent() instanceof StartedLoadJobEvent) {
+			StartedLoadJobEvent event = (StartedLoadJobEvent) eventContext.getEvent();
 			BulkLoadFileHistory bulkLoadFileHistory = bulkLoadFileHistoryDAO.find(event.getId());
 
-			if(bulkLoadFileHistory.getBulkLoad() instanceof BulkFMSLoad bulkFMSLoad) {
+			if (bulkLoadFileHistory.getBulkLoad() instanceof BulkFMSLoad bulkFMSLoad) {
 				bulkLoadFMSProcessor.endLoad(bulkLoadFileHistory, "Failed loading: " + bulkFMSLoad.getName() + " please check the logs for more info. " + bulkLoadFileHistory.getErrorMessage(), JobStatus.FAILED);
 			}
-			
-			if(bulkLoadFileHistory.getBulkLoad() instanceof BulkURLLoad bulkURLLoad) {
+
+			if (bulkLoadFileHistory.getBulkLoad() instanceof BulkURLLoad bulkURLLoad) {
 				bulkLoadURLProcessor.endLoad(bulkLoadFileHistory, "Failed loading: " + bulkURLLoad.getName() + " please check the logs for more info. " + bulkLoadFileHistory.getErrorMessage(), JobStatus.FAILED);
 			}
 
@@ -44,9 +44,7 @@ public class AsyncExceptionHandler implements AsyncObserverExceptionHandler {
 		} else {
 			Log.error("Error handling missing for error type: " + observerMethod);
 		}
-		
+
 	}
 
 }
-
-

--- a/src/main/java/org/alliancegenome/curation_api/jobs/processors/BulkLoadFMSProcessor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/processors/BulkLoadFMSProcessor.java
@@ -6,6 +6,7 @@ import org.alliancegenome.curation_api.enums.JobStatus;
 import org.alliancegenome.curation_api.jobs.events.StartedBulkLoadJobEvent;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoad;
+import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.fms.DataFile;
 
 import io.quarkus.logging.Log;
@@ -45,6 +46,11 @@ public class BulkLoadFMSProcessor extends BulkLoadProcessor {
 				endLoad(bulkFMSLoad, "Load: " + bulkFMSLoad.getName() + " failed: FMS Params are missing", JobStatus.FAILED);
 			}
 		}
+	}
+	
+	@Override
+	public void endLoad(BulkLoadFileHistory bulkLoadFileHistory, String message, JobStatus status) {
+		super.endLoad(bulkLoadFileHistory, message, status);
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/jobs/processors/BulkLoadURLProcessor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/processors/BulkLoadURLProcessor.java
@@ -4,6 +4,7 @@ import org.alliancegenome.curation_api.dao.loads.BulkLoadDAO;
 import org.alliancegenome.curation_api.enums.JobStatus;
 import org.alliancegenome.curation_api.jobs.events.StartedBulkLoadJobEvent;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoad;
+import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkURLLoad;
 
 import io.quarkus.logging.Log;
@@ -43,5 +44,11 @@ public class BulkLoadURLProcessor extends BulkLoadProcessor {
 				endLoad(bulkURLLoad, "Load: " + bulkURLLoad.getName() + " failed: URL is missing", JobStatus.FAILED);
 			}
 		}
+	}
+	
+	
+	@Override
+	public void endLoad(BulkLoadFileHistory bulkLoadFileHistory, String message, JobStatus status) {
+		super.endLoad(bulkLoadFileHistory, message, status);
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/document/builders/DiseaseSummaryDocumentBuilder.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/builders/DiseaseSummaryDocumentBuilder.java
@@ -94,7 +94,7 @@ public class DiseaseSummaryDocumentBuilder {
 	}
 
 	private String getAlleleName(Allele allele) {
-		return allele.getAlleleSymbol().getDisplayText() + getSpeciesAbbrev(allele);
+		return allele.getAlleleSymbol().getFormatText() + getSpeciesAbbrev(allele);
 	}
 
 	private String getModelName(AffectedGenomicModel model) {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoad.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoad.java
@@ -20,7 +20,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Index;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
@@ -76,7 +75,7 @@ public abstract class BulkLoad extends AuditedObject {
 	private BulkLoadGroup group;
 	
 	@JsonView({ View.FieldsOnly.class })
-	@OneToMany(mappedBy = "bulkLoad", fetch = FetchType.EAGER)
+	@OneToMany(mappedBy = "bulkLoad")
 	@OrderBy("loadFinished DESC")
 	private List<BulkLoadFileHistory> history;
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkScheduledLoad.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkScheduledLoad.java
@@ -27,7 +27,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.2.4", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { BulkLoad.class })
-public abstract class BulkScheduledLoad extends BulkLoad {
+public class BulkScheduledLoad extends BulkLoad {
 
 	@JsonView({ View.FieldsOnly.class })
 	private Boolean scheduleActive;
@@ -55,9 +55,6 @@ public abstract class BulkScheduledLoad extends BulkLoad {
 		} catch (Exception e) {
 			return "";
 		}
-	}
-
-	public void setNextRun(String nextRun) {
 	}
 
 }


### PR DESCRIPTION
new file:   src/main/java/org/alliancegenome/curation_api/dao/loads/BulkScheduledLoadDAO.java

- Added new DAO for scheduled loads

modified:   src/main/java/org/alliancegenome/curation_api/jobs/JobScheduler.java

- Change the job scheduler to run only every minute and minimized the amount of objects that its pulling

new file:   src/main/java/org/alliancegenome/curation_api/jobs/exceptions/AsyncExceptionHandler.java

- Added a new exception handler for all Async excpetions this can be used for other loads etc

modified:   src/main/java/org/alliancegenome/curation_api/jobs/processors/BulkLoadFMSProcessor.java
modified:   src/main/java/org/alliancegenome/curation_api/jobs/processors/BulkLoadURLProcessor.java

- Added access to endLoad method so it could be called from the outside

modified:   src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoad.java

- Turned of the default fetching of history... This might bite us on the history exception page we will have to see

modified:   src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkScheduledLoad.java

- Change BulkScheduledLoad to not be abstract and removed unused method