### PR TITLE
SCRUM-5200 (update) Fix association cleanup

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/associations/AgmAgmAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/AgmAgmAssociationService.java
@@ -1,6 +1,5 @@
 package org.alliancegenome.curation_api.services.associations;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -14,7 +13,6 @@ import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.SequenceTargetingReagentDAO;
 import org.alliancegenome.curation_api.dao.associations.AgmAgmAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
@@ -30,9 +28,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import lombok.extern.jbosslog.JBossLog;
 
-@JBossLog
 @RequestScoped
 public class AgmAgmAssociationService extends BaseAssociationDTOCrudService<AgmAgmAssociation, AgmAgmAssociationDTO, AgmAgmAssociationDAO> implements BaseUpsertServiceInterface<AgmAgmAssociation, AgmAgmAssociationDTO> {
 
@@ -71,39 +67,6 @@ public class AgmAgmAssociationService extends BaseAssociationDTOCrudService<AgmA
 		associationIds.removeIf(Objects::isNull);
 
 		return associationIds;
-	}
-
-	//todo: is this needed?
-	@Override
-	@Transactional
-	public AgmAgmAssociation deprecateOrDelete(Long id, Boolean throwApiError, String loadDescription, Boolean deprecate) {
-		AgmAgmAssociation association = agmAgmAssociationDAO.find(id);
-
-		if (association == null) {
-			String errorMessage = "Could not find AgmAgmAssociation with id: " + id;
-			if (throwApiError) {
-				ObjectResponse<AgmAgmAssociation> response = new ObjectResponse<>();
-				response.addErrorMessage("id", errorMessage);
-				throw new ApiErrorException(response);
-			}
-			log.error(errorMessage);
-			return null;
-		}
-		if (deprecate) {
-			if (!association.getObsolete()) {
-				association.setObsolete(true);
-				if (authenticatedPerson.getId() != null) {
-					association.setUpdatedBy(personDAO.find(authenticatedPerson.getId()));
-				} else {
-					association.setUpdatedBy(personService.fetchByUniqueIdOrCreate(loadDescription));
-				}
-				association.setDateUpdated(OffsetDateTime.now());
-				return agmAgmAssociationDAO.persist(association);
-			}
-			return association;
-		}
-
-		return null;
 	}
 
 	public ObjectResponse<AgmAgmAssociation> getAssociation(Long agmId, String relationName, Long strId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/AgmAlleleAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/AgmAlleleAssociationService.java
@@ -1,6 +1,5 @@
 package org.alliancegenome.curation_api.services.associations;
 
-import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,7 +12,6 @@ import org.alliancegenome.curation_api.dao.NoteDAO;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.AgmAlleleAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.associations.AgmAlleleAssociation;
@@ -24,7 +22,6 @@ import org.alliancegenome.curation_api.services.PersonService;
 import org.alliancegenome.curation_api.services.base.BaseAssociationDTOCrudService;
 import org.alliancegenome.curation_api.services.validation.dto.associations.AgmAlleleAssociationDTOValidator;
 
-import io.quarkus.logging.Log;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -60,39 +57,6 @@ public class AgmAlleleAssociationService extends BaseAssociationDTOCrudService<A
 		List<Long> associationIds = agmAlleleAssociationDAO.findIdsByParams(params);
 		associationIds.removeIf(Objects::isNull);
 		return associationIds;
-	}
-
-	//todo: is this needed?
-	@Override
-	@Transactional
-	public AgmAlleleAssociation deprecateOrDelete(Long id, Boolean throwApiError, String loadDescription, Boolean deprecate) {
-		AgmAlleleAssociation association = agmAlleleAssociationDAO.find(id);
-
-		if (association == null) {
-			String errorMessage = "Could not find AgmAlleleAssociation with id: " + id;
-			if (throwApiError) {
-				ObjectResponse<AgmAlleleAssociation> response = new ObjectResponse<>();
-				response.addErrorMessage("id", errorMessage);
-				throw new ApiErrorException(response);
-			}
-			Log.error(errorMessage);
-			return null;
-		}
-		if (deprecate) {
-			if (!association.getObsolete()) {
-				association.setObsolete(true);
-				if (authenticatedPerson.getId() != null) {
-					association.setUpdatedBy(personDAO.find(authenticatedPerson.getId()));
-				} else {
-					association.setUpdatedBy(personService.fetchByUniqueIdOrCreate(loadDescription));
-				}
-				association.setDateUpdated(OffsetDateTime.now());
-				return agmAlleleAssociationDAO.persist(association);
-			}
-			return association;
-		}
-
-		return null;
 	}
 
 	public ObjectResponse<AgmAlleleAssociation> getAssociation(Long agmId, String relationName, Long alleleId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/AgmStrAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/AgmStrAssociationService.java
@@ -1,6 +1,5 @@
 package org.alliancegenome.curation_api.services.associations;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -14,7 +13,6 @@ import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.SequenceTargetingReagentDAO;
 import org.alliancegenome.curation_api.dao.associations.AgmSequenceTargetingReagentAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
@@ -31,9 +29,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import lombok.extern.jbosslog.JBossLog;
 
-@JBossLog
 @RequestScoped
 public class AgmStrAssociationService extends BaseAssociationDTOCrudService<AgmSequenceTargetingReagentAssociation, AgmSequenceTargetingReagentAssociationDTO, AgmSequenceTargetingReagentAssociationDAO> implements BaseUpsertServiceInterface<AgmSequenceTargetingReagentAssociation, AgmSequenceTargetingReagentAssociationDTO> {
 
@@ -65,39 +61,6 @@ public class AgmStrAssociationService extends BaseAssociationDTOCrudService<AgmS
 		associationIds.removeIf(Objects::isNull);
 
 		return associationIds;
-	}
-
-	//todo: is this needed?
-	@Override
-	@Transactional
-	public AgmSequenceTargetingReagentAssociation deprecateOrDelete(Long id, Boolean throwApiError, String loadDescription, Boolean deprecate) {
-		AgmSequenceTargetingReagentAssociation association = agmStrAssociationDAO.find(id);
-
-		if (association == null) {
-			String errorMessage = "Could not find AgmSequenceTargetingReagentAssociation with id: " + id;
-			if (throwApiError) {
-				ObjectResponse<AgmSequenceTargetingReagentAssociation> response = new ObjectResponse<>();
-				response.addErrorMessage("id", errorMessage);
-				throw new ApiErrorException(response);
-			}
-			log.error(errorMessage);
-			return null;
-		}
-		if (deprecate) {
-			if (!association.getObsolete()) {
-				association.setObsolete(true);
-				if (authenticatedPerson.getId() != null) {
-					association.setUpdatedBy(personDAO.find(authenticatedPerson.getId()));
-				} else {
-					association.setUpdatedBy(personService.fetchByUniqueIdOrCreate(loadDescription));
-				}
-				association.setDateUpdated(OffsetDateTime.now());
-				return agmStrAssociationDAO.persist(association);
-			}
-			return association;
-		}
-
-		return null;
 	}
 
 	public ObjectResponse<AgmSequenceTargetingReagentAssociation> getAssociation(Long agmId, String relationName, Long strId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/CodingSequenceGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/CodingSequenceGenomicLocationAssociationService.java
@@ -1,6 +1,5 @@
 package org.alliancegenome.curation_api.services.associations;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,7 +11,6 @@ import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.CodingSequenceGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.CodingSequence;
 import org.alliancegenome.curation_api.model.entities.associations.CodingSequenceGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -24,10 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
-import lombok.extern.jbosslog.JBossLog;
 
-@JBossLog
 @RequestScoped
 public class CodingSequenceGenomicLocationAssociationService extends BaseEntityCrudService<CodingSequenceGenomicLocationAssociation, CodingSequenceGenomicLocationAssociationDAO> {
 
@@ -52,40 +47,6 @@ public class CodingSequenceGenomicLocationAssociationService extends BaseEntityC
 		associationIds.removeIf(Objects::isNull);
 
 		return associationIds;
-	}
-
-	@Override
-	@Transactional
-	public CodingSequenceGenomicLocationAssociation deprecateOrDelete(Long id, Boolean throwApiError, String loadDescription, Boolean deprecate) {
-		CodingSequenceGenomicLocationAssociation association = codingSequenceGenomicLocationAssociationDAO.find(id);
-
-		if (association == null) {
-			String errorMessage = "Could not find CodingSequenceGenomicLocationAssociation with id: " + id;
-			if (throwApiError) {
-				ObjectResponse<CodingSequenceGenomicLocationAssociation> response = new ObjectResponse<>();
-				response.addErrorMessage("id", errorMessage);
-				throw new ApiErrorException(response);
-			}
-			log.error(errorMessage);
-			return null;
-		}
-		if (deprecate) {
-			if (!association.getObsolete()) {
-				association.setObsolete(true);
-				if (authenticatedPerson.getId() != null) {
-					association.setUpdatedBy(personDAO.find(authenticatedPerson.getId()));
-				} else {
-					association.setUpdatedBy(personService.fetchByUniqueIdOrCreate(loadDescription));
-				}
-				association.setDateUpdated(OffsetDateTime.now());
-				return codingSequenceGenomicLocationAssociationDAO.persist(association);
-			}
-			return association;
-		}
-		
-		codingSequenceGenomicLocationAssociationDAO.remove(association.getId());
-		
-		return null;
 	}
 
 	public ObjectResponse<CodingSequenceGenomicLocationAssociation> getLocationAssociation(Long codingSequenceId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/ConstructGenomicEntityAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/ConstructGenomicEntityAssociationService.java
@@ -13,7 +13,6 @@ import org.alliancegenome.curation_api.dao.GenomicEntityDAO;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.ConstructGenomicEntityAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.Construct;
@@ -26,7 +25,6 @@ import org.alliancegenome.curation_api.services.base.BaseAssociationDTOCrudServi
 import org.alliancegenome.curation_api.services.validation.associations.ConstructGenomicEntityAssociationValidator;
 import org.alliancegenome.curation_api.services.validation.dto.associations.ConstructGenomicEntityAssociationDTOValidator;
 
-import io.quarkus.logging.Log;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -86,25 +84,6 @@ public class ConstructGenomicEntityAssociationService extends BaseAssociationDTO
 		associationIds.removeIf(Objects::isNull);
 
 		return associationIds;
-	}
-
-	@Override
-	@Transactional
-	public ConstructGenomicEntityAssociation deprecateOrDelete(Long id, Boolean throwApiError, String requestSource, Boolean deprecate) {
-		ConstructGenomicEntityAssociation object = dao.getShallowEntity(ConstructGenomicEntityAssociation.class, id);
-
-		if (object == null) {
-			String errorMessage = "Could not find entity with id: " + id;
-			if (throwApiError) {
-				ObjectResponse<ConstructGenomicEntityAssociation> response = new ObjectResponse<>();
-				response.addErrorMessage("id", errorMessage);
-				throw new ApiErrorException(response);
-			}
-			Log.error(errorMessage);
-			return null;
-		}
-		dao.remove(id);
-		return null;
 	}
 
 	public ObjectResponse<ConstructGenomicEntityAssociation> getAssociation(Long constructId, String relationName, Long genomicEntityId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/CuratedVariantGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/CuratedVariantGenomicLocationAssociationService.java
@@ -1,6 +1,5 @@
 package org.alliancegenome.curation_api.services.associations;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,7 +11,6 @@ import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.CuratedVariantGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.Variant;
 import org.alliancegenome.curation_api.model.entities.associations.CuratedVariantGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -25,10 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
-import lombok.extern.jbosslog.JBossLog;
 
-@JBossLog
 @RequestScoped
 public class CuratedVariantGenomicLocationAssociationService extends BaseEntityCrudService<CuratedVariantGenomicLocationAssociation, CuratedVariantGenomicLocationAssociationDAO> {
 
@@ -54,40 +49,6 @@ public class CuratedVariantGenomicLocationAssociationService extends BaseEntityC
 		associationIds.removeIf(Objects::isNull);
 
 		return associationIds;
-	}
-
-	@Override
-	@Transactional
-	public CuratedVariantGenomicLocationAssociation deprecateOrDelete(Long id, Boolean throwApiError, String loadDescription, Boolean deprecate) {
-		CuratedVariantGenomicLocationAssociation association = curatedVariantGenomicLocationAssociationDAO.find(id);
-
-		if (association == null) {
-			String errorMessage = "Could not find CuratedVariantGenomicLocationAssociation with id: " + id;
-			if (throwApiError) {
-				ObjectResponse<CuratedVariantGenomicLocationAssociation> response = new ObjectResponse<>();
-				response.addErrorMessage("id", errorMessage);
-				throw new ApiErrorException(response);
-			}
-			log.error(errorMessage);
-			return null;
-		}
-		if (deprecate) {
-			if (!association.getObsolete()) {
-				association.setObsolete(true);
-				if (authenticatedPerson.getId() != null) {
-					association.setUpdatedBy(personDAO.find(authenticatedPerson.getId()));
-				} else {
-					association.setUpdatedBy(personService.fetchByUniqueIdOrCreate(loadDescription));
-				}
-				association.setDateUpdated(OffsetDateTime.now());
-				return curatedVariantGenomicLocationAssociationDAO.persist(association);
-			}
-			return association;
-		}
-		
-		curatedVariantGenomicLocationAssociationDAO.remove(association.getId());
-		
-		return null;
 	}
 
 	public ObjectResponse<CuratedVariantGenomicLocationAssociation> getLocationAssociation(Long exonId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/ExonGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/ExonGenomicLocationAssociationService.java
@@ -1,6 +1,5 @@
 package org.alliancegenome.curation_api.services.associations;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,7 +11,6 @@ import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.ExonGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.Exon;
 import org.alliancegenome.curation_api.model.entities.associations.ExonGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -24,10 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
-import lombok.extern.jbosslog.JBossLog;
 
-@JBossLog
 @RequestScoped
 public class ExonGenomicLocationAssociationService extends BaseEntityCrudService<ExonGenomicLocationAssociation, ExonGenomicLocationAssociationDAO> {
 
@@ -52,40 +47,6 @@ public class ExonGenomicLocationAssociationService extends BaseEntityCrudService
 		associationIds.removeIf(Objects::isNull);
 
 		return associationIds;
-	}
-
-	@Override
-	@Transactional
-	public ExonGenomicLocationAssociation deprecateOrDelete(Long id, Boolean throwApiError, String loadDescription, Boolean deprecate) {
-		ExonGenomicLocationAssociation association = exonGenomicLocationAssociationDAO.find(id);
-
-		if (association == null) {
-			String errorMessage = "Could not find ExonGenomicLocationAssociation with id: " + id;
-			if (throwApiError) {
-				ObjectResponse<ExonGenomicLocationAssociation> response = new ObjectResponse<>();
-				response.addErrorMessage("id", errorMessage);
-				throw new ApiErrorException(response);
-			}
-			log.error(errorMessage);
-			return null;
-		}
-		if (deprecate) {
-			if (!association.getObsolete()) {
-				association.setObsolete(true);
-				if (authenticatedPerson.getId() != null) {
-					association.setUpdatedBy(personDAO.find(authenticatedPerson.getId()));
-				} else {
-					association.setUpdatedBy(personService.fetchByUniqueIdOrCreate(loadDescription));
-				}
-				association.setDateUpdated(OffsetDateTime.now());
-				return exonGenomicLocationAssociationDAO.persist(association);
-			}
-			return association;
-		}
-		
-		exonGenomicLocationAssociationDAO.remove(association.getId());
-		
-		return null;
 	}
 
 	public ObjectResponse<ExonGenomicLocationAssociation> getLocationAssociation(Long exonId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/GeneGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/GeneGenomicLocationAssociationService.java
@@ -1,6 +1,5 @@
 package org.alliancegenome.curation_api.services.associations;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,7 +11,6 @@ import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.GeneGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.associations.GeneGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -24,10 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
-import lombok.extern.jbosslog.JBossLog;
 
-@JBossLog
 @RequestScoped
 public class GeneGenomicLocationAssociationService extends BaseEntityCrudService<GeneGenomicLocationAssociation, GeneGenomicLocationAssociationDAO> {
 
@@ -52,40 +47,6 @@ public class GeneGenomicLocationAssociationService extends BaseEntityCrudService
 		associationIds.removeIf(Objects::isNull);
 
 		return associationIds;
-	}
-
-	@Override
-	@Transactional
-	public GeneGenomicLocationAssociation deprecateOrDelete(Long id, Boolean throwApiError, String loadDescription, Boolean deprecate) {
-		GeneGenomicLocationAssociation association = geneGenomicLocationAssociationDAO.find(id);
-
-		if (association == null) {
-			String errorMessage = "Could not find GeneGenomicLocationAssociation with id: " + id;
-			if (throwApiError) {
-				ObjectResponse<GeneGenomicLocationAssociation> response = new ObjectResponse<>();
-				response.addErrorMessage("id", errorMessage);
-				throw new ApiErrorException(response);
-			}
-			log.error(errorMessage);
-			return null;
-		}
-		if (deprecate) {
-			if (!association.getObsolete()) {
-				association.setObsolete(true);
-				if (authenticatedPerson.getId() != null) {
-					association.setUpdatedBy(personDAO.find(authenticatedPerson.getId()));
-				} else {
-					association.setUpdatedBy(personService.fetchByUniqueIdOrCreate(loadDescription));
-				}
-				association.setDateUpdated(OffsetDateTime.now());
-				return geneGenomicLocationAssociationDAO.persist(association);
-			}
-			return association;
-		}
-		
-		geneGenomicLocationAssociationDAO.remove(association.getId());
-		
-		return null;
 	}
 
 	public ObjectResponse<GeneGenomicLocationAssociation> getLocationAssociation(Long geneId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptCodingSequenceAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptCodingSequenceAssociationService.java
@@ -1,6 +1,5 @@
 package org.alliancegenome.curation_api.services.associations;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,7 +11,6 @@ import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.TranscriptCodingSequenceAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.CodingSequence;
 import org.alliancegenome.curation_api.model.entities.Transcript;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptCodingSequenceAssociation;
@@ -25,10 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
-import lombok.extern.jbosslog.JBossLog;
 
-@JBossLog
 @RequestScoped
 public class TranscriptCodingSequenceAssociationService extends BaseEntityCrudService<TranscriptCodingSequenceAssociation, TranscriptCodingSequenceAssociationDAO> {
 
@@ -53,40 +48,6 @@ public class TranscriptCodingSequenceAssociationService extends BaseEntityCrudSe
 		associationIds.removeIf(Objects::isNull);
 
 		return associationIds;
-	}
-
-	@Override
-	@Transactional
-	public TranscriptCodingSequenceAssociation deprecateOrDelete(Long id, Boolean throwApiError, String loadDescription, Boolean deprecate) {
-		TranscriptCodingSequenceAssociation association = transcriptCodingSequenceAssociationDAO.find(id);
-
-		if (association == null) {
-			String errorMessage = "Could not find TranscriptCodingSequenceAssociation with id: " + id;
-			if (throwApiError) {
-				ObjectResponse<TranscriptCodingSequenceAssociation> response = new ObjectResponse<>();
-				response.addErrorMessage("id", errorMessage);
-				throw new ApiErrorException(response);
-			}
-			log.error(errorMessage);
-			return null;
-		}
-		if (deprecate) {
-			if (!association.getObsolete()) {
-				association.setObsolete(true);
-				if (authenticatedPerson.getId() != null) {
-					association.setUpdatedBy(personDAO.find(authenticatedPerson.getId()));
-				} else {
-					association.setUpdatedBy(personService.fetchByUniqueIdOrCreate(loadDescription));
-				}
-				association.setDateUpdated(OffsetDateTime.now());
-				return transcriptCodingSequenceAssociationDAO.persist(association);
-			}
-			return association;
-		}
-		
-		transcriptCodingSequenceAssociationDAO.remove(association.getId());
-		
-		return null;
 	}
 
 	public ObjectResponse<TranscriptCodingSequenceAssociation> getLocationAssociation(Long transcriptId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptExonAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptExonAssociationService.java
@@ -1,6 +1,5 @@
 package org.alliancegenome.curation_api.services.associations;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,7 +11,6 @@ import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.TranscriptExonAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.Exon;
 import org.alliancegenome.curation_api.model.entities.Transcript;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptExonAssociation;
@@ -25,10 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
-import lombok.extern.jbosslog.JBossLog;
 
-@JBossLog
 @RequestScoped
 public class TranscriptExonAssociationService extends BaseEntityCrudService<TranscriptExonAssociation, TranscriptExonAssociationDAO> {
 
@@ -53,40 +48,6 @@ public class TranscriptExonAssociationService extends BaseEntityCrudService<Tran
 		associationIds.removeIf(Objects::isNull);
 
 		return associationIds;
-	}
-
-	@Override
-	@Transactional
-	public TranscriptExonAssociation deprecateOrDelete(Long id, Boolean throwApiError, String loadDescription, Boolean deprecate) {
-		TranscriptExonAssociation association = transcriptExonAssociationDAO.find(id);
-
-		if (association == null) {
-			String errorMessage = "Could not find TranscriptExonAssociation with id: " + id;
-			if (throwApiError) {
-				ObjectResponse<TranscriptExonAssociation> response = new ObjectResponse<>();
-				response.addErrorMessage("id", errorMessage);
-				throw new ApiErrorException(response);
-			}
-			log.error(errorMessage);
-			return null;
-		}
-		if (deprecate) {
-			if (!association.getObsolete()) {
-				association.setObsolete(true);
-				if (authenticatedPerson.getId() != null) {
-					association.setUpdatedBy(personDAO.find(authenticatedPerson.getId()));
-				} else {
-					association.setUpdatedBy(personService.fetchByUniqueIdOrCreate(loadDescription));
-				}
-				association.setDateUpdated(OffsetDateTime.now());
-				return transcriptExonAssociationDAO.persist(association);
-			}
-			return association;
-		}
-		
-		transcriptExonAssociationDAO.remove(association.getId());
-		
-		return null;
 	}
 
 	public ObjectResponse<TranscriptExonAssociation> getLocationAssociation(Long transcriptId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptGeneAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptGeneAssociationService.java
@@ -1,6 +1,5 @@
 package org.alliancegenome.curation_api.services.associations;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,7 +11,6 @@ import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.TranscriptGeneAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.Transcript;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptGeneAssociation;
@@ -25,10 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
-import lombok.extern.jbosslog.JBossLog;
 
-@JBossLog
 @RequestScoped
 public class TranscriptGeneAssociationService extends BaseEntityCrudService<TranscriptGeneAssociation, TranscriptGeneAssociationDAO> {
 
@@ -53,40 +48,6 @@ public class TranscriptGeneAssociationService extends BaseEntityCrudService<Tran
 		associationIds.removeIf(Objects::isNull);
 
 		return associationIds;
-	}
-
-	@Override
-	@Transactional
-	public TranscriptGeneAssociation deprecateOrDelete(Long id, Boolean throwApiError, String loadDescription, Boolean deprecate) {
-		TranscriptGeneAssociation association = transcriptGeneAssociationDAO.find(id);
-
-		if (association == null) {
-			String errorMessage = "Could not find TranscriptGeneAssociation with id: " + id;
-			if (throwApiError) {
-				ObjectResponse<TranscriptGeneAssociation> response = new ObjectResponse<>();
-				response.addErrorMessage("id", errorMessage);
-				throw new ApiErrorException(response);
-			}
-			log.error(errorMessage);
-			return null;
-		}
-		if (deprecate) {
-			if (!association.getObsolete()) {
-				association.setObsolete(true);
-				if (authenticatedPerson.getId() != null) {
-					association.setUpdatedBy(personDAO.find(authenticatedPerson.getId()));
-				} else {
-					association.setUpdatedBy(personService.fetchByUniqueIdOrCreate(loadDescription));
-				}
-				association.setDateUpdated(OffsetDateTime.now());
-				return transcriptGeneAssociationDAO.persist(association);
-			}
-			return association;
-		}
-		
-		transcriptGeneAssociationDAO.remove(association.getId());
-		
-		return null;
 	}
 
 	public ObjectResponse<TranscriptGeneAssociation> getLocationAssociation(Long transcriptId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptGenomicLocationAssociationService.java
@@ -1,6 +1,5 @@
 package org.alliancegenome.curation_api.services.associations;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,7 +11,6 @@ import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.TranscriptGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.Transcript;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -24,10 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
-import lombok.extern.jbosslog.JBossLog;
 
-@JBossLog
 @RequestScoped
 public class TranscriptGenomicLocationAssociationService extends BaseEntityCrudService<TranscriptGenomicLocationAssociation, TranscriptGenomicLocationAssociationDAO> {
 
@@ -52,40 +47,6 @@ public class TranscriptGenomicLocationAssociationService extends BaseEntityCrudS
 		associationIds.removeIf(Objects::isNull);
 
 		return associationIds;
-	}
-
-	@Override
-	@Transactional
-	public TranscriptGenomicLocationAssociation deprecateOrDelete(Long id, Boolean throwApiError, String loadDescription, Boolean deprecate) {
-		TranscriptGenomicLocationAssociation association = transcriptGenomicLocationAssociationDAO.find(id);
-
-		if (association == null) {
-			String errorMessage = "Could not find TranscriptGenomicLocationAssociation with id: " + id;
-			if (throwApiError) {
-				ObjectResponse<TranscriptGenomicLocationAssociation> response = new ObjectResponse<>();
-				response.addErrorMessage("id", errorMessage);
-				throw new ApiErrorException(response);
-			}
-			log.error(errorMessage);
-			return null;
-		}
-		if (deprecate) {
-			if (!association.getObsolete()) {
-				association.setObsolete(true);
-				if (authenticatedPerson.getId() != null) {
-					association.setUpdatedBy(personDAO.find(authenticatedPerson.getId()));
-				} else {
-					association.setUpdatedBy(personService.fetchByUniqueIdOrCreate(loadDescription));
-				}
-				association.setDateUpdated(OffsetDateTime.now());
-				return transcriptGenomicLocationAssociationDAO.persist(association);
-			}
-			return association;
-		}
-		
-		transcriptGenomicLocationAssociationDAO.remove(association.getId());
-		
-		return null;
 	}
 
 	public ObjectResponse<TranscriptGenomicLocationAssociation> getLocationAssociation(Long transcriptId, Long assemblyComponentId) {


### PR DESCRIPTION
Overriding of methods not necessary if no special handling required for notes, etc..  Also, some methods weren't actually removing associations if deprecate set to false;