### PR TITLE
Fix Bearer token authentication logic in AuthenticationFilter [SCRUM-5275]

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/auth/AuthenticationFilter.java
+++ b/src/main/java/org/alliancegenome/curation_api/auth/AuthenticationFilter.java
@@ -102,8 +102,8 @@ public class AuthenticationFilter implements ContainerRequestFilter {
 			if (oktaAuth.get()) {
 				String authorizationHeader = requestContext.getHeaderString(HttpHeaders.AUTHORIZATION);
 				String apiToken = null;
-				if (authorizationHeader != null && !authorizationHeader.toLowerCase().startsWith(AUTHENTICATION_SCHEME.toLowerCase() + " ")) {
-					apiToken = authorizationHeader.substring(AUTHENTICATION_SCHEME.length()).trim();
+				if (authorizationHeader != null && authorizationHeader.toLowerCase().startsWith(AUTHENTICATION_SCHEME.toLowerCase() + " ")) {
+					apiToken = authorizationHeader.substring(AUTHENTICATION_SCHEME.length() + 1).trim();
 
 					Person person = personService.findPersonByApiToken(apiToken);
 					if (person != null) {


### PR DESCRIPTION
This commit fixes the authentication issue where valid Bearer tokens were being rejected with 401 errors. The condition for checking the Authorization header has been corrected to properly validate requests that include the 'Bearer ' prefix.

Changes:
- Fixed inverted logic in Bearer token check (removed negation)
- Fixed off-by-one error in token extraction to skip the space after 'Bearer'

This resolves the 401 authentication errors reported in SCRUM-5275.