### PR TITLE
KANBAN-1067: Use CLAUDE_PR_REVIEW_MODEL org variable for model selection

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -456,7 +456,7 @@ jobs:
 
           # CLI arguments (v1 format)
           claude_args: |
-            --model claude-sonnet-4-5-20250929
+            --model ${{ vars.CLAUDE_PR_REVIEW_MODEL }}
             --max-turns 80
             --allowedTools "${{ steps.review-config.outputs.allowed_tools }}"
             --append-system-prompt "You are reviewing a PULL REQUEST DIFF for an Alliance of Genome Resources Java Quarkus backend application.


### PR DESCRIPTION
## Summary
- Replaces hardcoded `claude-sonnet-4-5-20250929` with `${{ vars.CLAUDE_PR_REVIEW_MODEL }}` org variable
- Future model updates only need the org variable changed, no PR required

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Open test PR to confirm Claude reviewer uses claude-sonnet-4-6