### PR TITLE
SCRUM-5456: Add read-only Gene Expression Annotations data table

### DIFF
--- a/src/main/cliapp/src/constants/FilterFields.js
+++ b/src/main/cliapp/src/constants/FilterFields.js
@@ -735,6 +735,54 @@ export const FIELD_SETS = Object.freeze({
 			'with.modInternalId',
 		],
 	},
+	geaExperimentUniqueidFieldSet: {
+		filterName: 'geaExperimentUniqueidFilter',
+		fields: ['expressionExperiment.uniqueId'],
+	},
+	geaExperimentPrimaryExternalIdFieldSet: {
+		filterName: 'geaExperimentPrimaryExternalIdFilter',
+		fields: ['expressionExperiment.primaryExternalId'],
+	},
+	geaExperimentModInternalIdFieldSet: {
+		filterName: 'geaExperimentModInternalIdFilter',
+		fields: ['expressionExperiment.modInternalId'],
+	},
+	geaExperimentSingleReferenceFieldSet: {
+		filterName: 'geaExperimentSingleReferenceFilter',
+		fields: [
+			'expressionExperiment.singleReference.curie',
+			'expressionExperiment.singleReference.primaryCrossReferenceCurie',
+			'expressionExperiment.singleReference.crossReferences.referencedCurie',
+		],
+	},
+	geaSubjectFieldSet: {
+		filterName: 'geaSubjectFilter',
+		fields: [
+			'expressionAnnotationSubject.geneSymbol.displayText',
+			'expressionAnnotationSubject.geneSymbol.formatText',
+			'expressionAnnotationSubject.curie',
+		],
+	},
+	geaAssayUsedFieldSet: {
+		filterName: 'geaAssayUsedFilter',
+		fields: ['expressionAssayUsed.name'],
+	},
+	geaDataProviderFieldSet: {
+		filterName: 'geaDataProviderFilter',
+		fields: ['dataProvider.abbreviation', 'dataProvider.fullName', 'dataProvider.shortName'],
+	},
+	geaRelationFieldSet: {
+		filterName: 'geaRelationFilter',
+		fields: ['relation.name'],
+	},
+	geaWhereExpressedFieldSet: {
+		filterName: 'geaWhereExpressedFilter',
+		fields: ['whereExpressedStatement'],
+	},
+	geaWhenExpressedFieldSet: {
+		filterName: 'geaWhenExpressedFilter',
+		fields: ['whenExpressedStageName'],
+	},
 });
 
 export const FILTER_CONFIGS = Object.freeze({
@@ -965,6 +1013,28 @@ export const FILTER_CONFIGS = Object.freeze({
 		fieldSets: [FIELD_SETS.vocabularyTermSetDescriptionFieldSet],
 	},
 	withFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.withFieldSet] },
+	geaExperimentUniqueidFilterConfig: {
+		filterComponentType: 'input',
+		fieldSets: [FIELD_SETS.geaExperimentUniqueidFieldSet],
+	},
+	geaExperimentPrimaryExternalIdFilterConfig: {
+		filterComponentType: 'input',
+		fieldSets: [FIELD_SETS.geaExperimentPrimaryExternalIdFieldSet],
+	},
+	geaExperimentModInternalIdFilterConfig: {
+		filterComponentType: 'input',
+		fieldSets: [FIELD_SETS.geaExperimentModInternalIdFieldSet],
+	},
+	geaExperimentSingleReferenceFilterConfig: {
+		filterComponentType: 'input',
+		fieldSets: [FIELD_SETS.geaExperimentSingleReferenceFieldSet],
+	},
+	geaSubjectFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.geaSubjectFieldSet] },
+	geaAssayUsedFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.geaAssayUsedFieldSet] },
+	geaDataProviderFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.geaDataProviderFieldSet] },
+	geaRelationFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.geaRelationFieldSet] },
+	geaWhereExpressedFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.geaWhereExpressedFieldSet] },
+	geaWhenExpressedFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.geaWhenExpressedFieldSet] },
 
 	isExtinctFilterConfig: { filterComponentType: 'dropdown', fieldSets: [FIELD_SETS.isExtinctFieldSet] },
 	obsoleteFilterConfig: { filterComponentType: 'dropdown', fieldSets: [FIELD_SETS.obsoleteFieldSet] },

--- a/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/GeneExpressionAnnotationsPage.js
+++ b/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/GeneExpressionAnnotationsPage.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { GeneExpressionAnnotationsTable } from './GeneExpressionAnnotationsTable';
+
+export function GeneExpressionAnnotationsPage() {
+	return <GeneExpressionAnnotationsTable />;
+}

