### PR TITLE
SCRUM-5200 (update) Clean up DAs with incorrect data providers

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/constants/EntityFieldConstants.java
+++ b/src/main/java/org/alliancegenome/curation_api/constants/EntityFieldConstants.java
@@ -86,4 +86,6 @@ public final class EntityFieldConstants {
 	
 	public static final String MAPS_TO_CHROMOSOME = "mapsToChromosome";
 
+	public static final String VARIANT_TRANSCRIPT = "variantTranscript";
+
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
@@ -93,7 +93,7 @@ public class GeneDAO extends BaseSQLDAO<Gene> {
 		paralogyParams.put("query_operator", "or");
 		paralogyParams.put(EntityFieldConstants.SUBJECT_GENE + ".id", geneId);
 		paralogyParams.put(EntityFieldConstants.OBJECT_GENE + ".id", geneId);
-		List<Long> results = geneToGeneOrthologyDAO.findIdsByParams(paralogyParams);
+		List<Long> results = geneToGeneParalogyDAO.findIdsByParams(paralogyParams);
 		return CollectionUtils.isNotEmpty(results);
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
@@ -22,6 +22,7 @@ public class GeneDAO extends BaseSQLDAO<Gene> {
 	@Inject AGMDiseaseAnnotationDAO agmDiseaseAnnotationDAO;
 	@Inject GeneDiseaseAnnotationDAO geneDiseaseAnnotationDAO;
 	@Inject GeneToGeneOrthologyDAO geneToGeneOrthologyDAO;
+	@Inject GeneToGeneParalogyDAO geneToGeneParalogyDAO;
 	@Inject GeneGeneticInteractionDAO geneGeneticInteractionDAO;
 	@Inject GeneMolecularInteractionDAO geneMolecularInteractionDAO;
 	@Inject AllelePhenotypeAnnotationDAO allelePhenotypeAnnotationDAO;
@@ -84,6 +85,15 @@ public class GeneDAO extends BaseSQLDAO<Gene> {
 		orthologyParams.put(EntityFieldConstants.SUBJECT_GENE + ".id", geneId);
 		orthologyParams.put(EntityFieldConstants.OBJECT_GENE + ".id", geneId);
 		List<Long> results = geneToGeneOrthologyDAO.findIdsByParams(orthologyParams);
+		return CollectionUtils.isNotEmpty(results);
+	}
+
+	public Boolean hasReferencingParalogyPairs(Long geneId) {
+		Map<String, Object> paralogyParams = new HashMap<>();
+		paralogyParams.put("query_operator", "or");
+		paralogyParams.put(EntityFieldConstants.SUBJECT_GENE + ".id", geneId);
+		paralogyParams.put(EntityFieldConstants.OBJECT_GENE + ".id", geneId);
+		List<Long> results = geneToGeneOrthologyDAO.findIdsByParams(paralogyParams);
 		return CollectionUtils.isNotEmpty(results);
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/dao/TranscriptDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/TranscriptDAO.java
@@ -1,15 +1,30 @@
 package org.alliancegenome.curation_api.dao;
 
+import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
+import org.alliancegenome.curation_api.model.entities.PredictedVariantConsequence;
 import org.alliancegenome.curation_api.model.entities.Transcript;
+import org.alliancegenome.curation_api.response.SearchResponse;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
 
 @ApplicationScoped
 public class TranscriptDAO extends BaseSQLDAO<Transcript> {
+	
+	@Inject PredictedVariantConsequenceDAO pvcDAO;
 
 	protected TranscriptDAO() {
 		super(Transcript.class);
+	}
+
+	public Boolean hasReferencingPredictedVariantConsequences(Long transcriptId) {
+		SearchResponse<PredictedVariantConsequence> response = pvcDAO.findByField(EntityFieldConstants.VARIANT_TRANSCRIPT + ".id", transcriptId);
+		if (response != null && response.getSingleResult() != null) {
+			return true;
+		}
+		return false;
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3TranscriptExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3TranscriptExecutor.java
@@ -77,9 +77,9 @@ public class Gff3TranscriptExecutor extends Gff3Executor {
 			boolean success = runLoad(bulkLoadFileHistory, gffHeaderData, preProcessedTranscriptGffData, geneIdCurieMap, entityIdsAdded, locationIdsAdded, associationIdsAdded, dataProvider, assemblyId);
 
 			if (success) {
-				runCleanup(transcriptService, bulkLoadFileHistory, dataProvider.name(), transcriptService.getIdsByDataProvider(dataProvider), entityIdsAdded, "GFF transcript");
 				runCleanup(transcriptLocationService, bulkLoadFileHistory, dataProvider.name(), transcriptLocationService.getIdsByDataProvider(dataProvider), locationIdsAdded, "GFF transcript genomic location association");
 				runCleanup(transcriptGeneService, bulkLoadFileHistory, dataProvider.name(), transcriptGeneService.getIdsByDataProvider(dataProvider), associationIdsAdded, "GFF transcript gene association");
+				runCleanup(transcriptService, bulkLoadFileHistory, dataProvider.name(), transcriptService.getIdsByDataProvider(dataProvider), entityIdsAdded, "GFF transcript");
 			}
 			bulkLoadFileHistory.finishLoad();
 			updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
@@ -99,6 +99,7 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 			if (forceDeprecate || geneDAO.hasReferencingDiseaseAnnotations(id)
 					|| geneDAO.hasReferencingPhenotypeAnnotations(id)
 					|| geneDAO.hasReferencingOrthologyPairs(id)
+					|| geneDAO.hasReferencingParalogyPairs(id)
 					|| geneDAO.hasReferencingInteractions(id)
 					|| geneDAO.hasReferencingGeneExpressionAnnotations(id)
 					|| CollectionUtils.isNotEmpty(gene.getAlleleGeneAssociations())

--- a/src/main/java/org/alliancegenome/curation_api/services/TranscriptService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/TranscriptService.java
@@ -1,5 +1,6 @@
 package org.alliancegenome.curation_api.services;
 
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -8,15 +9,18 @@ import java.util.Objects;
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.TranscriptDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.Transcript;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.services.base.BaseEntityCrudService;
 import org.alliancegenome.curation_api.services.validation.dto.Gff3DtoValidator;
 import org.apache.commons.lang3.StringUtils;
 
+import io.quarkus.logging.Log;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 
 @RequestScoped
 public class TranscriptService extends BaseEntityCrudService<Transcript, TranscriptDAO> {
@@ -49,6 +53,35 @@ public class TranscriptService extends BaseEntityCrudService<Transcript, Transcr
 		}
 		ObjectResponse<Transcript> ret = new ObjectResponse<>(transcript);
 		return ret;
+	}
+	
+	@Override
+	@Transactional
+	public Transcript deprecateOrDelete(Long id, Boolean throwApiError, String requestSource, Boolean forceDeprecate) {
+		Transcript transcript = transcriptDAO.find(id);
+		if (transcript != null) {
+			if (forceDeprecate || transcriptDAO.hasReferencingPredictedVariantConsequences(id)) {
+				if (!transcript.getObsolete()) {
+					transcript.setUpdatedBy(personService.fetchByUniqueIdOrCreate(requestSource));
+					transcript.setDateUpdated(OffsetDateTime.now());
+					transcript.setObsolete(true);
+					return transcriptDAO.persist(transcript);
+				} else {
+					return transcript;
+				}
+			} else {
+				transcriptDAO.remove(id);
+			}
+		} else {
+			String errorMessage = "Could not find Transcript with id: " + id;
+			if (throwApiError) {
+				ObjectResponse<Transcript> response = new ObjectResponse<>();
+				response.addErrorMessage("id", errorMessage);
+				throw new ApiErrorException(response);
+			}
+			Log.error(errorMessage);
+		}
+		return null;
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/CuratedVariantGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/CuratedVariantGenomicLocationAssociationService.java
@@ -1,5 +1,6 @@
 package org.alliancegenome.curation_api.services.associations;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -11,6 +12,8 @@ import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.CuratedVariantGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
+import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.Variant;
 import org.alliancegenome.curation_api.model.entities.associations.CuratedVariantGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -18,11 +21,14 @@ import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.PersonService;
 import org.alliancegenome.curation_api.services.base.BaseEntityCrudService;
 import org.alliancegenome.curation_api.services.validation.dto.fms.VariantFmsDTOValidator;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import io.quarkus.logging.Log;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 
 @RequestScoped
 public class CuratedVariantGenomicLocationAssociationService extends BaseEntityCrudService<CuratedVariantGenomicLocationAssociation, CuratedVariantGenomicLocationAssociationDAO> {
@@ -83,5 +89,34 @@ public class CuratedVariantGenomicLocationAssociationService extends BaseEntityC
 		if (!currentSubjectAssociationIds.contains(association.getId())) {
 			currentSubjectAssociations.add(association);
 		}
+	}
+
+	@Override
+	@Transactional
+	public CuratedVariantGenomicLocationAssociation deprecateOrDelete(Long id, Boolean throwApiError, String requestSource, Boolean forceDeprecate) {
+		CuratedVariantGenomicLocationAssociation cvgla = curatedVariantGenomicLocationAssociationDAO.find(id);
+		if (cvgla != null) {
+			if (forceDeprecate || CollectionUtils.isNotEmpty(cvgla.getPredictedVariantConsequences())) {
+				if (!cvgla.getObsolete()) {
+					cvgla.setUpdatedBy(personService.fetchByUniqueIdOrCreate(requestSource));
+					cvgla.setDateUpdated(OffsetDateTime.now());
+					cvgla.setObsolete(true);
+					return curatedVariantGenomicLocationAssociationDAO.persist(cvgla);
+				} else {
+					return cvgla;
+				}
+			} else {
+				curatedVariantGenomicLocationAssociationDAO.remove(id);
+			}
+		} else {
+			String errorMessage = "Could not find CuratedVariantGenomicLocationAssociation with id: " + id;
+			if (throwApiError) {
+				ObjectResponse<CuratedVariantGenomicLocationAssociation> response = new ObjectResponse<>();
+				response.addErrorMessage("id", errorMessage);
+				throw new ApiErrorException(response);
+			}
+			Log.error(errorMessage);
+		}
+		return null;
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/CuratedVariantGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/CuratedVariantGenomicLocationAssociationService.java
@@ -13,7 +13,6 @@ import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.CuratedVariantGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
-import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.Variant;
 import org.alliancegenome.curation_api.model.entities.associations.CuratedVariantGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.ObjectResponse;

--- a/src/main/resources/db/migration/v0.41.0.5__omim_annotation_cleanup.sql
+++ b/src/main/resources/db/migration/v0.41.0.5__omim_annotation_cleanup.sql
@@ -1,0 +1,69 @@
+CREATE TABLE tmp_da_ids_to_remove AS
+	SELECT d.id FROM diseaseannotation d
+		INNER JOIN organization o ON o.id = d.dataprovider_id
+		WHERE d.dataprovider_id = d.secondarydataprovider_id
+			AND o.abbreviation = 'OMIM';
+
+DELETE FROM diseaseannotation_ontologyterm
+	WHERE diseaseannotation_id IN (
+		SELECT id FROM tmp_da_ids_to_remove
+	);
+
+DELETE FROM diseaseannotation_vocabularyterm
+	WHERE diseaseannotation_id IN (
+		SELECT id FROM tmp_da_ids_to_remove
+	);
+
+DELETE FROM diseaseannotation_modifieragm
+	WHERE diseaseannotation_id IN (
+		SELECT id FROM tmp_da_ids_to_remove
+	);
+
+DELETE FROM diseaseannotation_modifierallele
+	WHERE diseaseannotation_id IN (
+		SELECT id FROM tmp_da_ids_to_remove
+	);
+
+DELETE FROM diseaseannotation_modifiergene
+	WHERE diseaseannotation_id IN (
+		SELECT id FROM tmp_da_ids_to_remove
+	);
+
+DELETE FROM diseaseannotation_conditionrelation
+	WHERE annotation_id IN (
+		SELECT id FROM tmp_da_ids_to_remove
+	);
+
+DELETE FROM diseaseannotation_gene
+	WHERE diseaseannotation_id IN (
+		SELECT id FROM tmp_da_ids_to_remove
+	);
+
+CREATE TABLE tmp_notes_to_remove AS
+	SELECT relatednotes_id FROM diseaseannotation_note WHERE annotation_id IN (
+		SELECT id FROM tmp_da_ids_to_remove
+	);
+
+DELETE FROM diseaseannotation_note
+	WHERE relatednotes_id IN (
+		SELECT relatednotes_id FROM tmp_notes_to_remove
+	);
+
+DELETE FROM note
+	WHERE id IN (
+		SELECT relatednotes_id FROM tmp_notes_to_remove
+	);
+	
+DROP TABLE tmp_notes_to_remove;
+
+DELETE FROM genediseaseannotation
+	WHERE id IN (
+		SELECT id FROM tmp_da_ids_to_remove
+	);
+
+DELETE FROM diseaseannotation
+	WHERE id IN (
+		SELECT id FROM tmp_da_ids_to_remove
+	);
+
+DROP TABLE tmp_da_ids_to_remove;


### PR DESCRIPTION
These need to be cleaned up manually as shouldn't have cases with OMIM for primary and secondary dataprovider.  Therefore cleanup methods not identifying these as previously loaded annotations.