### PR TITLE
SCRUM-5200 Remove unnecessary DataProviderCrossReferences causing cleanup FK errors

### DIFF
--- a/src/main/resources/db/migration/v0.41.0.1__remove_dataprovider_xref_from_pa.sql
+++ b/src/main/resources/db/migration/v0.41.0.1__remove_dataprovider_xref_from_pa.sql
@@ -1,0 +1,10 @@
+CREATE TABLE tmp_dpxref_id AS SELECT DISTINCT id FROM crossreference WHERE referencedcurie IN ('WB','FB','SGD','RGD','MGI','ZFIN','XB','XBXL','XBXT','OMIM');
+
+UPDATE phenotypeannotation SET dataprovidercrossreference_id = NULL;
+UPDATE htpdatasetexpressionannotation SET dataprovidercrossreference_id = NULL;
+
+UPDATE biologicalentity SET dataprovidercrossreference_id = NULL WHERE dataprovidercrossreference_id IN (SELECT id FROM tmp_dpxref_id);
+
+DELETE FROM crossreference WHERE id IN (SELECT id FROM tmp_dpxref_id);
+
+DROP TABLE tmp_dpxref_id;

--- a/src/main/resources/db/migration/v0.41.0.1__remove_dataprovider_xref_from_pa.sql
+++ b/src/main/resources/db/migration/v0.41.0.1__remove_dataprovider_xref_from_pa.sql
@@ -1,7 +1,7 @@
 CREATE TABLE tmp_dpxref_id AS SELECT DISTINCT id FROM crossreference WHERE referencedcurie IN ('WB','FB','SGD','RGD','MGI','ZFIN','XB','XBXL','XBXT','OMIM');
 
 UPDATE phenotypeannotation SET dataprovidercrossreference_id = NULL;
-UPDATE htpdatasetexpressionannotation SET dataprovidercrossreference_id = NULL;
+UPDATE htpexpressiondatasetannotation SET dataprovidercrossreference_id = NULL;
 
 UPDATE biologicalentity SET dataprovidercrossreference_id = NULL WHERE dataprovidercrossreference_id IN (SELECT id FROM tmp_dpxref_id);
 


### PR DESCRIPTION
Data provider xrefs should be unique (even if referencing same curie). This cleans up shared xrefs that only reference the organization, and therefore provide no information not available directly from the dataprovider. These xrefs are no longer generated and are hangovers from old loads and/or migrations.