--- a/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/GeneExpressionAnnotationsTable.js
+++ b/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/GeneExpressionAnnotationsTable.js
@@ -1,0 +1,338 @@
+import React, { useRef, useState, useMemo } from 'react';
+
+import { GenericDataTable } from '../../components/GenericDataTable/GenericDataTable';
+import { IdTemplate } from '../../components/Templates/IdTemplate';
+import { GenomicEntityTemplate } from '../../components/Templates/genomicEntity/GenomicEntityTemplate';
+import { BooleanTemplate } from '../../components/Templates/BooleanTemplate';
+import { OntologyTermTemplate } from '../../components/Templates/OntologyTermTemplate';
+import { StringTemplate } from '../../components/Templates/StringTemplate';
+import { SingleReferenceTemplate } from '../../components/Templates/reference/SingleReferenceTemplate';
+import { CrossReferencesTemplate } from '../../components/Templates/CrossReferencesTemplate';
+import { getDefaultTableState } from '../../service/TableStateService';
+import { FILTER_CONFIGS } from '../../constants/FilterFields';
+import { useGetTableData } from '../../service/useGetTableData';
+import { useGetUserSettings } from '../../service/useGetUserSettings';
+import { SearchService } from '../../service/SearchService';
+
+export const GeneExpressionAnnotationsTable = () => {
+	const [isInEditMode, setIsInEditMode] = useState(false);
+	const [errorMessages, setErrorMessages] = useState({});
+	const [totalRecords, setTotalRecords] = useState(0);
+	const [geneExpressionAnnotations, setGeneExpressionAnnotations] = useState([]);
+	const errorMessagesRef = useRef();
+	errorMessagesRef.current = errorMessages;
+
+	const searchService = new SearchService();
+
+	const [uiErrorMessages, setUiErrorMessages] = useState([]);
+	const uiErrorMessagesRef = useRef();
+	uiErrorMessagesRef.current = uiErrorMessages;
+
+	const toast_topleft = useRef(null);
+	const toast_topright = useRef(null);
+
+	const sortMapping = {};
+
+	const conditionRelationsTemplate = (rowData) => {
+		if (rowData?.conditionRelations) {
+			const withoutHandle = rowData.conditionRelations.filter((cr) => !cr.handle);
+			if (withoutHandle.length > 0) {
+				return <StringTemplate string={`Conditions (${withoutHandle.length})`} />;
+			}
+		}
+	};
+
+	const experimentsTemplate = (rowData) => {
+		if (rowData?.conditionRelations) {
+			const withHandle = rowData.conditionRelations.filter((cr) => cr.handle);
+			if (withHandle.length > 0) {
+				return <StringTemplate string={withHandle[0].handle} />;
+			}
+		}
+	};
+
+	const relatedNotesTemplate = (rowData) => {
+		if (rowData?.relatedNotes) {
+			return <StringTemplate string={`Notes (${rowData.relatedNotes.length})`} />;
+		}
+	};
+
+	const columns = useMemo(
+		() => [
+			{
+				field: 'expressionExperiment.singleReference.primaryCrossReferenceCurie',
+				header: 'Reference',
+				body: (rowData) => <SingleReferenceTemplate singleReference={rowData.expressionExperiment?.singleReference} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.geaExperimentSingleReferenceFilterConfig,
+			},
+			{
+				field: 'expressionExperiment.curie',
+				header: 'Experiment Curie',
+				body: (rowData) => <IdTemplate id={rowData.expressionExperiment?.curie} />,
+				sortable: false,
+			},
+			{
+				field: 'expressionExperiment.uniqueId',
+				header: 'Experiment Unique ID',
+				body: (rowData) => <IdTemplate id={rowData.expressionExperiment?.uniqueId} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.geaExperimentUniqueidFilterConfig,
+			},
+			{
+				field: 'expressionExperiment.primaryExternalId',
+				header: 'MOD Experiment ID',
+				body: (rowData) => <StringTemplate string={rowData.expressionExperiment?.primaryExternalId} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.geaExperimentPrimaryExternalIdFilterConfig,
+			},
+			{
+				field: 'expressionExperiment.modInternalId',
+				header: 'MOD Internal Experiment ID',
+				body: (rowData) => <StringTemplate string={rowData.expressionExperiment?.modInternalId} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.geaExperimentModInternalIdFilterConfig,
+			},
+			{
+				field: 'expressionAnnotationSubject.geneSymbol.displayText',
+				header: 'Subject',
+				body: (rowData) => <GenomicEntityTemplate genomicEntity={rowData.expressionAnnotationSubject} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.geaSubjectFilterConfig,
+			},
+			{
+				field: 'expressionAssayUsed.name',
+				header: 'Assay Used',
+				body: (rowData) => <OntologyTermTemplate term={rowData.expressionAssayUsed} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.geaAssayUsedFilterConfig,
+			},
+			{
+				field: 'conditionRelations.handle',
+				header: 'Experiments',
+				body: experimentsTemplate,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.daConditionRelationsHandleFilterConfig,
+			},
+			{
+				field: 'conditionRelations.uniqueId',
+				header: 'Experimental Conditions',
+				body: conditionRelationsTemplate,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.daConditionRelationsSummaryFilterConfig,
+			},
+			{
+				field: 'expressionExperiment.crossReferences.displayName',
+				header: 'Experiment Cross Refs',
+				body: (rowData) => <CrossReferencesTemplate list={rowData.expressionExperiment?.crossReferences} />,
+				sortable: false,
+			},
+			{
+				field: 'dataProvider.abbreviation',
+				header: 'Data Provider',
+				body: (rowData) => <StringTemplate string={rowData.dataProvider?.abbreviation} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.geaDataProviderFilterConfig,
+			},
+			{
+				field: 'curie',
+				header: 'Annotation Curie',
+				body: (rowData) => <IdTemplate id={rowData.curie} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.curieFilterConfig,
+			},
+			{
+				field: 'uniqueId',
+				header: 'Annotation Unique ID',
+				body: (rowData) => <IdTemplate id={rowData.uniqueId} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.uniqueidFilterConfig,
+			},
+			{
+				field: 'primaryExternalId',
+				header: 'MOD Annotation ID',
+				body: (rowData) => <StringTemplate string={rowData.primaryExternalId} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.primaryexternalidFilterConfig,
+			},
+			{
+				field: 'modInternalId',
+				header: 'MOD Internal Annotation ID',
+				body: (rowData) => <StringTemplate string={rowData.modInternalId} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.modinternalidFilterConfig,
+			},
+			{
+				field: 'relation.name',
+				header: 'Expression Relation',
+				body: (rowData) => <StringTemplate string={rowData.relation?.name} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.geaRelationFilterConfig,
+			},
+			{
+				field: 'whereExpressedStatement',
+				header: 'Where Expressed',
+				body: (rowData) => <StringTemplate string={rowData.whereExpressedStatement} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.geaWhereExpressedFilterConfig,
+			},
+			{
+				field: 'whenExpressedStageName',
+				header: 'When Expressed',
+				body: (rowData) => <StringTemplate string={rowData.whenExpressedStageName} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.geaWhenExpressedFilterConfig,
+			},
+			{
+				field: 'relatedNotes.freeText',
+				header: 'Related Notes',
+				body: relatedNotesTemplate,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.relatedNotesFilterConfig,
+			},
+			{
+				field: 'crossReferences.displayName',
+				header: 'Annotation Cross Refs',
+				body: (rowData) => <CrossReferencesTemplate list={rowData.crossReferences} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.crossReferencesFilterConfig,
+			},
+			{
+				field: 'expressionExperiment.createdBy.uniqueId',
+				header: 'Experiment Created By',
+				body: (rowData) => <StringTemplate string={rowData.expressionExperiment?.createdBy?.uniqueId} />,
+				sortable: false,
+			},
+			{
+				field: 'expressionExperiment.dateCreated',
+				header: 'Experiment Date Created',
+				body: (rowData) => <StringTemplate string={rowData.expressionExperiment?.dateCreated} />,
+				sortable: false,
+			},
+			{
+				field: 'expressionExperiment.updatedBy.uniqueId',
+				header: 'Experiment Updated By',
+				body: (rowData) => <StringTemplate string={rowData.expressionExperiment?.updatedBy?.uniqueId} />,
+				sortable: false,
+			},
+			{
+				field: 'expressionExperiment.dateUpdated',
+				header: 'Experiment Date Updated',
+				body: (rowData) => <StringTemplate string={rowData.expressionExperiment?.dateUpdated} />,
+				sortable: false,
+			},
+			{
+				field: 'expressionExperiment.internal',
+				header: 'Experiment Internal',
+				body: (rowData) => <BooleanTemplate value={rowData.expressionExperiment?.internal} />,
+				sortable: false,
+			},
+			{
+				field: 'expressionExperiment.obsolete',
+				header: 'Experiment Obsolete',
+				body: (rowData) => <BooleanTemplate value={rowData.expressionExperiment?.obsolete} />,
+				sortable: false,
+			},
+			{
+				field: 'createdBy.uniqueId',
+				header: 'Annotation Created By',
+				body: (rowData) => <StringTemplate string={rowData.createdBy?.uniqueId} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.createdByFilterConfig,
+			},
+			{
+				field: 'dateCreated',
+				header: 'Annotation Date Created',
+				body: (rowData) => <StringTemplate string={rowData.dateCreated} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+			},
+			{
+				field: 'updatedBy.uniqueId',
+				header: 'Annotation Updated By',
+				body: (rowData) => <StringTemplate string={rowData.updatedBy?.uniqueId} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.updatedByFilterConfig,
+			},
+			{
+				field: 'dateUpdated',
+				header: 'Annotation Date Updated',
+				body: (rowData) => <StringTemplate string={rowData.dateUpdated} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.dateUpdatedFilterConfig,
+			},
+			{
+				field: 'internal',
+				header: 'Annotation Internal',
+				body: (rowData) => <BooleanTemplate value={rowData.internal} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.internalFilterConfig,
+			},
+			{
+				field: 'obsolete',
+				header: 'Annotation Obsolete',
+				body: (rowData) => <BooleanTemplate value={rowData.obsolete} />,
+				sortable: true,
+				filterConfig: FILTER_CONFIGS.obsoleteFilterConfig,
+			},
+		],
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[]
+	);
+
+	const DEFAULT_COLUMN_WIDTH = 10;
+	const SEARCH_ENDPOINT = 'gene-expression-annotation';
+	const defaultFilters = { obsoleteFilter: { obsolete: { queryString: 'false' } } };
+
+	const initialTableState = useMemo(
+		() => getDefaultTableState('GeneExpressionAnnotations', columns, DEFAULT_COLUMN_WIDTH, defaultFilters),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[columns]
+	);
+
+	const { settings: tableState, mutate: setTableState } = useGetUserSettings(
+		initialTableState.tableSettingsKeyName,
+		initialTableState
+	);
+
+	const { isFetching, isLoading } = useGetTableData({
+		tableState,
+		endpoint: SEARCH_ENDPOINT,
+		setIsInEditMode,
+		setEntities: setGeneExpressionAnnotations,
+		setTotalRecords,
+		toast_topleft,
+		searchService,
+	});
+
+	return (
+		<>
+			<div className="card">
+				<GenericDataTable
+					endpoint={SEARCH_ENDPOINT}
+					tableName="Gene Expression Annotations"
+					entities={geneExpressionAnnotations}
+					setEntities={setGeneExpressionAnnotations}
+					totalRecords={totalRecords}
+					setTotalRecords={setTotalRecords}
+					tableState={tableState}
+					setTableState={setTableState}
+					columns={columns}
+					toasts={{ toast_topleft, toast_topright }}
+					isEditable={false}
+					isInEditMode={isInEditMode}
+					setIsInEditMode={setIsInEditMode}
+					sortMapping={sortMapping}
+					errorObject={{ errorMessages, setErrorMessages, uiErrorMessages, setUiErrorMessages }}
+					deletionEnabled={false}
+					deprecateOption={false}
+					modReset={false}
+					duplicationEnabled={false}
+					defaultColumnWidth={DEFAULT_COLUMN_WIDTH}
+					fetching={isFetching || isLoading}
+					defaultFilters={defaultFilters}
+				/>
+			</div>
+		</>
+	);
+};

--- a/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/index.js
+++ b/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/index.js
@@ -1,0 +1,3 @@
+import { GeneExpressionAnnotationsPage } from './GeneExpressionAnnotationsPage';
+
+export { GeneExpressionAnnotationsPage };

--- a/src/main/cliapp/src/containers/layout/SiteLayout.js
+++ b/src/main/cliapp/src/containers/layout/SiteLayout.js
@@ -237,6 +237,7 @@ export const SiteLayout = (props) => {
 						{ label: 'Experimental Conditions', icon: 'pi pi-fw pi-home', to: '/experimentalConditions' },
 						{ label: 'Experiments', icon: 'pi pi-fw pi-home', to: '/conditionRelations' },
 						{ label: 'Genes', icon: 'pi pi-fw pi-home', to: '/genes' },
+						{ label: 'Gene Expression Annotations', icon: 'pi pi-fw pi-home', to: '/geneExpressionAnnotations' },
 						{ label: 'Gene Genetic Interactions', icon: 'pi pi-fw pi-home', to: '/geneGeneticInteractions' },
 						{ label: 'Gene Molecular Interactions', icon: 'pi pi-fw pi-home', to: '/geneMolecularInteractions' },
 						{ label: 'Literature References', icon: 'pi pi-fw pi-home', to: '/references' },

--- a/src/main/cliapp/src/routes.js
+++ b/src/main/cliapp/src/routes.js
@@ -8,6 +8,7 @@ import { DataLoadsPage } from './containers/dataLoadsPage/';
 import { ReportsPage } from './containers/reportsPage/';
 import { DiseaseAnnotationsPage } from './containers/diseaseAnnotationsPage';
 import { PhenotypeAnnotationsPage } from './containers/phenotypeAnnotationsPage';
+import { GeneExpressionAnnotationsPage } from './containers/geneExpressionAnnotationsPage';
 import { GeneGeneticInteractionsPage } from './containers/geneGeneticInteractionsPage/GeneGeneticInteractionsPage';
 import { GeneMolecularInteractionsPage } from './containers/geneMolecularInteractionsPage/GeneMolecularInteractionsPage';
 import { ExperimentalConditionsPage } from './containers/experimentalConditionsPage';
@@ -89,6 +90,14 @@ export default function AppRoutes() {
 						element={
 							<ErrorBoundary>
 								<GeneMolecularInteractionsPage />
+							</ErrorBoundary>
+						}
+					/>
+					<Route
+						path="/geneExpressionAnnotations"
+						element={
+							<ErrorBoundary>
+								<GeneExpressionAnnotationsPage />
 							</ErrorBoundary>
 						}
 					/>

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ExpressionExperiment.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ExpressionExperiment.java
@@ -20,7 +20,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmb
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -71,7 +71,7 @@ public abstract class ExpressionExperiment extends SubmittedObject {
 	private MMOTerm expressionAssayUsed;
 
 	@OneToMany(mappedBy = "expressionExperiment", cascade = CascadeType.ALL, orphanRemoval = true)
-	@JsonManagedReference
+	@JsonIgnoreProperties("expressionExperiment")
 	@Fetch(FetchMode.SUBSELECT)
 	@JsonView({ CurationView.FieldsAndLists.class, CurationView.ForPublic.class })
 	private Set<GeneExpressionAnnotation> expressionAnnotations;

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GeneExpressionAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GeneExpressionAnnotation.java
@@ -12,7 +12,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonView;
 
@@ -77,9 +77,19 @@ public class GeneExpressionAnnotation extends ExpressionAnnotation {
 	@JsonView({ CurationView.FieldsAndLists.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class })
 	private List<CrossReference> crossReferences;
 	
+	@IndexedEmbedded(includePaths = {
+		"uniqueId", "uniqueId_keyword",
+		"primaryExternalId", "primaryExternalId_keyword",
+		"modInternalId", "modInternalId_keyword",
+		"singleReference.curie", "singleReference.primaryCrossReferenceCurie",
+		"singleReference.crossReferences.referencedCurie",
+		"singleReference.curie_keyword", "singleReference.primaryCrossReferenceCurie_keyword",
+		"singleReference.crossReferences.referencedCurie_keyword"
+	})
+	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
 	@JoinColumn(name = "expressionexperiment_id")
-	@JsonBackReference
+	@JsonIgnoreProperties("expressionAnnotations")
 	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class})
 	private GeneExpressionExperiment expressionExperiment;
 }


### PR DESCRIPTION
## Summary
- Add a new read-only data table page for browsing gene expression annotation data, combining GeneExpressionExperiment and GeneExpressionAnnotation in a flattened view (one row per annotation)
- Fix JSON serialization between GeneExpressionAnnotation and ExpressionExperiment by replacing @JsonBackReference/@JsonManagedReference with @JsonIgnoreProperties to allow experiment data in API responses
- Add @IndexedEmbedded on expressionExperiment field for search indexing of experiment uniqueId, primaryExternalId, modInternalId, and singleReference

## Test plan
- [ ] Run `make apirun` and verify `POST /gene-expression-annotation/search` returns results with experiment data populated
- [ ] Run `make uirunalpha`, navigate to Gene Expression Annotations in sidebar, verify table loads with data and pagination
- [ ] Verify column sorting and filtering works (gene symbol, assay, data provider, etc.)
- [ ] Verify obsolete filter defaults to hiding obsolete records
- [ ] Run `make checkstyle` and `make prettier-check` to confirm code style compliance
- [ ] Trigger reindex of GeneExpressionAnnotation after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)