### PR TITLE
SCRUM-2479: Add OpenAPI/Swagger UI documentation

### DIFF
--- a/FIND.md
+++ b/FIND.md
@@ -1,64 +1,237 @@
-# Find payload for /find endpoints
+# Find Payload for /find and /findForPublic Endpoints
+
+## Overview
+
+The `/find` and `/findForPublic` endpoints query the **relational database** (PostgreSQL via JPA/Hibernate) using exact field-level matching. These endpoints are used for precise lookups where you know the exact values you're searching for, as opposed to the `/search` endpoints which use OpenSearch for full-text searching.
 
 ## Endpoints
 
-Endpoints are in the following structure
+```
+POST /api/{object}/find?page={page}&limit={limit}
+POST /api/{object}/findForPublic?page={page}&limit={limit}&view={view}
+```
 
-POST /api/{object}/find
+`{object}` is any entity that has a corresponding table in the curation system (e.g., `gene`, `allele`, `disease-annotation`, `vocabularyterm`).
 
-{object} will be any of the objects that we have tables for in the UI and the database
+### /find vs /findForPublic
+
+- **`/find`** -- Returns the full curation view of the data. Intended for internal curation use.
+- **`/findForPublic`** -- Returns a filtered view of the data based on the `view` parameter. Intended for public-facing API consumers. The `view` parameter maps to a `CurationView` inner class name (e.g., `ForPublic`, `FieldsOnly`). If the view name is not recognized, it defaults to `ForPublic`.
 
 ## Query Parameters
 
-### Page
+| Parameter | Type    | Default      | Endpoint          | Description                                           |
+|-----------|---------|--------------|-------------------|-------------------------------------------------------|
+| `page`    | Integer | `0`          | Both              | Zero-based page number.                               |
+| `limit`   | Integer | `10`         | Both              | Number of results per page.                           |
+| `view`    | String  | `ForPublic`  | `/findForPublic`  | JSON view class name controlling response serialization. |
 
-This will be a zero based page of results that is pulled from the database. 
+Results are fetched starting at offset `page * limit` and returning up to `limit` records.
 
-### Limit 
+### Count-Only Mode
 
-This will be the size of the page that comes back. 
+When `page` is `0` **and** `limit` is `0`, the endpoint returns **only** the `totalResults` count without fetching any entity records. The `results` array will be empty. This is useful for getting a count of matching records without the overhead of loading entities.
 
-## POST Search Payload Example
+When `limit` is greater than `0`, the endpoint returns the `results` array but does **not** populate `totalResults`.
 
-```javascript
+---
+
+## Request Body
+
+The request body is a **flat JSON object** mapping field names to their expected values. All fields are matched using **exact equality** and are **AND**'d together by default.
+
+### Basic Example
+
+```json
+{
+    "vocabulary.vocabularyLabel": "disease_qualifier"
+}
+```
+
+This returns all entities where `vocabulary.vocabularyLabel` equals exactly `"disease_qualifier"`.
+
+### Full Example
+
+```json
+{
+    "vocabulary.vocabularyLabel": "disease_qualifier",
+    "obsolete": false,
+    "query_operator": "or",
+    "debug": "true"
+}
+```
+
+---
+
+## Fields
+
+Each key in the request body is a field name on the entity. The corresponding value is what that field must equal.
+
+### Field Names
+
+Field names correspond to JPA entity properties. Use dot notation to traverse nested relationships:
+
+- `"obsolete"` -- a direct field on the entity
+- `"vocabulary.vocabularyLabel"` -- traverses the `vocabulary` relationship, then matches on `vocabularyLabel`
+- `"diseaseAnnotationSubject.taxon.curie"` -- traverses subject -> taxon -> curie
+
+When a field in the traversal path is a collection (List), the system automatically performs a LEFT JOIN to traverse into it.
+
+### Supported Value Types
+
+| JSON Type   | Java Type | Behavior                                                                                              |
+|-------------|-----------|-------------------------------------------------------------------------------------------------------|
+| String      | String    | Exact string equality.                                                                                |
+| Number (int)| Integer   | Exact numeric equality.                                                                               |
+| Number (long)| Long     | Exact numeric equality (for values exceeding Integer range).                                          |
+| Boolean     | Boolean   | Exact boolean equality (`true` / `false`).                                                            |
+| Array       | List      | Exact collection match -- the entity's collection must contain all listed values **and** be the same size. |
+| null        | null      | Checks that the collection field is **empty** (has no elements).                                      |
+
+**Note on null values:** Setting a field's value to `null` uses `isEmpty()` on the entity's collection field. This is specifically for checking empty collections, not for checking whether a scalar field is null.
+
+**Note on Arrays:** When you pass a JSON array as a value, the system checks that (1) the entity's collection contains all values in the array, and (2) the collection has exactly the same number of elements. This is an **exact set match**, not a subset check.
+
+### Examples
+
+Exact string match:
+```json
+{ "curie": "HGNC:11998" }
+```
+
+Exact boolean match:
+```json
+{ "obsolete": false, "internal": false }
+```
+
+Nested field match:
+```json
+{ "vocabulary.vocabularyLabel": "disease_qualifier" }
+```
+
+---
+
+## Reserved Keys
+
+The following keys have special meaning and are **not** treated as field names:
+
+### debug (optional)
+
+Set to the string `"true"` to include the generated database queries in the response. The value must be the **string** `"true"`, not a boolean. Default is `"false"`.
+
+When enabled, the response includes:
+- `dbQuery` -- The generated HQL query string
+
+```json
+{ "debug": "true" }
+```
+
+### query_operator (optional)
+
+Controls how fields are combined. By default, all field restrictions are **AND**'d together. Set to `"or"` to **OR** them instead.
+
+```json
+{
+    "name": "pax6",
+    "symbol": "pax6",
+    "query_operator": "or"
+}
+```
+
+This returns entities where `name` equals `"pax6"` **OR** `symbol` equals `"pax6"`.
+
+| Value   | Behavior                        |
+|---------|---------------------------------|
+| (absent)| Fields are AND'd (default).     |
+| `"or"`  | Fields are OR'd.                |
+| anything else | Fields are AND'd.         |
+
+---
+
+## Sorting
+
+Results are always sorted in **ascending** order by the entity's primary key (ID field). This ensures consistent ordering across pages.
+
+---
+
+## Response Object
+
+```json
+{
+    "results": [
+        { "...entity..." },
+        { "...entity..." }
+    ],
+    "totalResults": 7,
+    "returnedRecords": 2,
+    "dbQuery": "..."
+}
+```
+
+| Field             | Type    | Description                                                                                                             |
+|-------------------|---------|-------------------------------------------------------------------------------------------------------------------------|
+| `results`         | Array   | The page of entity objects matching the query. Empty when using count-only mode (`page=0`, `limit=0`).                  |
+| `totalResults`    | Long    | Total number of matching records. **Only populated in count-only mode** (`page=0`, `limit=0`). Null otherwise.          |
+| `returnedRecords` | Integer | Number of records in this page. Will equal `limit` except on the last page.                                             |
+| `dbQuery`         | String  | Present only when `debug` is `"true"`. The generated HQL query string.                                                  |
+
+---
+
+## Example
+
+**Request:**
+
+```
+POST /api/vocabularyterm/find?limit=10&page=0
+```
+
+**Request Body:**
+
+```json
 {
     "vocabulary.vocabularyLabel": "disease_qualifier",
     "debug": "true"
 }
 ```
 
-### Fields (required)
+**Response:**
 
-Fields are just a list of fields and their values to search the datgabase. All are exact matches and they are all ANDed together.
-
-### Debug (optional)
-
-Debug true will turn on some extra debugging in order to see the query getting sent to ElasticSearch and some duration statistics. Default value is false.
-
-## Return Object "SearchResults"
-
-```javascript
+```json
 {
     "results": [
+        { "...vocabulary term entity..." },
+        { "...vocabulary term entity..." }
     ],
-    "totalResults": 7,
     "returnedRecords": 7,
+    "debug": "true",
     "dbQuery": "select alias_1764182562 from org.alliancegenome.curation_api.model.entities.VocabularyTerm alias_1764182562 where alias_1764182562.vocabulary.vocabularyLabel = disease_qualifier order by alias_1764182562.id asc nulls last"
 }
 ```
 
-### Results
+---
 
-This is the list of objects coming back from the system.
+## Count-Only Example
 
-### Total Results
+**Request:**
 
-This is the count of the total results found on the whole query.
+```
+POST /api/vocabularyterm/find?limit=0&page=0
+```
 
-### Returned Results
+**Request Body:**
 
-This is the count of the page of results, for each page should be the count that is in the result set. May be smaller then limit on the last page.
+```json
+{
+    "vocabulary.vocabularyLabel": "disease_qualifier"
+}
+```
 
-### DB Query
+**Response:**
 
-This is the JQL query that will be run against the database.
+```json
+{
+    "results": [],
+    "totalResults": 7,
+    "returnedRecords": 0
+}
+```

--- a/SEARCH.md
+++ b/SEARCH.md
@@ -1,24 +1,40 @@
-# Search payload for /search endpoints
+# Search Payload for /search Endpoints
 
-## Endpoints
+## Overview
 
-Endpoints are in the following structure
+The `/search` endpoints query against OpenSearch (via Hibernate Search) and are used by the curation UI for browsing and filtering data. Each entity type exposes its own search endpoint.
 
-POST /api/{object}/search
+## Endpoint
 
-{object} will be any of the objects that we have tables for in the UI and the database
+```
+POST /api/{object}/search?page={page}&limit={limit}
+```
+
+`{object}` is any entity that has a corresponding table in the curation system (e.g., `gene`, `allele`, `disease-annotation`).
 
 ## Query Parameters
 
-### Page
+| Parameter | Type    | Default | Description                                      |
+|-----------|---------|---------|--------------------------------------------------|
+| `page`    | Integer | `0`     | Zero-based page number.                          |
+| `limit`   | Integer | `10`    | Number of results per page.                      |
 
-This will be a zero based page of results that is pulled from the database. 
+Results are fetched starting at offset `page * limit` and returning up to `limit` records.
 
-### Limit 
+## Request Body
 
-This will be the size of the page that comes back. 
+The request body is a JSON object with the following top-level fields:
 
-## POST Search Payload Example
+| Field                   | Required | Type                | Description                                                        |
+|-------------------------|----------|---------------------|--------------------------------------------------------------------|
+| `searchFilters`         | Yes      | Object              | Named filter groups containing field-level search criteria.        |
+| `searchFilterOperator`  | No       | String              | How filters are combined: `"AND"` (default) or `"OR"`.            |
+| `sortOrders`            | No       | Array               | Ordered list of sort directives.                                   |
+| `aggregations`          | No       | Array of Strings    | Fields to aggregate (facet) in the results.                        |
+| `nonNullFieldsTable`    | No       | Array of Strings    | Fields that must be non-null across the entire result set.         |
+| `debug`                 | No       | String              | Set to `"true"` to include the generated query in the response.   |
+
+### Full Example
 
 ```json
 {
@@ -43,134 +59,231 @@ This will be the size of the page that comes back.
         "uniqueidFilter": {
             "uniqueId": {
                 "queryString": "wb",
-                "tokenOperator": "AND",
-                "useKeywordFields": false
-            }
-            "nonNullFields": [],
-            "nullFields": [],
+                "tokenOperator": "AND"
+            },
+            "nonNullFields": ["someRelation.curie"],
+            "nullFields": ["deprecatedField"]
         }
     },
-    "searchFilterOperator": "OR",
     "sortOrders": [
-        {
-            "field": "diseaseAnnotationSubject.symbol",
-            "order": 1
-        },
-        {
-            "field": "diseaseAnnotationSubject.name",
-            "order": 1
-        },
-        {
-            "field": "diseaseAnnotationSubject.primaryExternalId",
-            "order": 1
-        }
+        { "field": "diseaseAnnotationSubject.symbol", "order": 1 },
+        { "field": "diseaseAnnotationSubject.name", "order": 1 },
+        { "field": "diseaseAnnotationSubject.primaryExternalId", "order": 1 }
     ],
     "aggregations": ["secondaryDataProvider.sourceOrganization.abbreviation"],
     "nonNullFieldsTable": [],
-    "debug": "true",
+    "debug": "true"
 }
-
 ```
 
-### Search filters (required)
+---
 
-#### Filters
+## Search Filters
 
-All search filters need to have a unique name. Names only have meaning to the caller of the endpoint. In the above example "nameFilter" is only the name of the filter. It could be called "filter1" or any other name that makes sense to the caller.
+`searchFilters` is a map of **named filter groups**. Each key is an arbitrary name chosen by the caller (e.g., `"nameFilter"`, `"filter1"`). The names have no meaning to the server -- they only need to be unique within the request.
 
-Filters by default will be "AND"ed together so in the above example "nameFilter" AND "obsoleteFilter" AND "uniqueidFilter". However if you wish to have them "OR"ed together set the "searchFilterOperator" to "OR".
+### How Filters Combine
 
-#### Fields
+By default, all filter groups are **AND**'d together:
 
-Inside a single filter there can be multiple items listed. These items are the names of the fields in the linkML model starting with {object} and its field. These fields can be chanined together to get access to nested properties as in if {object} is a disease annotation then a field could be "diseaseAnnotationSubject.taxon.curie", which would query against the tax id that is on the subject of a disease annotation.
+> nameFilter **AND** obsoleteFilter **AND** uniqueidFilter
 
-Fields inside a single filter are "OR"ed together, in the above example for "obsoleteFilter" we are saying where field "obsolete" is false OR field "internal" is false.
+To **OR** them instead, set `searchFilterOperator` to `"OR"` at the top level:
 
-##### Query String (required)
+> nameFilter **OR** obsoleteFilter **OR** uniqueidFilter
 
-The queryString inside a field will be tokenized and a match will be performed on each token.
+### Fields Within a Filter
 
-##### Query Type (optional)
+Each filter group contains one or more **field entries** (plus optional `nonNullFields` / `nullFields` lists). The field entries within a single filter are **OR**'d together.
 
-Query type only has one option "matchQuery" this will do a "match" query in Elastic Search vs any other value it will do a simpleQueryString search instead. Default is to use Simple Query String.
+For example, given this filter:
 
-##### Use Keyword Fields (optional)
+```json
+"obsoleteFilter": {
+    "obsolete": { "queryString": "false", "tokenOperator": "AND" },
+    "internal": { "queryString": "false", "tokenOperator": "AND" }
+}
+```
 
-This option will run against the _keyword fields vs the regular field names. In the above example for the uniqueId field the uniqueId_keyword field will be used instead. Default is false.
+The logic is: `obsolete matches "false"` **OR** `internal matches "false"`.
 
-##### Token Operator (optional)
+#### Field Names
 
-This option controls how the tokens are matched. Values are "AND" or "OR". So in the above example the name field will have to match pax6 OR pax. Default value is AND.
+Field names correspond to entity properties and can be dot-separated to traverse nested relationships. For example, if the entity is a disease annotation:
 
-#### Non Null Fields (optional)
+- `"uniqueId"` -- a direct field on the disease annotation
+- `"diseaseAnnotationSubject.taxon.curie"` -- traverses subject -> taxon -> curie
 
-In the context of a single filter we can specify that certain fields needs to be populated, this will be AND'ed to the field criteria. As in this list of fields must have a non null value.
+### Field Configuration
 
-#### Null Fields (optional)
+Each field entry is an object with the following properties:
 
-In the context of a single filter we can specify that certain field needs to be empty or null, this will be AND'ed to the field criteria. As in this list of fields must have a non null value.
+| Property           | Required | Type    | Default                | Description                                                  |
+|--------------------|----------|---------|------------------------|--------------------------------------------------------------|
+| `queryString`      | Yes      | String  | --                     | The search text. Will be tokenized by whitespace.            |
+| `tokenOperator`    | No       | String  | `"AND"`                | How tokens are matched: `"AND"` or `"OR"`.                   |
+| `queryType`        | No       | String  | (simple query string)  | Set to `"matchQuery"` for a plain match query.               |
+| `useKeywordFields` | No       | Boolean | `false`                | If `true`, queries against the `_keyword` variant of the field. |
 
-### Sort Orders (optional)
+#### queryString
 
-Sort orders is a list of objects that contain two fields on called "field" and the other called "order" field is the field in elasticSearch that we are going to order on which can also be a nest object field. Order is of two values 1 meaning ascending and -1 descending.
+The query string is tokenized by whitespace. Each token is matched according to the `tokenOperator`.
 
-### Non Null Fields Table (optional)
+For example, with `"queryString": "pax6 pax7"`:
+- `tokenOperator: "OR"` -- matches documents containing **pax6** or **pax7** (or both)
+- `tokenOperator: "AND"` -- matches only documents containing **both** pax6 and pax7
 
-This is a list of fields that have to be non null across the whole "table" or query. This will filter out all records that have null's in the fields in this list.
+#### queryType
 
-### Aggregations (optional)
+Controls which type of OpenSearch query is generated:
 
-This is a list of fields that will be aggregated in the results. This will be in the returned object see the response object below.
+- **Default (simple query string)** -- Supports special query syntax characters: `+` (must contain), `-` (must not contain), `"..."` (exact phrase), `*` (prefix wildcard), `(` `)` (grouping). Use this when the caller needs advanced search syntax.
+- **`"matchQuery"`** -- A plain text match with no special syntax. All characters are treated as literal search terms. Use this for straightforward text matching.
 
-### Debug (optional)
+#### useKeywordFields
 
-Debug true will turn on some extra debugging in order to see the query getting sent to ElasticSearch and some duration statistics. Default value is false.
+When set to `true`, the query runs against the `_keyword` variant of the field (e.g., `uniqueId_keyword` instead of `uniqueId`). Keyword fields are not analyzed/tokenized, so queries match on the exact stored value. This is useful for exact-match filtering on identifiers or controlled vocabulary values.
 
-## Return Object "SearchResults"
+When using simple query string mode (the default), setting `useKeywordFields: true` will query **both** the keyword field and the analyzed field, with the keyword field receiving a higher relevance boost.
+
+### nonNullFields (optional)
+
+A list of field names that must have a non-null value. This is specified **inside** a filter group and is AND'd with the filter's field criteria. Any documents where these fields are missing or null will be excluded.
+
+```json
+"myFilter": {
+    "name": { "queryString": "pax6", "tokenOperator": "AND" },
+    "nonNullFields": ["symbol", "taxon.curie"]
+}
+```
+
+Logic: `(name matches "pax6") AND (symbol exists) AND (taxon.curie exists)`
+
+### nullFields (optional)
+
+A list of field names that must be null or empty. This is specified **inside** a filter group and is AND'd with the filter's field criteria. Only documents where these fields are missing or null will be included.
+
+```json
+"myFilter": {
+    "name": { "queryString": "pax6", "tokenOperator": "AND" },
+    "nullFields": ["deprecatedField"]
+}
+```
+
+Logic: `(name matches "pax6") AND (deprecatedField does NOT exist)`
+
+---
+
+## Sort Orders (optional)
+
+An ordered list of sort directives. Each entry has two fields:
+
+| Property | Type    | Description                                         |
+|----------|---------|-----------------------------------------------------|
+| `field`  | String  | The entity field to sort on (supports dot notation). |
+| `order`  | Integer | `1` for ascending, `-1` for descending.             |
+
+Sorting is applied in the order the entries appear in the array.
+
+**Note:** The system automatically appends `_keyword` to sort field names. When you specify `"field": "diseaseAnnotationSubject.symbol"`, the actual sort is performed on `diseaseAnnotationSubject.symbol_keyword`.
+
+```json
+"sortOrders": [
+    { "field": "diseaseAnnotationSubject.symbol", "order": 1 },
+    { "field": "diseaseAnnotationSubject.name", "order": -1 }
+]
+```
+
+---
+
+## Non Null Fields Table (optional)
+
+A list of fields that must be non-null across the **entire** query result set. Unlike `nonNullFields` inside a filter (which is scoped to that filter's boolean context), this applies globally and filters out any record that has a null value in any of the listed fields.
+
+```json
+"nonNullFieldsTable": ["diseaseAnnotationSubject.symbol"]
+```
+
+---
+
+## Aggregations (optional)
+
+A list of field names to aggregate (facet). The results include term counts for each unique value in the specified fields. Each aggregation returns up to **30 terms** (the values with the highest document counts).
+
+**Note:** Like sort fields, the system automatically appends `_keyword` to aggregation field names.
+
+```json
+"aggregations": ["secondaryDataProvider.sourceOrganization.abbreviation"]
+```
+
+---
+
+## Debug (optional)
+
+Set to the string `"true"` to include the generated OpenSearch query in the response. This is useful for troubleshooting search behavior. The value must be the **string** `"true"`, not a boolean.
+
+```json
+"debug": "true"
+```
+
+---
+
+## Relevance Scoring
+
+The system assigns boost values to filters based on their declaration order. Filters listed **first** in `searchFilters` receive a higher relevance boost than those listed later. Within a single filter, fields listed first also receive a higher boost than later fields.
+
+This means the order of filters and fields affects result ranking (but not which results are returned).
+
+---
+
+## Behavior With Empty or Missing Filters
+
+If `searchFilters` is empty (`{}`) or not provided, the query performs a **match all** and returns all documents (subject to `nonNullFieldsTable`, pagination, and sorting).
+
+---
+
+## Response Object
 
 ```json
 {
     "results": [
-        { ... },
-        { ... },
-        { ... },
-        { ... },
-        { ... }
+        { "...entity..." },
+        { "...entity..." }
     ],
+    "totalResults": 1163,
+    "returnedRecords": 2,
     "aggregations": {
         "secondaryDataProvider.sourceOrganization.abbreviation": {
-            "rgd": 11297,
-            "omim": 200,
-            "alliance": 14
+            "RGD": 11297,
+            "OMIM": 200,
+            "Alliance": 14
         }
-    }
-    "esQuery": "..."
-    "totalResults": 1163,
-    "returnedRecords": 5
+    },
+    "esQuery": "...",
+    "dbQuery": "..."
 }
 ```
 
-### Results
+| Field             | Type    | Description                                                                                                    |
+|-------------------|---------|----------------------------------------------------------------------------------------------------------------|
+| `results`         | Array   | The page of entity objects matching the query.                                                                 |
+| `totalResults`    | Long    | Total number of matching documents across all pages.                                                           |
+| `returnedRecords` | Integer | Number of records in this page. Will equal `limit` except on the last page.                                    |
+| `aggregations`    | Object  | Present only if `aggregations` was requested. Map of field name to value/count pairs.                          |
+| `esQuery`         | String  | Present only when `debug` is `"true"`. The raw OpenSearch query that was generated.                            |
+| `dbQuery`         | String  | Present only when `debug` is `"true"` on `/find` endpoints. The generated HQL query (not used by `/search`).  |
 
-This is the list of objects coming back from the system.
+---
 
-### Aggregations
+## Example
 
-Aggregations will be an object containing fields by field name. Each entry will have all the values under, with the counts.
+**Request:**
 
-### Total Results
-
-This is the count of the total results found on the whole query.
-
-### Returned Results
-
-This is the count of the page of results, for each page should be the count that is in the result set. May be smaller then limit on the last page.
-
-### Examples
-
+```
 POST /api/disease-annotation/search?limit=1&page=0
+```
 
-Search Payload:
+**Request Body:**
 
 ```json
 {
@@ -195,18 +308,9 @@ Search Payload:
         }
     },
     "sortOrders": [
-        {
-            "field": "diseaseAnnotationSubject.symbol",
-            "order": 1
-        },
-        {
-            "field": "diseaseAnnotationSubject.name",
-            "order": 1
-        },
-        {
-            "field": "diseaseAnnotationSubject.primaryExternalId",
-            "order": 1
-        }
+        { "field": "diseaseAnnotationSubject.symbol", "order": 1 },
+        { "field": "diseaseAnnotationSubject.name", "order": 1 },
+        { "field": "diseaseAnnotationSubject.primaryExternalId", "order": 1 }
     ],
     "aggregations": [],
     "nonNullFieldsTable": [],
@@ -214,21 +318,21 @@ Search Payload:
 }
 ```
 
-Return Payload
+**Response:**
 
 ```json
 {
     "results": [
-        { ... }
+        { "...disease annotation entity..." }
     ],
     "totalResults": 1163,
     "returnedRecords": 1,
     "debug": "true",
-    "esQuery": "{\"query\":{\"bool\":{\"must\":[{\"simple_query_string\":{\"boost\":31000.0,\"query\":\"false\",\"default_operator\":\"or\",\"fields\":[\"internal\"]}},{\"simple_query_string\":{\"boost\":21000.0,\"query\":\"false\",\"default_operator\":\"or\",\"fields\":[\"obsolete\"]}},{\"simple_query_string\":{\"boost\":11000.0,\"query\":\"wb\",\"default_operator\":\"and\",\"fields\":[\"uniqueId\"]}},{\"match_all\":{}}],\"minimum_should_match\":\"0\"}},\"sort\":[{\"diseaseAnnotationSubject.symbol_keyword\":{\"order\":\"asc\",\"unmapped_type\":\"keyword\"}},{\"diseaseAnnotationSubject.name_keyword\":{\"order\":\"asc\",\"unmapped_type\":\"keyword\"}},{\"diseaseAnnotationSubject.primaryExternalId_keyword\":{\"order\":\"asc\",\"unmapped_type\":\"keyword\"}}],\"docvalue_fields\":[\"_entity_type\"],\"_source\":false}"
+    "esQuery": "..."
 }
 ```
 
-Destringify the esQuery:
+When `debug` is enabled, the `esQuery` field contains the raw OpenSearch query. Below is the prettified version of a typical generated query:
 
 ```json
 {
@@ -237,32 +341,26 @@ Destringify the esQuery:
             "must": [
                 {
                     "simple_query_string": {
-                        "boost": 31000,
+                        "boost": 31000.0,
                         "query": "false",
                         "default_operator": "or",
-                        "fields": [
-                            "internal"
-                        ]
+                        "fields": ["internal"]
                     }
                 },
                 {
                     "simple_query_string": {
-                        "boost": 21000,
+                        "boost": 21000.0,
                         "query": "false",
                         "default_operator": "or",
-                        "fields": [
-                            "obsolete"
-                        ]
+                        "fields": ["obsolete"]
                     }
                 },
                 {
                     "simple_query_string": {
-                        "boost": 11000,
+                        "boost": 11000.0,
                         "query": "wb",
                         "default_operator": "and",
-                        "fields": [
-                            "uniqueId"
-                        ]
+                        "fields": ["uniqueId"]
                     }
                 },
                 {
@@ -291,11 +389,8 @@ Destringify the esQuery:
                 "unmapped_type": "keyword"
             }
         }
-    ],
-    "docvalue_fields": [
-        "_entity_type"
-    ],
-    "_source": false
+    ]
 }
 ```
 
+Notice that the boost values decrease with each filter (31000, 21000, 11000) reflecting the declaration-order relevance scoring, and that the sort fields have `_keyword` appended automatically.

--- a/src/main/java/org/alliancegenome/curation_api/config/OpenApiSchemaFilter.java
+++ b/src/main/java/org/alliancegenome/curation_api/config/OpenApiSchemaFilter.java
@@ -1,0 +1,416 @@
+package org.alliancegenome.curation_api.config;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.media.Schema.SchemaType;
+
+/**
+ * OASFilter that optimizes the generated OpenAPI schema for Swagger UI.
+ *
+ * This filter performs two optimizations:
+ * 1. Breaks circular $ref chains that cause Swagger UI to recurse infinitely.
+ * 2. Limits schema nesting depth by truncating $ref properties in schemas
+ *	  with large expansion trees, preventing browser hangs.
+ *
+ * Both optimizations work by modifying Schema objects in-place (via addProperty,
+ * setItems) rather than modifying the unmodifiable schemas map.
+ */
+public class OpenApiSchemaFilter implements OASFilter {
+
+	private static final Logger LOG = Logger.getLogger(OpenApiSchemaFilter.class.getName());
+	private static final String REF_PREFIX = "#/components/schemas/";
+
+	@Override
+	public void filterOpenAPI(OpenAPI openAPI) {
+		if (openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null) {
+			return;
+		}
+		Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
+
+		// Phase 1: Break circular references
+		breakCircularRefs(schemas);
+
+		// Phase 2: Limit schema nesting depth
+		limitSchemaDepth(schemas);
+
+		// Phase 3: Clean up SmallRye cyclic reference descriptions
+		cleanCyclicRefDescriptions(schemas);
+
+		// Phase 4: Add CRUD tags to search/find/findForPublic operations
+		propagateCrudTags(openAPI);
+
+		LOG.info("OpenAPI schema filter: processed " + schemas.size() + " schemas");
+	}
+
+	/**
+	 * For /search, /find, and /findForPublic operations, finds the CRUD tag
+	 * from sibling operations under the same base path and adds it so the
+	 * endpoint appears under both its browsing category and its entity's
+	 * CRUD section in Swagger UI.
+	 */
+	private void propagateCrudTags(OpenAPI openAPI) {
+		if (openAPI.getPaths() == null) {
+			return;
+		}
+		Map<String, PathItem> paths = openAPI.getPaths().getPathItems();
+		if (paths == null) {
+			return;
+		}
+
+		// Build a map of base path -> CRUD tag by looking at non-search/find operations
+		Map<String, String> baseCrudTags = new HashMap<>();
+		for (Map.Entry<String, PathItem> entry : paths.entrySet()) {
+			String path = entry.getKey();
+			if (path.endsWith("/search") || path.endsWith("/find") || path.endsWith("/findForPublic")) {
+				continue;
+			}
+			PathItem pathItem = entry.getValue();
+			String crudTag = findCrudTag(pathItem);
+			if (crudTag != null) {
+				baseCrudTags.put(path, crudTag);
+			}
+		}
+
+		int tagged = 0;
+		for (Map.Entry<String, PathItem> entry : paths.entrySet()) {
+			String path = entry.getKey();
+			if (!path.endsWith("/search") && !path.endsWith("/find") && !path.endsWith("/findForPublic")) {
+				continue;
+			}
+			// Derive the base path by removing the suffix
+			String basePath = path.substring(0, path.lastIndexOf('/'));
+			// Look for a CRUD tag on a path that matches the base path exactly
+			// or is a subpath (e.g. /api/gene/{id}), but not a different entity
+			// (e.g. /api/gene-expression-annotation)
+			String crudTag = null;
+			for (Map.Entry<String, String> tagEntry : baseCrudTags.entrySet()) {
+				String candidate = tagEntry.getKey();
+				if (candidate.equals(basePath)
+						|| candidate.startsWith(basePath + "/")
+						|| candidate.startsWith(basePath + "{")) {
+					crudTag = tagEntry.getValue();
+					break;
+				}
+			}
+			if (crudTag == null) {
+				continue;
+			}
+			// Add the CRUD tag to all operations on this path
+			PathItem pathItem = entry.getValue();
+			for (Operation op : getOperations(pathItem)) {
+				if (op.getTags() != null && !op.getTags().contains(crudTag)) {
+					op.addTag(crudTag);
+					tagged++;
+				}
+			}
+		}
+		LOG.info("OpenAPI schema filter: added CRUD tags to " + tagged + " search/find operations");
+	}
+
+	private String findCrudTag(PathItem pathItem) {
+		for (Operation op : getOperations(pathItem)) {
+			if (op.getTags() != null) {
+				for (String tag : op.getTags()) {
+					if (tag.startsWith("CRUD")) {
+						return tag;
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	private List<Operation> getOperations(PathItem pathItem) {
+		List<Operation> ops = new ArrayList<>();
+		if (pathItem.getGET() != null) {
+			ops.add(pathItem.getGET());
+		}
+		if (pathItem.getPOST() != null) {
+			ops.add(pathItem.getPOST());
+		}
+		if (pathItem.getPUT() != null) {
+			ops.add(pathItem.getPUT());
+		}
+		if (pathItem.getDELETE() != null) {
+			ops.add(pathItem.getDELETE());
+		}
+		if (pathItem.getPATCH() != null) {
+			ops.add(pathItem.getPATCH());
+		}
+		return ops;
+	}
+
+	/**
+	 * Detects and breaks circular $ref chains using DFS back-edge detection.
+	 */
+	private void breakCircularRefs(Map<String, Schema> schemas) {
+		Map<String, Set<String>> graph = buildRefGraph(schemas);
+
+		List<String[]> backEdges = findBackEdges(graph);
+		LOG.info("OpenAPI schema filter: found " + backEdges.size() + " circular reference back-edges");
+
+		int broken = 0;
+		for (String[] edge : backEdges) {
+			Schema srcSchema = schemas.get(edge[0]);
+			if (srcSchema != null && breakRefsInSchema(srcSchema, REF_PREFIX + edge[1], edge[1])) {
+				broken++;
+			}
+		}
+		LOG.info("OpenAPI schema filter: broke " + broken + " circular references");
+	}
+
+	/**
+	 * Limits schema nesting depth by globally truncating $ref properties that
+	 * point to complex schemas. Any property referencing a schema with more
+	 * than MAX_TARGET_REFS outgoing refs is replaced with a placeholder.
+	 * This prevents Swagger UI from recursively expanding deep schema trees.
+	 */
+	private static final int MAX_TARGET_REFS = 3;
+
+	private void limitSchemaDepth(Map<String, Schema> schemas) {
+		Map<String, Set<String>> graph = buildRefGraph(schemas);
+
+		int truncated = 0;
+		for (Map.Entry<String, Schema> entry : schemas.entrySet()) {
+			if (truncateDeepRefs(entry.getValue(), graph)) {
+				truncated++;
+			}
+		}
+		LOG.info("OpenAPI schema filter: truncated deep refs in " + truncated + " schemas");
+	}
+
+	/**
+	 * Cleans up SmallRye's "Cyclic reference to fully.qualified.ClassName"
+	 * descriptions by stripping the package path, leaving just the class name.
+	 */
+	private void cleanCyclicRefDescriptions(Map<String, Schema> schemas) {
+		for (Schema schema : schemas.values()) {
+			cleanCyclicDescInSchema(schema);
+		}
+	}
+
+	private void cleanCyclicDescInSchema(Schema schema) {
+		if (schema == null) {
+			return;
+		}
+
+		String desc = schema.getDescription();
+		if (desc != null && desc.startsWith("Cyclic reference to ")) {
+			String fqcn = desc.substring("Cyclic reference to ".length());
+			int lastDot = fqcn.lastIndexOf('.');
+			String className = lastDot >= 0 ? fqcn.substring(lastDot + 1) : fqcn;
+			schema.setTitle(className);
+			schema.setDescription("See " + className + " schema");
+		}
+
+		if (schema.getProperties() != null) {
+			for (Schema propSchema : schema.getProperties().values()) {
+				cleanCyclicDescInSchema(propSchema);
+			}
+		}
+		if (schema.getItems() != null) {
+			cleanCyclicDescInSchema(schema.getItems());
+		}
+		if (schema.getAllOf() != null) {
+			for (Schema s : schema.getAllOf()) {
+				cleanCyclicDescInSchema(s);
+			}
+		}
+	}
+
+	/**
+	 * Replace $ref properties that point to complex schemas (more than
+	 * MAX_TARGET_REFS outgoing refs) with type: object placeholders.
+	 */
+	private boolean truncateDeepRefs(Schema schema, Map<String, Set<String>> graph) {
+		boolean truncated = false;
+
+		Map<String, Schema> props = schema.getProperties();
+		if (props != null) {
+			for (Map.Entry<String, Schema> entry : new ArrayList<>(props.entrySet())) {
+				Schema propSchema = entry.getValue();
+				String targetName = extractRefName(propSchema);
+				String arrayTargetName = propSchema.getItems() != null
+					? extractRefName(propSchema.getItems()) : null;
+
+				String refTarget = targetName != null ? targetName : arrayTargetName;
+				if (refTarget == null) {
+					continue;
+				}
+
+				// Truncate refs to schemas that have their own outgoing refs
+				Set<String> targetRefs = graph.getOrDefault(refTarget, Collections.emptySet());
+				if (targetRefs.size() > MAX_TARGET_REFS) {
+					if (targetName != null) {
+						schema.addProperty(entry.getKey(), createPlaceholder(targetName));
+					} else {
+						propSchema.setItems(createPlaceholder(arrayTargetName));
+					}
+					truncated = true;
+				}
+			}
+		}
+
+		// Also check allOf members
+		if (schema.getAllOf() != null) {
+			for (Schema allOfMember : schema.getAllOf()) {
+				if (allOfMember.getRef() == null) {
+					if (truncateDeepRefs(allOfMember, graph)) {
+						truncated = true;
+					}
+				}
+			}
+		}
+
+		return truncated;
+	}
+
+	private String extractRefName(Schema schema) {
+		if (schema == null) {
+			return null;
+		}
+		String ref = schema.getRef();
+		if (ref != null && ref.startsWith(REF_PREFIX)) {
+			return ref.substring(REF_PREFIX.length());
+		}
+		return null;
+	}
+
+	private Map<String, Set<String>> buildRefGraph(Map<String, Schema> schemas) {
+		Map<String, Set<String>> graph = new HashMap<>();
+		for (Map.Entry<String, Schema> entry : schemas.entrySet()) {
+			Set<String> refs = new HashSet<>();
+			collectSchemaRefs(entry.getValue(), refs);
+			refs.retainAll(schemas.keySet());
+			graph.put(entry.getKey(), refs);
+		}
+		return graph;
+	}
+
+	private void collectSchemaRefs(Schema schema, Set<String> refs) {
+		if (schema == null) {
+			return;
+		}
+
+		String ref = schema.getRef();
+		if (ref != null && ref.startsWith(REF_PREFIX)) {
+			refs.add(ref.substring(REF_PREFIX.length()));
+			return;
+		}
+
+		if (schema.getProperties() != null) {
+			for (Schema propSchema : schema.getProperties().values()) {
+				collectSchemaRefs(propSchema, refs);
+			}
+		}
+		if (schema.getItems() != null) {
+			collectSchemaRefs(schema.getItems(), refs);
+		}
+		if (schema.getAllOf() != null) {
+			for (Schema s : schema.getAllOf()) {
+				collectSchemaRefs(s, refs);
+			}
+		}
+		if (schema.getAnyOf() != null) {
+			for (Schema s : schema.getAnyOf()) {
+				collectSchemaRefs(s, refs);
+			}
+		}
+		if (schema.getOneOf() != null) {
+			for (Schema s : schema.getOneOf()) {
+				collectSchemaRefs(s, refs);
+			}
+		}
+		if (schema.getAdditionalPropertiesSchema() != null) {
+			collectSchemaRefs(schema.getAdditionalPropertiesSchema(), refs);
+		}
+	}
+
+	private List<String[]> findBackEdges(Map<String, Set<String>> graph) {
+		Map<String, Integer> color = new HashMap<>();
+		graph.keySet().forEach(n -> color.put(n, 0));
+		List<String[]> backEdges = new ArrayList<>();
+
+		for (String node : graph.keySet()) {
+			if (color.get(node) == 0) {
+				dfs(node, graph, color, backEdges);
+			}
+		}
+		return backEdges;
+	}
+
+	private void dfs(String node, Map<String, Set<String>> graph,
+			Map<String, Integer> color, List<String[]> backEdges) {
+		color.put(node, 1);
+		for (String neighbor : graph.getOrDefault(node, Collections.emptySet())) {
+			Integer c = color.get(neighbor);
+			if (c == null) {
+				continue;
+			}
+			if (c == 1) {
+				backEdges.add(new String[]{node, neighbor});
+			} else if (c == 0) {
+				dfs(neighbor, graph, color, backEdges);
+			}
+		}
+		color.put(node, 2);
+	}
+
+	/**
+	 * Breaks $ref references to the target schema within the source schema.
+	 * Handles direct property $refs, array items $refs, and allOf member properties.
+	 * Does NOT break allOf inheritance $refs (to preserve schema hierarchy).
+	 */
+	private boolean breakRefsInSchema(Schema schema, String targetRef, String targetName) {
+		boolean broken = false;
+
+		Map<String, Schema> props = schema.getProperties();
+		if (props != null) {
+			for (Map.Entry<String, Schema> entry : new ArrayList<>(props.entrySet())) {
+				Schema propSchema = entry.getValue();
+				if (targetRef.equals(propSchema.getRef())) {
+					schema.addProperty(entry.getKey(), createPlaceholder(targetName));
+					broken = true;
+				} else if (propSchema.getItems() != null
+						&& targetRef.equals(propSchema.getItems().getRef())) {
+					propSchema.setItems(createPlaceholder(targetName));
+					broken = true;
+				}
+			}
+		}
+
+		if (schema.getAllOf() != null) {
+			for (Schema allOfMember : schema.getAllOf()) {
+				if (allOfMember.getRef() == null) {
+					if (breakRefsInSchema(allOfMember, targetRef, targetName)) {
+						broken = true;
+					}
+				}
+			}
+		}
+
+		return broken;
+	}
+
+	private Schema createPlaceholder(String targetName) {
+		String className = targetName.replace("_", "");
+		Schema placeholder = OASFactory.createObject(Schema.class);
+		placeholder.addType(SchemaType.OBJECT);
+		placeholder.setTitle(className);
+		placeholder.setDescription("See " + className + " schema");
+		return placeholder;
+	}
+}

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/BaseFindControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/BaseFindControllerInterface.java
@@ -2,12 +2,13 @@ package org.alliancegenome.curation_api.interfaces.base;
 
 import java.util.HashMap;
 
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
@@ -31,48 +32,69 @@ public interface BaseFindControllerInterface<E extends AuditedObject> {
 	@POST
 	@Path("/findForPublic")
 	@Tag(name = "Public Web API Database Searching Endpoints")
-	@RequestBody(
-		description = "Post Request",
-		content = @Content(
-			mediaType = "application/json",
-			schema = @Schema(implementation = String.class)
-		)
-	)
+	@Operation(summary = "Find entities for public API", description = "Query the relational database for entities using exact field-level filters. Returns a public-facing view of the data.\n\n"
+		+ "## Fields (required)\n\n"
+		+ "The request body is a flat map of field names to values. All fields are exact matches and are AND'ed together. "
+		+ "Fields use dot notation for nested properties (e.g. 'vocabulary.vocabularyLabel').\n\n"
+		+ "## Debug (optional)\n\n"
+		+ "Set `debug` to 'true' to include the generated JQL database query in the response `dbQuery` field. Default false.\n\n"
+		+ "For full documentation see [FIND.md](https://github.com/alliance-genome/agr_curation/blob/alpha/FIND.md)")
 	@APIResponses(
 		@APIResponse(
-			description = "Response Entity",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
-			)
-		)
+			responseCode = "200",
+			description = "Paginated results containing: results (list of matching entities), totalResults (total match count), "
+				+ "returnedRecords (page size), and optionally dbQuery (generated JQL query when debug is true)")
 	)
 	Response findForPublic(
-		@DefaultValue("0") @QueryParam("page") Integer page,
-		@DefaultValue("10") @QueryParam("limit") Integer limit,
-		@DefaultValue("ForPublic") @QueryParam("view") String view,
-		@RequestBody HashMap<String, Object> params);
+		@Parameter(description = "Zero-based page number of results to return") @DefaultValue("0") @QueryParam("page") Integer page,
+		@Parameter(description = "Number of results per page") @DefaultValue("10") @QueryParam("limit") Integer limit,
+		@Parameter(description = "Response view format") @DefaultValue("ForPublic") @QueryParam("view") String view,
+		@RequestBody(description = "Map of field names to exact-match filter values",
+			content = @Content(
+				mediaType = MediaType.APPLICATION_JSON,
+				examples = @ExampleObject(
+					name = "Find example",
+					summary = "Find by field with debug enabled",
+					value = "{\n"
+						+ "	 \"vocabulary.vocabularyLabel\": \"disease_qualifier\",\n"
+						+ "	 \"debug\": \"true\"\n"
+						+ "}"
+				)
+			)
+		) HashMap<String, Object> params);
 
 	@POST
 	@Path("/find")
 	@Tag(name = "Relational Database Browsing Endpoints")
 	@JsonView(CurationView.FieldsAndLists.class)
-	@RequestBody(
-		description = "Post Request",
-		content = @Content(
-			mediaType = "application/json",
-			schema = @Schema(implementation = String.class)
-		)
-	)
+	@Operation(summary = "Find entities via database query", description = "Query the relational database for entities using exact field-level filters. Returns the full curation view of the data.\n\n"
+		+ "## Fields (required)\n\n"
+		+ "The request body is a flat map of field names to values. All fields are exact matches and are AND'ed together. "
+		+ "Fields use dot notation for nested properties (e.g. 'vocabulary.vocabularyLabel').\n\n"
+		+ "## Debug (optional)\n\n"
+		+ "Set `debug` to 'true' to include the generated JQL database query in the response `dbQuery` field. Default false.\n\n"
+		+ "For full documentation see [FIND.md](https://github.com/alliance-genome/agr_curation/blob/alpha/FIND.md)")
 	@APIResponses(
 		@APIResponse(
-			description = "Response Entity",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
-			)
-		)
+			responseCode = "200",
+			description = "Paginated results containing: results (list of matching entities), totalResults (total match count), "
+				+ "returnedRecords (page size), and optionally dbQuery (generated JQL query when debug is true)")
 	)
-	SearchResponse<E> find(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<E> find(
+		@Parameter(description = "Zero-based page number of results to return") @DefaultValue("0") @QueryParam("page") Integer page,
+		@Parameter(description = "Number of results per page") @DefaultValue("10") @QueryParam("limit") Integer limit,
+		@RequestBody(description = "Map of field names to exact-match filter values",
+			content = @Content(
+				mediaType = MediaType.APPLICATION_JSON,
+				examples = @ExampleObject(
+					name = "Find example",
+					summary = "Find by field with debug enabled",
+					value = "{\n"
+						+ "	 \"vocabulary.vocabularyLabel\": \"disease_qualifier\",\n"
+						+ "	 \"debug\": \"true\"\n"
+						+ "}"
+				)
+			)
+		) HashMap<String, Object> params);
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/BaseFindControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/BaseFindControllerInterface.java
@@ -32,34 +32,77 @@ public interface BaseFindControllerInterface<E extends AuditedObject> {
 	@POST
 	@Path("/findForPublic")
 	@Tag(name = "Public Web API Database Searching Endpoints")
-	@Operation(summary = "Find entities for public API", description = "Query the relational database for entities using exact field-level filters. Returns a public-facing view of the data.\n\n"
-		+ "## Fields (required)\n\n"
-		+ "The request body is a flat map of field names to values. All fields are exact matches and are AND'ed together. "
-		+ "Fields use dot notation for nested properties (e.g. 'vocabulary.vocabularyLabel').\n\n"
-		+ "## Debug (optional)\n\n"
-		+ "Set `debug` to 'true' to include the generated JQL database query in the response `dbQuery` field. Default false.\n\n"
+	@Operation(summary = "Find entities for public API", description = "Query the relational database (PostgreSQL via JPA/Hibernate) for entities using exact field-level filters. "
+		+ "Returns a public-facing view of the data controlled by the `view` parameter.\n\n"
+		+ "## Request Body\n\n"
+		+ "A flat JSON object mapping field names to their expected values. All fields are matched using exact equality.\n\n"
+		+ "### Field Names\n\n"
+		+ "Field names correspond to JPA entity properties. Use dot notation to traverse nested relationships "
+		+ "(e.g. `vocabulary.vocabularyLabel`, `diseaseAnnotationSubject.taxon.curie`). "
+		+ "Collection fields in the traversal path are automatically joined.\n\n"
+		+ "### Supported Value Types\n\n"
+		+ "- **String**: Exact string equality\n"
+		+ "- **Integer/Long**: Exact numeric equality\n"
+		+ "- **Boolean**: Exact boolean equality (true/false)\n"
+		+ "- **Array**: Exact collection match — entity collection must contain all listed values and be the same size\n"
+		+ "- **null**: Checks that the collection field is empty (has no elements)\n\n"
+		+ "### Reserved Keys\n\n"
+		+ "- **debug** (optional): Set to the string `\"true\"` to include the generated HQL query in the response `dbQuery` field. Default false.\n"
+		+ "- **query_operator** (optional): Set to `\"or\"` to OR fields together instead of the default AND.\n\n"
+		+ "### Count-Only Mode\n\n"
+		+ "When `page=0` and `limit=0`, only `totalResults` is returned without fetching entity records. "
+		+ "When `limit > 0`, the `results` array is returned but `totalResults` is not populated.\n\n"
+		+ "Results are always sorted ascending by entity primary key.\n\n"
 		+ "For full documentation see [FIND.md](https://github.com/alliance-genome/agr_curation/blob/alpha/FIND.md)")
 	@APIResponses(
 		@APIResponse(
 			responseCode = "200",
-			description = "Paginated results containing: results (list of matching entities), totalResults (total match count), "
-				+ "returnedRecords (page size), and optionally dbQuery (generated JQL query when debug is true)")
+			description = "Paginated results containing: results (list of matching entities), returnedRecords (page size), "
+				+ "and optionally totalResults (only in count-only mode with page=0 and limit=0) "
+				+ "and dbQuery (generated HQL query when debug is true)")
 	)
 	Response findForPublic(
-		@Parameter(description = "Zero-based page number of results to return") @DefaultValue("0") @QueryParam("page") Integer page,
-		@Parameter(description = "Number of results per page") @DefaultValue("10") @QueryParam("limit") Integer limit,
-		@Parameter(description = "Response view format") @DefaultValue("ForPublic") @QueryParam("view") String view,
-		@RequestBody(description = "Map of field names to exact-match filter values",
+		@Parameter(description = "Zero-based page number of results to return. Set page=0 with limit=0 for count-only mode.") @DefaultValue("0") @QueryParam("page") Integer page,
+		@Parameter(description = "Number of results per page. Set to 0 with page=0 for count-only mode.") @DefaultValue("10") @QueryParam("limit") Integer limit,
+		@Parameter(description = "JSON view class name controlling response serialization (e.g. ForPublic, FieldsOnly). Defaults to ForPublic if not recognized.") @DefaultValue("ForPublic") @QueryParam("view") String view,
+		@RequestBody(description = "Flat map of field names to exact-match filter values. Supports dot notation for nested properties. "
+			+ "Reserved keys: 'debug' (set to 'true' for query output), 'query_operator' (set to 'or' to OR fields).",
 			content = @Content(
 				mediaType = MediaType.APPLICATION_JSON,
-				examples = @ExampleObject(
-					name = "Find example",
-					summary = "Find by field with debug enabled",
-					value = "{\n"
-						+ "	 \"vocabulary.vocabularyLabel\": \"disease_qualifier\",\n"
-						+ "	 \"debug\": \"true\"\n"
-						+ "}"
-				)
+				examples = {
+					@ExampleObject(
+						name = "Basic find",
+						summary = "Find by nested field",
+						value = "{\n"
+							+ "  \"vocabulary.vocabularyLabel\": \"disease_qualifier\"\n"
+							+ "}"
+					),
+					@ExampleObject(
+						name = "Find with debug",
+						summary = "Find with debug enabled to see the generated HQL query",
+						value = "{\n"
+							+ "  \"vocabulary.vocabularyLabel\": \"disease_qualifier\",\n"
+							+ "  \"debug\": \"true\"\n"
+							+ "}"
+					),
+					@ExampleObject(
+						name = "Multiple fields with OR",
+						summary = "Find where name OR symbol matches using query_operator",
+						value = "{\n"
+							+ "  \"name\": \"pax6\",\n"
+							+ "  \"symbol\": \"pax6\",\n"
+							+ "  \"query_operator\": \"or\"\n"
+							+ "}"
+					),
+					@ExampleObject(
+						name = "Boolean filter",
+						summary = "Find non-obsolete, non-internal entities",
+						value = "{\n"
+							+ "  \"obsolete\": false,\n"
+							+ "  \"internal\": false\n"
+							+ "}"
+					)
+				}
 			)
 		) HashMap<String, Object> params);
 
@@ -67,33 +110,76 @@ public interface BaseFindControllerInterface<E extends AuditedObject> {
 	@Path("/find")
 	@Tag(name = "Relational Database Browsing Endpoints")
 	@JsonView(CurationView.FieldsAndLists.class)
-	@Operation(summary = "Find entities via database query", description = "Query the relational database for entities using exact field-level filters. Returns the full curation view of the data.\n\n"
-		+ "## Fields (required)\n\n"
-		+ "The request body is a flat map of field names to values. All fields are exact matches and are AND'ed together. "
-		+ "Fields use dot notation for nested properties (e.g. 'vocabulary.vocabularyLabel').\n\n"
-		+ "## Debug (optional)\n\n"
-		+ "Set `debug` to 'true' to include the generated JQL database query in the response `dbQuery` field. Default false.\n\n"
+	@Operation(summary = "Find entities via database query", description = "Query the relational database (PostgreSQL via JPA/Hibernate) for entities using exact field-level filters. "
+		+ "Returns the full curation view of the data.\n\n"
+		+ "## Request Body\n\n"
+		+ "A flat JSON object mapping field names to their expected values. All fields are matched using exact equality.\n\n"
+		+ "### Field Names\n\n"
+		+ "Field names correspond to JPA entity properties. Use dot notation to traverse nested relationships "
+		+ "(e.g. `vocabulary.vocabularyLabel`, `diseaseAnnotationSubject.taxon.curie`). "
+		+ "Collection fields in the traversal path are automatically joined.\n\n"
+		+ "### Supported Value Types\n\n"
+		+ "- **String**: Exact string equality\n"
+		+ "- **Integer/Long**: Exact numeric equality\n"
+		+ "- **Boolean**: Exact boolean equality (true/false)\n"
+		+ "- **Array**: Exact collection match — entity collection must contain all listed values and be the same size\n"
+		+ "- **null**: Checks that the collection field is empty (has no elements)\n\n"
+		+ "### Reserved Keys\n\n"
+		+ "- **debug** (optional): Set to the string `\"true\"` to include the generated HQL query in the response `dbQuery` field. Default false.\n"
+		+ "- **query_operator** (optional): Set to `\"or\"` to OR fields together instead of the default AND.\n\n"
+		+ "### Count-Only Mode\n\n"
+		+ "When `page=0` and `limit=0`, only `totalResults` is returned without fetching entity records. "
+		+ "When `limit > 0`, the `results` array is returned but `totalResults` is not populated.\n\n"
+		+ "Results are always sorted ascending by entity primary key.\n\n"
 		+ "For full documentation see [FIND.md](https://github.com/alliance-genome/agr_curation/blob/alpha/FIND.md)")
 	@APIResponses(
 		@APIResponse(
 			responseCode = "200",
-			description = "Paginated results containing: results (list of matching entities), totalResults (total match count), "
-				+ "returnedRecords (page size), and optionally dbQuery (generated JQL query when debug is true)")
+			description = "Paginated results containing: results (list of matching entities), returnedRecords (page size), "
+				+ "and optionally totalResults (only in count-only mode with page=0 and limit=0) "
+				+ "and dbQuery (generated HQL query when debug is true)")
 	)
 	SearchResponse<E> find(
-		@Parameter(description = "Zero-based page number of results to return") @DefaultValue("0") @QueryParam("page") Integer page,
-		@Parameter(description = "Number of results per page") @DefaultValue("10") @QueryParam("limit") Integer limit,
-		@RequestBody(description = "Map of field names to exact-match filter values",
+		@Parameter(description = "Zero-based page number of results to return. Set page=0 with limit=0 for count-only mode.") @DefaultValue("0") @QueryParam("page") Integer page,
+		@Parameter(description = "Number of results per page. Set to 0 with page=0 for count-only mode.") @DefaultValue("10") @QueryParam("limit") Integer limit,
+		@RequestBody(description = "Flat map of field names to exact-match filter values. Supports dot notation for nested properties. "
+			+ "Reserved keys: 'debug' (set to 'true' for query output), 'query_operator' (set to 'or' to OR fields).",
 			content = @Content(
 				mediaType = MediaType.APPLICATION_JSON,
-				examples = @ExampleObject(
-					name = "Find example",
-					summary = "Find by field with debug enabled",
-					value = "{\n"
-						+ "	 \"vocabulary.vocabularyLabel\": \"disease_qualifier\",\n"
-						+ "	 \"debug\": \"true\"\n"
-						+ "}"
-				)
+				examples = {
+					@ExampleObject(
+						name = "Basic find",
+						summary = "Find by nested field",
+						value = "{\n"
+							+ "  \"vocabulary.vocabularyLabel\": \"disease_qualifier\"\n"
+							+ "}"
+					),
+					@ExampleObject(
+						name = "Find with debug",
+						summary = "Find with debug enabled to see the generated HQL query",
+						value = "{\n"
+							+ "  \"vocabulary.vocabularyLabel\": \"disease_qualifier\",\n"
+							+ "  \"debug\": \"true\"\n"
+							+ "}"
+					),
+					@ExampleObject(
+						name = "Multiple fields with OR",
+						summary = "Find where name OR symbol matches using query_operator",
+						value = "{\n"
+							+ "  \"name\": \"pax6\",\n"
+							+ "  \"symbol\": \"pax6\",\n"
+							+ "  \"query_operator\": \"or\"\n"
+							+ "}"
+					),
+					@ExampleObject(
+						name = "Boolean filter",
+						summary = "Find non-obsolete, non-internal entities",
+						value = "{\n"
+							+ "  \"obsolete\": false,\n"
+							+ "  \"internal\": false\n"
+							+ "}"
+					)
+				}
 			)
 		) HashMap<String, Object> params);
 

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/BaseOntologyTermCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/BaseOntologyTermCrudInterface.java
@@ -9,7 +9,11 @@ import org.alliancegenome.curation_api.interfaces.base.crud.BaseUpdateController
 import org.alliancegenome.curation_api.model.entities.ontology.OntologyTerm;
 import org.alliancegenome.curation_api.response.ObjectListResponse;
 import org.alliancegenome.curation_api.view.CurationView;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -38,30 +42,75 @@ public interface BaseOntologyTermCrudInterface<E extends OntologyTerm> extends
 	@POST
 	@Path("/bulk/owl")
 	@Consumes(MediaType.APPLICATION_XML)
-	String updateTerms(@DefaultValue("true") @QueryParam("async") boolean async, @RequestBody String fullText);
+	@Operation(summary = "Bulk load ontology terms from OWL", description = "Load ontology terms from an OWL/XML document. Can run synchronously or asynchronously.")
+	@RequestBody(description = "OWL/XML ontology document")
+	@APIResponses(
+		@APIResponse(
+			responseCode = "200",
+			description = "Status message indicating load result")
+	)
+	String updateTerms(@Parameter(description = "Run asynchronously") @DefaultValue("true") @QueryParam("async") boolean async, @RequestBody String fullText);
 
 	@GET
 	@Path("/rootNodes")
 	@JsonView(CurationView.FieldsOnly.class)
+	@Operation(summary = "Get root nodes", description = "Retrieve all root nodes (terms with no parents) in this ontology")
+	@APIResponses(
+		@APIResponse(
+			responseCode = "200",
+			description = "List of root ontology terms")
+	)
 	ObjectListResponse<E> getRootNodes();
 
 	@GET
 	@Path("/{curie}/descendants")
 	@JsonView(CurationView.FieldsOnly.class)
-	ObjectListResponse<E> getDescendants(@PathParam("curie") String curie, @QueryParam("relationTypes") Set<String> relationTypes);
+	@Operation(summary = "Get descendants of term", description = "Retrieve all descendant terms (children, grandchildren, etc.) of the given term")
+	@APIResponses(
+		@APIResponse(
+			responseCode = "200",
+			description = "List of descendant ontology terms")
+	)
+	ObjectListResponse<E> getDescendants(
+		@Parameter(description = "Curie of the parent term") @PathParam("curie") String curie,
+		@Parameter(description = "Relation types to traverse (e.g. is_a, part_of)") @QueryParam("relationTypes") Set<String> relationTypes);
 
 	@GET
 	@Path("/{curie}/children")
 	@JsonView(CurationView.FieldsOnly.class)
-	ObjectListResponse<E> getChildren(@PathParam("curie") String curie, @QueryParam("relationTypes") Set<String> relationTypes);
+	@Operation(summary = "Get children of term", description = "Retrieve the direct child terms of the given term")
+	@APIResponses(
+		@APIResponse(
+			responseCode = "200",
+			description = "List of child ontology terms")
+	)
+	ObjectListResponse<E> getChildren(
+		@Parameter(description = "Curie of the parent term") @PathParam("curie") String curie,
+		@Parameter(description = "Relation types to traverse (e.g. is_a, part_of)") @QueryParam("relationTypes") Set<String> relationTypes);
 
 	@GET
 	@Path("/{curie}/parents")
 	@JsonView(CurationView.FieldsOnly.class)
-	ObjectListResponse<E> getParents(@PathParam("curie") String curie, @QueryParam("relationTypes") Set<String> relationTypes);
+	@Operation(summary = "Get parents of term", description = "Retrieve the direct parent terms of the given term")
+	@APIResponses(
+		@APIResponse(
+			responseCode = "200",
+			description = "List of parent ontology terms")
+	)
+	ObjectListResponse<E> getParents(
+		@Parameter(description = "Curie of the child term") @PathParam("curie") String curie,
+		@Parameter(description = "Relation types to traverse (e.g. is_a, part_of)") @QueryParam("relationTypes") Set<String> relationTypes);
 
 	@GET
 	@Path("/{curie}/ancestors")
 	@JsonView(CurationView.FieldsOnly.class)
-	ObjectListResponse<E> getAncestors(@PathParam("curie") String curie, @QueryParam("relationTypes") Set<String> relationTypes);
+	@Operation(summary = "Get ancestors of term", description = "Retrieve all ancestor terms (parents, grandparents, etc.) of the given term")
+	@APIResponses(
+		@APIResponse(
+			responseCode = "200",
+			description = "List of ancestor ontology terms")
+	)
+	ObjectListResponse<E> getAncestors(
+		@Parameter(description = "Curie of the descendant term") @PathParam("curie") String curie,
+		@Parameter(description = "Relation types to traverse (e.g. is_a, part_of)") @QueryParam("relationTypes") Set<String> relationTypes);
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/BaseReindexControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/BaseReindexControllerInterface.java
@@ -1,5 +1,7 @@
 package org.alliancegenome.curation_api.interfaces.base;
 
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import jakarta.ws.rs.Consumes;
@@ -17,11 +19,12 @@ public interface BaseReindexControllerInterface {
 	@GET
 	@Path("/reindex")
 	@Tag(name = "Reindex Endpoints")
+	@Operation(summary = "Reindex entities into OpenSearch", description = "Trigger a reindex of this entity type from the relational database into OpenSearch. Configurable batch size, threading, and limits.")
 	void reindex(
-		@DefaultValue("1000") @QueryParam("batchSizeToLoadObjects") Integer batchSizeToLoadObjects,
-		@DefaultValue("0") @QueryParam("idFetchSize") Integer idFetchSize,
-		@DefaultValue("0") @QueryParam("limitIndexedObjectsTo") Integer limitIndexedObjectsTo,
-		@DefaultValue("4") @QueryParam("threadsToLoadObjects") Integer threadsToLoadObjects,
-		@DefaultValue("14400") @QueryParam("transactionTimeout") Integer transactionTimeout,
-		@DefaultValue("1") @QueryParam("typesToIndexInParallel") Integer typesToIndexInParallel);
+		@Parameter(description = "Number of objects to load per batch") @DefaultValue("1000") @QueryParam("batchSizeToLoadObjects") Integer batchSizeToLoadObjects,
+		@Parameter(description = "Number of IDs to fetch at a time (0 = default)") @DefaultValue("0") @QueryParam("idFetchSize") Integer idFetchSize,
+		@Parameter(description = "Maximum number of objects to index (0 = unlimited)") @DefaultValue("0") @QueryParam("limitIndexedObjectsTo") Integer limitIndexedObjectsTo,
+		@Parameter(description = "Number of threads for loading objects") @DefaultValue("4") @QueryParam("threadsToLoadObjects") Integer threadsToLoadObjects,
+		@Parameter(description = "Transaction timeout in seconds") @DefaultValue("14400") @QueryParam("transactionTimeout") Integer transactionTimeout,
+		@Parameter(description = "Number of types to index in parallel") @DefaultValue("1") @QueryParam("typesToIndexInParallel") Integer typesToIndexInParallel);
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/BaseSearchControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/BaseSearchControllerInterface.java
@@ -2,11 +2,12 @@ package org.alliancegenome.curation_api.interfaces.base;
 
 import java.util.HashMap;
 
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
@@ -30,22 +31,77 @@ public interface BaseSearchControllerInterface<E> {
 	@Path("/search")
 	@Tag(name = "Elastic Search Browsing Endpoints")
 	@JsonView({ CurationView.FieldsAndLists.class })
-	@RequestBody(
-		description = "Post Request",
-		content = @Content(
-			mediaType = "application/json",
-			schema = @Schema(implementation = String.class)
-		)
-	)
+	@Operation(summary = "Search entities via OpenSearch", description = "Search for entities using OpenSearch full-text search with structured filtering, sorting, and aggregation.\n\n"
+		+ "## Search Filters (required)\n\n"
+		+ "The `searchFilters` object contains named filter groups. Filter group names are arbitrary (e.g. 'nameFilter', 'obsoleteFilter'). "
+		+ "By default, filter groups are AND'ed together. Set `searchFilterOperator` to 'OR' to OR them instead.\n\n"
+		+ "Each filter group contains field entries keyed by field name. Fields use dot notation for nested properties "
+		+ "(e.g. 'diseaseAnnotationSubject.taxon.curie'). Fields within a single filter group are OR'ed together.\n\n"
+		+ "### Field Options\n\n"
+		+ "- **queryString** (required): The search text. Will be tokenized and matched.\n"
+		+ "- **tokenOperator** (optional): 'AND' (default) or 'OR' — controls how tokens within the queryString are matched.\n"
+		+ "- **queryType** (optional): Set to 'matchQuery' for an Elasticsearch match query. Default uses simpleQueryString.\n"
+		+ "- **useKeywordFields** (optional): If true, searches the `_keyword` variant of the field for exact matching. Default false.\n"
+		+ "- **nonNullFields** (optional): List of fields that must be non-null within this filter group.\n"
+		+ "- **nullFields** (optional): List of fields that must be null within this filter group.\n\n"
+		+ "## Sort Orders (optional)\n\n"
+		+ "Array of `{field, order}` objects. `field` is the field name (supports nested dot notation, uses `_keyword` suffix internally). "
+		+ "`order` is 1 for ascending, -1 for descending.\n\n"
+		+ "## Aggregations (optional)\n\n"
+		+ "Array of field names to compute faceted counts for. Results appear in the response `aggregations` object keyed by field name.\n\n"
+		+ "## Non Null Fields Table (optional)\n\n"
+		+ "Array of field names that must be non-null across all results (applied globally, not per filter group).\n\n"
+		+ "## Debug (optional)\n\n"
+		+ "Set to 'true' to include the generated OpenSearch query and duration statistics in the response. Default false.\n\n"
+		+ "For full documentation see [SEARCH.md](https://github.com/alliance-genome/agr_curation/blob/alpha/SEARCH.md)")
 	@APIResponses(
 		@APIResponse(
-			description = "Response Entity",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
-			)
-		)
+			responseCode = "200",
+			description = "Paginated search results containing: results (list of matching entities), totalResults (total match count), "
+				+ "returnedRecords (page size), aggregations (faceted counts by field), and optionally esQuery (generated OpenSearch query when debug is true)")
 	)
-	SearchResponse<E> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<E> search(
+		@Parameter(description = "Zero-based page number of results to return") @DefaultValue("0") @QueryParam("page") Integer page,
+		@Parameter(description = "Number of results per page") @DefaultValue("10") @QueryParam("limit") Integer limit,
+		@RequestBody(description = "Search request payload",
+			content = @Content(
+				mediaType = MediaType.APPLICATION_JSON,
+				examples = @ExampleObject(
+					name = "Search example",
+					summary = "Search with filters, sorting, and aggregations",
+					value = "{\n"
+						+ "	 \"searchFilters\": {\n"
+						+ "	   \"nameFilter\": {\n"
+						+ "		 \"name\": {\n"
+						+ "		   \"queryString\": \"pax6 pax7\",\n"
+						+ "		   \"tokenOperator\": \"OR\",\n"
+						+ "		   \"queryType\": \"matchQuery\"\n"
+						+ "		 }\n"
+						+ "	   },\n"
+						+ "	   \"obsoleteFilter\": {\n"
+						+ "		 \"obsolete\": {\n"
+						+ "		   \"queryString\": \"false\",\n"
+						+ "		   \"tokenOperator\": \"AND\"\n"
+						+ "		 },\n"
+						+ "		 \"internal\": {\n"
+						+ "		   \"queryString\": \"false\",\n"
+						+ "		   \"tokenOperator\": \"AND\"\n"
+						+ "		 }\n"
+						+ "	   }\n"
+						+ "	 },\n"
+						+ "	 \"searchFilterOperator\": \"OR\",\n"
+						+ "	 \"sortOrders\": [\n"
+						+ "	   {\n"
+						+ "		 \"field\": \"diseaseAnnotationSubject.symbol\",\n"
+						+ "		 \"order\": 1\n"
+						+ "	   }\n"
+						+ "	 ],\n"
+						+ "	 \"aggregations\": [\"secondaryDataProvider.sourceOrganization.abbreviation\"],\n"
+						+ "	 \"nonNullFieldsTable\": [],\n"
+						+ "	 \"debug\": \"true\"\n"
+						+ "}"
+				)
+			)
+		) HashMap<String, Object> params);
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/BaseUpsertControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/BaseUpsertControllerInterface.java
@@ -5,6 +5,10 @@ import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
 import org.alliancegenome.curation_api.model.ingest.dto.base.BaseDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 
 import com.fasterxml.jackson.annotation.JsonView;
 
@@ -16,5 +20,12 @@ public interface BaseUpsertControllerInterface<E extends AuditedObject, T extend
 	@POST
 	@Path("/upsert")
 	@JsonView(CurationView.FieldsOnly.class)
+	@Operation(summary = "Upsert entity from DTO", description = "Create or update an entity from a data transfer object. If the entity exists it will be updated, otherwise a new one is created.")
+	@RequestBody(description = "The DTO object to upsert")
+	@APIResponses(
+		@APIResponse(
+			responseCode = "200",
+			description = "The created or updated entity")
+	)
 	ObjectResponse<E> upsert(T dto) throws ValidationException;
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseCreateControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseCreateControllerInterface.java
@@ -7,7 +7,6 @@ import org.alliancegenome.curation_api.response.ObjectListResponse;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseCreateControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseCreateControllerInterface.java
@@ -2,13 +2,12 @@ package org.alliancegenome.curation_api.interfaces.base.crud;
 
 import java.util.List;
 
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
 import org.alliancegenome.curation_api.response.ObjectListResponse;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
@@ -28,43 +27,25 @@ public interface BaseCreateControllerInterface<E extends AuditedObject> {
 	@POST
 	@Path("/")
 	@JsonView(CurationView.FieldsOnly.class)
-	@RequestBody(
-		description = "Post Request",
-		content = @Content(
-			mediaType = "application/json",
-			schema = @Schema(implementation = String.class)
-		)
-	)
+	@Operation(summary = "Create entity", description = "Create a new entity from the submitted JSON payload")
+	@RequestBody(description = "The entity object to create")
 	@APIResponses(
 		@APIResponse(
-			description = "Response Entity",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
-			)
-		)
+			responseCode = "200",
+			description = "The created entity")
 	)
 	ObjectResponse<E> create(E entity);
 
 	@POST
 	@Path("/multiple")
 	@JsonView(CurationView.FieldsOnly.class)
-	@RequestBody(
-		description = "Post Request",
-		content = @Content(
-			mediaType = "application/json",
-			schema = @Schema(implementation = String.class)
-		)
-	)
+	@Operation(summary = "Create multiple entities", description = "Create multiple entities from the submitted JSON array")
+	@RequestBody(description = "List of entity objects to create")
 	@APIResponses(
 		@APIResponse(
-			description = "Response Entity",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
-			)
-		)
+			responseCode = "200",
+			description = "The list of created entities")
 	)
 	ObjectListResponse<E> create(List<E> entities);
-	
+
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseDeleteCurieControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseDeleteCurieControllerInterface.java
@@ -1,11 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.base.crud;
 
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 
@@ -25,15 +24,12 @@ public interface BaseDeleteCurieControllerInterface<E extends AuditedObject> {
 	@DELETE
 	@Path("/{curie}")
 	@JsonView(CurationView.FieldsOnly.class)
+	@Operation(summary = "Delete entity by curie", description = "Delete an entity by its curie identifier")
 	@APIResponses(
 		@APIResponse(
-			description = "Get the Entity by Curie",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
-			)
-		)
+			responseCode = "200",
+			description = "The deleted entity")
 	)
-	ObjectResponse<E> deleteByCurie(@PathParam("curie") String curie);
+	ObjectResponse<E> deleteByCurie(@Parameter(description = "Curie identifier of the entity to delete") @PathParam("curie") String curie);
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseDeleteIdControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseDeleteIdControllerInterface.java
@@ -1,11 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.base.crud;
 
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 
@@ -25,15 +24,12 @@ public interface BaseDeleteIdControllerInterface<E extends AuditedObject> {
 	@DELETE
 	@Path("/{id}")
 	@JsonView(CurationView.FieldsOnly.class)
+	@Operation(summary = "Delete entity by ID", description = "Delete an entity by its internal database ID")
 	@APIResponses(
 		@APIResponse(
-			description = "Delete Entity by Id",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
-			)
-		)
+			responseCode = "200",
+			description = "The deleted entity")
 	)
-	ObjectResponse<E> deleteById(@PathParam("id") Long id);
-	
+	ObjectResponse<E> deleteById(@Parameter(description = "Internal database ID of the entity to delete") @PathParam("id") Long id);
+
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseDeleteIdentifierControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseDeleteIdentifierControllerInterface.java
@@ -1,11 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.base.crud;
 
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 
@@ -25,14 +24,12 @@ public interface BaseDeleteIdentifierControllerInterface<E extends AuditedObject
 	@DELETE
 	@Path("/{identifierString}")
 	@JsonView(CurationView.FieldsOnly.class)
+	@Operation(summary = "Delete entity by identifier", description = "Delete an entity by its identifier string (curie, MOD ID, or other unique identifier)")
 	@APIResponses(
 		@APIResponse(
-			description = "Delete the Entity by Identifier String",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
-			)
-		)
+			responseCode = "200",
+			description = "The deleted entity")
 	)
-	ObjectResponse<E> deleteByIdentifier(@PathParam("identifierString") String identifierString);
+	ObjectResponse<E> deleteByIdentifier(@Parameter(description = "Identifier string (curie, MOD ID, etc.)") @PathParam("identifierString") String identifierString);
+
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseReadCurieControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseReadCurieControllerInterface.java
@@ -1,11 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.base.crud;
 
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 
@@ -25,15 +24,12 @@ public interface BaseReadCurieControllerInterface<E extends AuditedObject> {
 	@GET
 	@Path("/{curie}")
 	@JsonView(CurationView.FieldsOnly.class)
+	@Operation(summary = "Get entity by curie", description = "Retrieve a single entity by its curie identifier")
 	@APIResponses(
 		@APIResponse(
-			description = "Get the Entity by Curie",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
-			)
-		)
+			responseCode = "200",
+			description = "The entity matching the given curie")
 	)
-	ObjectResponse<E> getByCurie(@PathParam("curie") String curie);
+	ObjectResponse<E> getByCurie(@Parameter(description = "Curie identifier of the entity") @PathParam("curie") String curie);
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseReadIdControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseReadIdControllerInterface.java
@@ -1,11 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.base.crud;
 
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 
@@ -25,15 +24,12 @@ public interface BaseReadIdControllerInterface<E extends AuditedObject> {
 	@GET
 	@Path("/{id}")
 	@JsonView(CurationView.FieldsOnly.class)
+	@Operation(summary = "Get entity by ID", description = "Retrieve a single entity by its internal database ID")
 	@APIResponses(
 		@APIResponse(
-			description = "Get Entity by Id",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
-			)
-		)
+			responseCode = "200",
+			description = "The entity matching the given ID")
 	)
-	ObjectResponse<E> getById(@PathParam("id") Long id);
-	
+	ObjectResponse<E> getById(@Parameter(description = "Internal database ID of the entity") @PathParam("id") Long id);
+
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseReadIdentifierControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseReadIdentifierControllerInterface.java
@@ -1,11 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.base.crud;
 
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 
@@ -25,15 +24,12 @@ public interface BaseReadIdentifierControllerInterface<E extends AuditedObject> 
 	@GET
 	@Path("/{identifierString}")
 	@JsonView(CurationView.FieldsAndLists.class)
+	@Operation(summary = "Get entity by identifier", description = "Retrieve a single entity by its identifier string (curie, MOD ID, or other unique identifier)")
 	@APIResponses(
 		@APIResponse(
-			description = "Get the Entity by Identifier String",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
-			)
-		)
+			responseCode = "200",
+			description = "The entity matching the given identifier")
 	)
-	ObjectResponse<E> getByIdentifier(@PathParam("identifierString") String identifierString);
+	ObjectResponse<E> getByIdentifier(@Parameter(description = "Identifier string (curie, MOD ID, etc.)") @PathParam("identifierString") String identifierString);
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseUpdateControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/base/crud/BaseUpdateControllerInterface.java
@@ -1,11 +1,9 @@
 package org.alliancegenome.curation_api.interfaces.base.crud;
 
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
@@ -25,22 +23,13 @@ public interface BaseUpdateControllerInterface<E extends AuditedObject> {
 	@PUT
 	@Path("/")
 	@JsonView(CurationView.FieldsOnly.class)
-	@RequestBody(
-		description = "Put Request",
-		content = @Content(
-			mediaType = "application/json",
-			schema = @Schema(implementation = String.class)
-		)
-	)
+	@Operation(summary = "Update entity", description = "Update an existing entity with the submitted JSON payload")
+	@RequestBody(description = "The entity object with updated fields")
 	@APIResponses(
 		@APIResponse(
-			description = "Response Entity",
-			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
-			)
-		)
+			responseCode = "200",
+			description = "The updated entity")
 	)
 	ObjectResponse<E> update(E entity);
-	
+
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AGMDiseaseAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AGMDiseaseAnnotationCrudInterface.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/agm-disease-annotation")
 @Tag(name = "CRUD - AGM Disease Annotations")
@@ -28,6 +29,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AGMDiseaseAnnotationCrudInterface extends BaseIdCrudInterface<AGMDiseaseAnnotation>, BaseUpsertControllerInterface<AGMDiseaseAnnotation, AGMDiseaseAnnotationDTO> {
 
+	@Operation(summary = "Get AGM disease annotation by identifier", description = "Retrieve a single AGM disease annotation by its identifier")
 	@GET
 	@Path("/findBy/{identifier}")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -45,6 +47,7 @@ public interface AGMDiseaseAnnotationCrudInterface extends BaseIdCrudInterface<A
 	@JsonView(CurationView.DiseaseAnnotation.class)
 	ObjectResponse<AGMDiseaseAnnotation> create(AGMDiseaseAnnotation entity);
 
+	@Operation(summary = "Bulk load AGM disease annotation data", description = "Bulk load AGM disease annotation records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/annotationFile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AGMPhenotypeAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AGMPhenotypeAnnotationCrudInterface.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/agm-phenotype-annotation")
 @Tag(name = "CRUD - AGM Phenotype Annotations")
@@ -23,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AGMPhenotypeAnnotationCrudInterface extends BaseIdCrudInterface<AGMPhenotypeAnnotation> {
 
+	@Operation(summary = "Get AGM phenotype annotation by identifier", description = "Retrieve a single AGM phenotype annotation by its identifier")
 	@GET
 	@Path("/findBy/{identifier}")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AffectedGenomicModelCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AffectedGenomicModelCrudInterface.java
@@ -73,6 +73,6 @@ public interface AffectedGenomicModelCrudInterface extends BaseSubmittedObjectCr
 	@Path("/search")
 	@Tag(name = "Elastic Search Browsing Endpoints")
 	@JsonView({ CurationView.AffectedGenomicModelView.class })
-	SearchResponse<AffectedGenomicModel> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<AffectedGenomicModel> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AffectedGenomicModelCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AffectedGenomicModelCrudInterface.java
@@ -12,7 +12,6 @@ import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -66,7 +65,7 @@ public interface AffectedGenomicModelCrudInterface extends BaseSubmittedObjectCr
 	@Path("/find")
 	@Tag(name = "Relational Database Browsing Endpoints")
 	@JsonView(CurationView.AffectedGenomicModelView.class)
-	SearchResponse<AffectedGenomicModel> find(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<AffectedGenomicModel> find(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 	@Override
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AffectedGenomicModelCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AffectedGenomicModelCrudInterface.java
@@ -27,6 +27,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/agm")
 @Tag(name = "CRUD - Affected Genomic Models")
@@ -36,6 +37,7 @@ public interface AffectedGenomicModelCrudInterface extends BaseSubmittedObjectCr
 	BaseReadIdentifierControllerInterface<AffectedGenomicModel>,
 	BaseUpsertControllerInterface<AffectedGenomicModel, AffectedGenomicModelDTO> {
 
+	@Operation(summary = "Bulk load affected genomic model data", description = "Bulk load affected genomic model records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/agms")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AlleleCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AlleleCrudInterface.java
@@ -76,6 +76,6 @@ public interface AlleleCrudInterface extends BaseSubmittedObjectCrudInterface<Al
 	@Path("/search")
 	@Tag(name = "Elastic Search Browsing Endpoints")
 	@JsonView({ CurationView.AlleleView.class })
-	SearchResponse<Allele> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<Allele> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AlleleCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AlleleCrudInterface.java
@@ -11,7 +11,6 @@ import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -69,7 +68,7 @@ public interface AlleleCrudInterface extends BaseSubmittedObjectCrudInterface<Al
 	@Path("/find")
 	@Tag(name = "Relational Database Browsing Endpoints")
 	@JsonView(CurationView.AlleleView.class)
-	SearchResponse<Allele> find(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<Allele> find(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 	@Override
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AlleleCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AlleleCrudInterface.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/allele")
 @Tag(name = "CRUD - Alleles")
@@ -33,6 +34,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AlleleCrudInterface extends BaseSubmittedObjectCrudInterface<Allele>, BaseUpsertControllerInterface<Allele, AlleleDTO> {
 
+	@Operation(summary = "Bulk load allele data", description = "Bulk load allele records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/alleles")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -50,6 +52,7 @@ public interface AlleleCrudInterface extends BaseSubmittedObjectCrudInterface<Al
 	@JsonView(CurationView.AlleleView.class)
 	ObjectResponse<Allele> update(Allele entity);
 	
+	@Operation(summary = "Update allele with full detail", description = "Update a allele entity and return the detailed view")
 	@PUT
 	@Path("/updateDetail")
 	@JsonView(CurationView.AlleleDetailView.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AlleleDiseaseAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AlleleDiseaseAnnotationCrudInterface.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/allele-disease-annotation")
 @Tag(name = "CRUD - Allele Disease Annotations")
@@ -28,6 +29,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AlleleDiseaseAnnotationCrudInterface extends BaseIdCrudInterface<AlleleDiseaseAnnotation>, BaseUpsertControllerInterface<AlleleDiseaseAnnotation, AlleleDiseaseAnnotationDTO> {
 
+	@Operation(summary = "Get allele disease annotation by identifier", description = "Retrieve a single allele disease annotation by its identifier")
 	@GET
 	@Path("/findBy/{identifier}")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -45,6 +47,7 @@ public interface AlleleDiseaseAnnotationCrudInterface extends BaseIdCrudInterfac
 	@JsonView(CurationView.DiseaseAnnotation.class)
 	ObjectResponse<AlleleDiseaseAnnotation> create(AlleleDiseaseAnnotation entity);
 
+	@Operation(summary = "Bulk load allele disease annotation data", description = "Bulk load allele disease annotation records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/annotationFile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AllelePhenotypeAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/AllelePhenotypeAnnotationCrudInterface.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/allele-phenotype-annotation")
 @Tag(name = "CRUD - Allele Phenotype Annotations")
@@ -23,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AllelePhenotypeAnnotationCrudInterface extends BaseIdCrudInterface<AllelePhenotypeAnnotation> {
 
+	@Operation(summary = "Get allele phenotype annotation by identifier", description = "Retrieve a single allele phenotype annotation by its identifier")
 	@GET
 	@Path("/findBy/{identifier}")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/BiogridOrcCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/BiogridOrcCrudInterface.java
@@ -15,6 +15,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 
 @Path("/biogrid-orc")
@@ -24,6 +25,7 @@ import jakarta.ws.rs.core.MediaType;
 public interface BiogridOrcCrudInterface extends BaseCreateControllerInterface<CrossReference> {
 
 
+	@Operation(summary = "Bulk load biogrid orc data", description = "Bulk load biogrid orc records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/biogridfile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/CodingSequenceCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/CodingSequenceCrudInterface.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/cds")
 @Tag(name = "CRUD - Coding Sequence")
@@ -24,6 +25,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface CodingSequenceCrudInterface extends BaseSubmittedObjectCrudInterface<CodingSequence> {
 
+	@Operation(summary = "Bulk load coding sequence data", description = "Bulk load coding sequence records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}_{assemblyName}/codingSequences")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ConditionRelationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ConditionRelationCrudInterface.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/condition-relation")
 @Tag(name = "CRUD - ConditionRelations")
@@ -45,11 +46,13 @@ public interface ConditionRelationCrudInterface extends BaseIdCrudInterface<Cond
 	@JsonView(CurationView.ConditionRelationView.class)
 	ObjectResponse<ConditionRelation> getById(@PathParam("id") Long id);
 
+	@Operation(summary = "Validate condition relation", description = "Validate a condition relation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.ConditionRelationView.class)
 	ObjectResponse<ConditionRelation> validate(ConditionRelation entity);
 
+	@Operation(summary = "Find experiments", description = "Search for experimental condition relation records using field-level filters")
 	@POST
 	@Path("/find-experiments")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ConstructCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ConstructCrudInterface.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/construct")
 @Tag(name = "CRUD - Constructs")
@@ -46,6 +47,7 @@ public interface ConstructCrudInterface extends BaseSubmittedObjectCrudInterface
 	@JsonView(CurationView.ConstructView.class)
 	ObjectResponse<Construct> create(Construct entity);
 
+	@Operation(summary = "Bulk load construct data", description = "Bulk load construct records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/constructs")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/DiseaseAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/DiseaseAnnotationCrudInterface.java
@@ -7,7 +7,6 @@ import org.alliancegenome.curation_api.model.entities.DiseaseAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -38,7 +37,8 @@ public interface DiseaseAnnotationCrudInterface extends BaseIdCrudInterface<Dise
 	@Override
 	@POST
 	@Path("/search")
+	@Tag(name = "Elastic Search Browsing Endpoints")
 	@JsonView(CurationView.DiseaseAnnotation.class)
-	SearchResponse<DiseaseAnnotation> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<DiseaseAnnotation> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/DiseaseAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/DiseaseAnnotationCrudInterface.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/disease-annotation")
 @Tag(name = "CRUD - Disease Annotations")
@@ -28,6 +29,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface DiseaseAnnotationCrudInterface extends BaseIdCrudInterface<DiseaseAnnotation> {
 
+	@Operation(summary = "Get disease annotation by identifier", description = "Retrieve a single disease annotation by its identifier")
 	@GET
 	@Path("/findBy/{identifier}")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ExonCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ExonCrudInterface.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/exon")
 @Tag(name = "CRUD - Exon")
@@ -24,6 +25,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface ExonCrudInterface extends BaseSubmittedObjectCrudInterface<Exon> {
 
+	@Operation(summary = "Bulk load exon data", description = "Bulk load exon records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}_{assemblyName}/exons")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ExperimentalConditionCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ExperimentalConditionCrudInterface.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/experimental-condition")
 @Tag(name = "CRUD - ExperimentalConditions")
@@ -21,6 +22,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface ExperimentalConditionCrudInterface extends BaseIdCrudInterface<ExperimentalCondition> {
 
+	@Operation(summary = "Get experimental condition by identifier", description = "Retrieve a single experimental condition by its identifier")
 	@GET
 	@Path("/findBy/{conditionSummary}")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ExpressionAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ExpressionAnnotationCrudInterface.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/expression-annotation")
 @Tag(name = "CRUD - Expression Annotations")
@@ -21,6 +22,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface ExpressionAnnotationCrudInterface extends BaseIdCrudInterface<ExpressionAnnotation> {
 
+	@Operation(summary = "Get expression annotation by identifier", description = "Retrieve a single expression annotation by its identifier")
 	@GET
 	@Path("/findBy/{identifier}")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ExpressionAtlasCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ExpressionAtlasCrudInterface.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/expression-atlas")
 @Tag(name = "CRUD - Expression Atlas")
@@ -24,6 +25,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface ExpressionAtlasCrudInterface extends BaseCreateControllerInterface<CrossReference> {
 
+	@Operation(summary = "Bulk load expression atlas data", description = "Bulk load expression atlas records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}_{assemblyName}/transcripts")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneCrudInterface.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/gene")
 @Tag(name = "CRUD - Genes")
@@ -32,6 +33,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneCrudInterface extends BaseSubmittedObjectCrudInterface<Gene>, BaseUpsertControllerInterface<Gene, GeneDTO> {
 
+	@Operation(summary = "Bulk load gene data", description = "Bulk load gene records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/genes")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneCrudInterface.java
@@ -11,7 +11,6 @@ import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -56,7 +55,7 @@ public interface GeneCrudInterface extends BaseSubmittedObjectCrudInterface<Gene
 	@Path("/find")
 	@Tag(name = "Relational Database Browsing Endpoints")
 	@JsonView(CurationView.GeneView.class)
-	SearchResponse<Gene> find(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<Gene> find(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 	@Override
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneCrudInterface.java
@@ -63,6 +63,6 @@ public interface GeneCrudInterface extends BaseSubmittedObjectCrudInterface<Gene
 	@Path("/search")
 	@Tag(name = "Elastic Search Browsing Endpoints")
 	@JsonView({ CurationView.GeneView.class })
-	SearchResponse<Gene> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<Gene> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneDiseaseAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneDiseaseAnnotationCrudInterface.java
@@ -22,6 +22,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/gene-disease-annotation")
 @Tag(name = "CRUD - Gene Disease Annotations")
@@ -29,6 +30,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneDiseaseAnnotationCrudInterface extends BaseIdCrudInterface<GeneDiseaseAnnotation>, BaseUpsertControllerInterface<GeneDiseaseAnnotation, GeneDiseaseAnnotationDTO> {
 
+	@Operation(summary = "Get gene disease annotation by identifier", description = "Retrieve a single gene disease annotation by its identifier")
 	@GET
 	@Path("/findBy/{identifier}")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -46,11 +48,13 @@ public interface GeneDiseaseAnnotationCrudInterface extends BaseIdCrudInterface<
 	@JsonView(CurationView.DiseaseAnnotation.class)
 	ObjectResponse<GeneDiseaseAnnotation> create(GeneDiseaseAnnotation entity);
 
+	@Operation(summary = "Bulk load gene disease annotation data", description = "Bulk load gene disease annotation records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/annotationFile")
 	@JsonView(CurationView.FieldsAndLists.class)
 	APIResponse updateGeneDiseaseAnnotations(@PathParam("dataProvider") String dataProvider, List<GeneDiseaseAnnotationDTO> annotationData);
 
+	@Operation(summary = "Get annotated gene identifiers", description = "Retrieve list of gene identifiers that have gene disease annotation annotations")
 	@GET
 	@Path("/annotatedGeneList")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneExpressionAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneExpressionAnnotationCrudInterface.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/gene-expression-annotation")
 @Tag(name = "CRUD - Gene Expression Annotations")
@@ -27,16 +28,19 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneExpressionAnnotationCrudInterface extends BaseIdCrudInterface<GeneExpressionAnnotation> {
 
+	@Operation(summary = "Get gene expression annotation by identifier", description = "Retrieve a single gene expression annotation by its identifier")
 	@GET
 	@Path("/findBy/{identifier}")
 	@JsonView(CurationView.FieldsAndLists.class)
 	ObjectResponse<GeneExpressionAnnotation> getByIdentifier(@PathParam("identifier") String identifier);
 
+	@Operation(summary = "Get annotated gene identifiers", description = "Retrieve list of gene identifiers that have gene expression annotation annotations")
 	@GET
 	@Path("/annotatedGeneList")
 	@JsonView(CurationView.FieldsAndLists.class)
 	ObjectListResponse<String> annotatedGeneList();
 
+	@Operation(summary = "Bulk load gene expression annotation data", description = "Bulk load gene expression annotation records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/annotationFile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneExpressionExperimentCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneExpressionExperimentCrudInterface.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 
 @Path("/gene-expression-experiment")
@@ -21,6 +22,7 @@ import jakarta.ws.rs.core.MediaType;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneExpressionExperimentCrudInterface extends BaseIdCrudInterface<GeneExpressionExperiment> {
+	@Operation(summary = "Get gene expression experiment by identifier", description = "Retrieve a single gene expression experiment by its identifier")
 	@GET
 	@Path("/findBy/{identifier}")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneGeneticInteractionCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneGeneticInteractionCrudInterface.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("gene-genetic-interaction")
 @Tag(name = "CRUD - Gene Genetic Interactions")
@@ -31,6 +32,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneGeneticInteractionCrudInterface extends BaseIdCrudInterface<GeneGeneticInteraction> {
 
+	@Operation(summary = "Get gene genetic interaction by identifier", description = "Retrieve a single gene genetic interaction by its identifier")
 	@GET
 	@Path("/findBy/{identifier}")
 	@JsonView(CurationView.GeneInteractionView.class)
@@ -42,6 +44,7 @@ public interface GeneGeneticInteractionCrudInterface extends BaseIdCrudInterface
 	@JsonView(CurationView.GeneInteractionView.class)
 	SearchResponse<GeneGeneticInteraction> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
 
+	@Operation(summary = "Bulk load gene genetic interaction data", description = "Bulk load gene genetic interaction records from a data provider submission")
 	@POST
 	@Path("/bulk/interactionFile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneGeneticInteractionCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneGeneticInteractionCrudInterface.java
@@ -10,7 +10,6 @@ import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -41,8 +40,9 @@ public interface GeneGeneticInteractionCrudInterface extends BaseIdCrudInterface
 	@Override
 	@POST
 	@Path("/search")
+	@Tag(name = "Elastic Search Browsing Endpoints")
 	@JsonView(CurationView.GeneInteractionView.class)
-	SearchResponse<GeneGeneticInteraction> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<GeneGeneticInteraction> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 	@Operation(summary = "Bulk load gene genetic interaction data", description = "Bulk load gene genetic interaction records from a data provider submission")
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneInteractionCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneInteractionCrudInterface.java
@@ -7,7 +7,6 @@ import org.alliancegenome.curation_api.model.entities.GeneInteraction;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -38,7 +37,8 @@ public interface GeneInteractionCrudInterface extends BaseIdCrudInterface<GeneIn
 	@Override
 	@POST
 	@Path("/search")
+	@Tag(name = "Elastic Search Browsing Endpoints")
 	@JsonView(CurationView.GeneInteractionView.class)
-	SearchResponse<GeneInteraction> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<GeneInteraction> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneInteractionCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneInteractionCrudInterface.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("gene-interaction")
 @Tag(name = "CRUD - Gene Interactions")
@@ -28,6 +29,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneInteractionCrudInterface extends BaseIdCrudInterface<GeneInteraction> {
 
+	@Operation(summary = "Get gene interaction by identifier", description = "Retrieve a single gene interaction by its identifier")
 	@GET
 	@Path("/findBy/{identifierString}")
 	@JsonView(CurationView.GeneInteractionView.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneMolecularInteractionCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneMolecularInteractionCrudInterface.java
@@ -10,7 +10,6 @@ import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -41,8 +40,9 @@ public interface GeneMolecularInteractionCrudInterface extends BaseIdCrudInterfa
 	@Override
 	@POST
 	@Path("/search")
+	@Tag(name = "Elastic Search Browsing Endpoints")
 	@JsonView(CurationView.GeneInteractionView.class)
-	SearchResponse<GeneMolecularInteraction> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<GeneMolecularInteraction> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 	@Operation(summary = "Bulk load gene molecular interaction data", description = "Bulk load gene molecular interaction records from a data provider submission")
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneMolecularInteractionCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneMolecularInteractionCrudInterface.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("gene-molecular-interaction")
 @Tag(name = "CRUD - Gene Molecular Interactions")
@@ -31,6 +32,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneMolecularInteractionCrudInterface extends BaseIdCrudInterface<GeneMolecularInteraction> {
 
+	@Operation(summary = "Get gene molecular interaction by identifier", description = "Retrieve a single gene molecular interaction by its identifier")
 	@GET
 	@Path("/findBy/{identifier}")
 	@JsonView(CurationView.GeneInteractionView.class)
@@ -42,6 +44,7 @@ public interface GeneMolecularInteractionCrudInterface extends BaseIdCrudInterfa
 	@JsonView(CurationView.GeneInteractionView.class)
 	SearchResponse<GeneMolecularInteraction> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
 
+	@Operation(summary = "Bulk load gene molecular interaction data", description = "Bulk load gene molecular interaction records from a data provider submission")
 	@POST
 	@Path("/bulk/interactionFile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GenePhenotypeAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GenePhenotypeAnnotationCrudInterface.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/gene-phenotype-annotation")
 @Tag(name = "CRUD - Gene Phenotype Annotations")
@@ -23,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GenePhenotypeAnnotationCrudInterface extends BaseIdCrudInterface<GenePhenotypeAnnotation> {
 
+	@Operation(summary = "Get gene phenotype annotation by identifier", description = "Retrieve a single gene phenotype annotation by its identifier")
 	@GET
 	@Path("/findBy/{identifier}")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneToGeneParalogyCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/GeneToGeneParalogyCrudInterface.java
@@ -15,6 +15,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/paralogy")
 @Tag(name = "CRUD - Paralogy")
@@ -22,6 +23,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneToGeneParalogyCrudInterface extends BaseIdCrudInterface<GeneToGeneParalogy> {
 
+	@Operation(summary = "Bulk load gene to gene paralogy data", description = "Bulk load gene to gene paralogy records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/paralogyfile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/HTPExpressionDatasetAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/HTPExpressionDatasetAnnotationCrudInterface.java
@@ -15,6 +15,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/htpexpressiondatasetannotation")
 @Tag(name = "CRUD - HTP Expression Dataset Annotation")
@@ -22,6 +23,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface HTPExpressionDatasetAnnotationCrudInterface extends BaseIdCrudInterface<HTPExpressionDatasetAnnotation> {
 	
+	@Operation(summary = "Bulk load HTP expression dataset annotation data", description = "Bulk load HTP expression dataset annotation records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/htpexpressiondatasetannotationfile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/HTPExpressionDatasetSampleAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/HTPExpressionDatasetSampleAnnotationCrudInterface.java
@@ -15,6 +15,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/htpexpressiondatasetsampleannotation")
 @Tag(name = "CRUD - HTP Expression Dataset Sample Annotation")
@@ -22,6 +23,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface HTPExpressionDatasetSampleAnnotationCrudInterface extends BaseIdCrudInterface<HTPExpressionDatasetSampleAnnotation> {
 	
+	@Operation(summary = "Bulk load HTP expression dataset sample annotation data", description = "Bulk load HTP expression dataset sample annotation records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/htpexpressiondatasetsampleannotationfile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/MoleculeCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/MoleculeCrudInterface.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/molecule")
 @Tag(name = "CRUD - Molecules")
@@ -21,6 +22,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface MoleculeCrudInterface extends BaseIdCrudInterface<Molecule> {
 
+	@Operation(summary = "Bulk load molecule data", description = "Bulk load molecule records from a data provider submission")
 	@POST
 	@Path("/bulk/moleculefile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/NoteCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/NoteCrudInterface.java
@@ -15,6 +15,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/note")
 @Tag(name = "CRUD - Notes")
@@ -22,6 +23,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface NoteCrudInterface extends BaseIdCrudInterface<Note> {
 
+	@Operation(summary = "Validate note", description = "Validate a note entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.NoteView.class)
@@ -33,6 +35,7 @@ public interface NoteCrudInterface extends BaseIdCrudInterface<Note> {
 	@Path("/{id}")
 	ObjectResponse<Note> getById(@PathParam("id") Long id);
 
+	@Operation(summary = "Create note", description = "Create a new note entity")
 	@POST
 	@Path("/")
 	@JsonView(CurationView.NoteView.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/PhenotypeAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/PhenotypeAnnotationCrudInterface.java
@@ -10,7 +10,6 @@ import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -47,8 +46,9 @@ public interface PhenotypeAnnotationCrudInterface extends BaseIdCrudInterface<Ph
 	@Override
 	@POST
 	@Path("/search")
+	@Tag(name = "Elastic Search Browsing Endpoints")
 	@JsonView(CurationView.PhenotypeAnnotationView.class)
-	SearchResponse<PhenotypeAnnotation> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<PhenotypeAnnotation> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 	@Operation(summary = "Bulk load phenotype annotation data", description = "Bulk load phenotype annotation records from a data provider submission")
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/PhenotypeAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/PhenotypeAnnotationCrudInterface.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/phenotype-annotation")
 @Tag(name = "CRUD - Phenotype Annotations")
@@ -31,6 +32,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface PhenotypeAnnotationCrudInterface extends BaseIdCrudInterface<PhenotypeAnnotation> {
 
+	@Operation(summary = "Get phenotype annotation by identifier", description = "Retrieve a single phenotype annotation by its identifier")
 	@GET
 	@Path("/findBy/{identifier}")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -48,6 +50,7 @@ public interface PhenotypeAnnotationCrudInterface extends BaseIdCrudInterface<Ph
 	@JsonView(CurationView.PhenotypeAnnotationView.class)
 	SearchResponse<PhenotypeAnnotation> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
 
+	@Operation(summary = "Bulk load phenotype annotation data", description = "Bulk load phenotype annotation records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/annotationFile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/PredictedVariantConsequenceCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/PredictedVariantConsequenceCrudInterface.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("predictedvariantconsequence")
 @Tag(name = "CRUD - Predicted Variant Consequence")
@@ -24,11 +25,13 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface PredictedVariantConsequenceCrudInterface extends BaseIdCrudInterface<PredictedVariantConsequence> {
 
+	@Operation(summary = "Bulk load predicted variant consequence data", description = "Bulk load predicted variant consequence records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/transcriptConsequenceFile")
 	@JsonView(CurationView.FieldsAndLists.class)
 	APIResponse updateTranscriptLevelConsequences(@PathParam("dataProvider") String dataProvider, List<VepTxtDTO> consequenceData);
 	
+	@Operation(summary = "Bulk load predicted variant consequence data", description = "Bulk load predicted variant consequence records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/geneConsequenceFile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ReferenceCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ReferenceCrudInterface.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/reference")
 @Tag(name = "CRUD - Reference")
@@ -21,10 +22,12 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface ReferenceCrudInterface extends BaseCurieObjectCrudInterface<Reference> {
 
+	@Operation(summary = "Synchronise all references", description = "Synchronise all references with external sources")
 	@GET
 	@Path("/sync")
 	void synchroniseReferences();
 
+	@Operation(summary = "Synchronise reference", description = "Synchronise a single reference with external sources")
 	@GET
 	@Path("/sync/{id}")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ResourceDescriptorPageCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ResourceDescriptorPageCrudInterface.java
@@ -6,7 +6,6 @@ import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
 import org.alliancegenome.curation_api.model.entities.ResourceDescriptorPage;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -29,5 +28,5 @@ public interface ResourceDescriptorPageCrudInterface extends BaseIdCrudInterface
 	@Path("/search")
 	@JsonView(CurationView.ResourceDescriptorPageView.class)
 	@Tag(name = "Elastic Search Browsing Endpoints")
-	SearchResponse<ResourceDescriptorPage> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<ResourceDescriptorPage> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/SequenceTargetingReagentCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/SequenceTargetingReagentCrudInterface.java
@@ -49,7 +49,7 @@ public interface SequenceTargetingReagentCrudInterface extends BaseSubmittedObje
 	@Path("/search")
 	@Tag(name = "Elastic Search Browsing Endpoints")
 	@JsonView({ CurationView.SequenceTargetingReagentView.class })
-	SearchResponse<SequenceTargetingReagent> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<SequenceTargetingReagent> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 	@Override
 	@GET

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/SequenceTargetingReagentCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/SequenceTargetingReagentCrudInterface.java
@@ -23,6 +23,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/sqtr")
 @Tag(name = "CRUD - SQTR")
@@ -30,6 +31,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface SequenceTargetingReagentCrudInterface extends BaseSubmittedObjectCrudInterface<SequenceTargetingReagent> {
 
+	@Operation(summary = "Bulk load sequence targeting reagent data", description = "Bulk load sequence targeting reagent records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/sqtrfile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/SequenceTargetingReagentCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/SequenceTargetingReagentCrudInterface.java
@@ -9,7 +9,6 @@ import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -42,7 +41,7 @@ public interface SequenceTargetingReagentCrudInterface extends BaseSubmittedObje
 	@Path("/find")
 	@Tag(name = "Relational Database Browsing Endpoints")
 	@JsonView(CurationView.SequenceTargetingReagentView.class)
-	SearchResponse<SequenceTargetingReagent> find(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<SequenceTargetingReagent> find(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 	@Override
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/TranscriptCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/TranscriptCrudInterface.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/transcript")
 @Tag(name = "CRUD - Transcript")
@@ -24,6 +25,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface TranscriptCrudInterface extends BaseSubmittedObjectCrudInterface<Transcript> {
 
+	@Operation(summary = "Bulk load transcript data", description = "Bulk load transcript records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}_{assemblyName}/transcripts")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VariantCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VariantCrudInterface.java
@@ -12,7 +12,6 @@ import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -70,7 +69,7 @@ public interface VariantCrudInterface extends BaseSubmittedObjectCrudInterface<V
 	@Path("/find")
 	@Tag(name = "Relational Database Browsing Endpoints")
 	@JsonView(CurationView.VariantView.class)
-	SearchResponse<Variant> find(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<Variant> find(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 	@Override
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VariantCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VariantCrudInterface.java
@@ -77,6 +77,6 @@ public interface VariantCrudInterface extends BaseSubmittedObjectCrudInterface<V
 	@Path("/search")
 	@Tag(name = "Elastic Search Browsing Endpoints")
 	@JsonView({ CurationView.VariantView.class })
-	SearchResponse<Variant> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<Variant> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VariantCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VariantCrudInterface.java
@@ -27,6 +27,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/variant")
 @Tag(name = "CRUD - Variants")
@@ -34,11 +35,13 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface VariantCrudInterface extends BaseSubmittedObjectCrudInterface<Variant>, BaseUpsertControllerInterface<Variant, VariantDTO> {
 
+	@Operation(summary = "Bulk load variant data", description = "Bulk load variant records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/variants")
 	@JsonView(CurationView.FieldsAndLists.class)
 	APIResponse updateVariants(@PathParam("dataProvider") String dataProvider, List<VariantDTO> alleleData);
 
+	@Operation(summary = "Bulk load variant data", description = "Bulk load variant records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/fmsvariants")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VocabularyCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VocabularyCrudInterface.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/vocabulary")
 @Tag(name = "CRUD - Vocabulary")
@@ -23,16 +24,19 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface VocabularyCrudInterface extends BaseIdCrudInterface<Vocabulary> {
 
+	@Operation(summary = "Get vocabulary by ID", description = "Retrieve a single vocabulary by its database ID")
 	@GET
 	@Path("/{id}")
 	@JsonView(CurationView.VocabularyView.class)
 	ObjectResponse<Vocabulary> getById(@PathParam("id") Long id);
 
+	@Operation(summary = "Get terms for vocabulary", description = "Retrieve all vocabulary terms belonging to this vocabulary")
 	@GET
 	@Path("/{id}/terms")
 	@JsonView(CurationView.VocabularyTermView.class)
 	ObjectListResponse<VocabularyTerm> getTerms(@PathParam("id") Long id);
 
+	@Operation(summary = "Find vocabulary by name", description = "Retrieve a vocabulary by its name")
 	@GET
 	@Path("/findBy/{name}")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VocabularyTermCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VocabularyTermCrudInterface.java
@@ -8,7 +8,6 @@ import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.alliancegenome.curation_api.view.CurationView.VocabularyTermView;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -36,7 +35,7 @@ public interface VocabularyTermCrudInterface extends BaseIdCrudInterface<Vocabul
 	@Path("/search")
 	@JsonView(CurationView.VocabularyTermView.class)
 	@Tag(name = "Elastic Search Browsing Endpoints")
-	SearchResponse<VocabularyTerm> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<VocabularyTerm> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 	@Override
 	@GET

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VocabularyTermCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VocabularyTermCrudInterface.java
@@ -23,6 +23,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/vocabularyterm")
 @Tag(name = "CRUD - VocabularyTerm")
@@ -43,21 +44,25 @@ public interface VocabularyTermCrudInterface extends BaseIdCrudInterface<Vocabul
 	@JsonView(CurationView.VocabularyTermView.class)
 	ObjectResponse<VocabularyTerm> getById(@PathParam("id") Long id);
 
+	@Operation(summary = "Get term in vocabulary", description = "Retrieve a specific vocabulary term by vocabulary name and term name")
 	@GET
 	@Path("/findBy")
 	@JsonView(CurationView.VocabularyTermView.class)
 	ObjectResponse<VocabularyTerm> getTermInVocabulary(@QueryParam("vocabularyName") String vocabularyName, @QueryParam("termName") String termName);
 
+	@Operation(summary = "Get term in vocabulary term set", description = "Retrieve a specific vocabulary term by vocabulary term set name and term name")
 	@GET
 	@Path("/findInSet")
 	@JsonView(CurationView.VocabularyTermView.class)
 	ObjectResponse<VocabularyTerm> getTermInVocabularyTermSet(@QueryParam("vocabularyTermSetName") String vocabularyTermSetName, @QueryParam("termName") String termName);
 
+	@Operation(summary = "Update", description = "Update for vocabulary term")
 	@PUT
 	@Path("/")
 	@JsonView(CurationView.VocabularyTermUpdate.class)
 	ObjectResponse<VocabularyTerm> update(VocabularyTerm entity);
 
+	@Operation(summary = "Create vocabulary term", description = "Create a new vocabulary term entity")
 	@POST
 	@Path("/")
 	@JsonView(VocabularyTermView.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VocabularyTermSetCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VocabularyTermSetCrudInterface.java
@@ -68,5 +68,5 @@ public interface VocabularyTermSetCrudInterface extends BaseIdCrudInterface<Voca
 	@Path("/search")
 	@Tag(name = "Elastic Search Browsing Endpoints")
 	@JsonView({ CurationView.VocabularyTermSetView.class })
-	SearchResponse<VocabularyTermSet> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<VocabularyTermSet> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VocabularyTermSetCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VocabularyTermSetCrudInterface.java
@@ -9,7 +9,6 @@ import org.alliancegenome.curation_api.response.ObjectListResponse;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -61,7 +60,7 @@ public interface VocabularyTermSetCrudInterface extends BaseIdCrudInterface<Voca
 	@Path("/find")
 	@Tag(name = "Relational Database Browsing Endpoints")
 	@JsonView(CurationView.VocabularyTermSetView.class)
-	SearchResponse<VocabularyTermSet> find(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+	SearchResponse<VocabularyTermSet> find(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 	@Override
 	@POST

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VocabularyTermSetCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/VocabularyTermSetCrudInterface.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/vocabularytermset")
 @Tag(name = "CRUD - VocabularyTermSet")
@@ -31,11 +32,13 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface VocabularyTermSetCrudInterface extends BaseIdCrudInterface<VocabularyTermSet> {
 
+	@Operation(summary = "Get vocabulary term set by ID", description = "Retrieve a single vocabulary term set by its database ID")
 	@GET
 	@Path("/{id}")
 	@JsonView(CurationView.VocabularyTermSetView.class)
 	ObjectResponse<VocabularyTermSet> getById(@PathParam("id") Long id);
 
+	@Operation(summary = "Get terms for vocabulary term set", description = "Retrieve all vocabulary terms belonging to this vocabulary term set")
 	@GET
 	@Path("/{id}/terms")
 	@JsonView(CurationView.VocabularyTermSetView.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/AgmAgmAssociationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/AgmAgmAssociationCrudInterface.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/agmagmassociation")
 @Tag(name = "CRUD - AGM AGM Associations")
@@ -27,11 +28,13 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AgmAgmAssociationCrudInterface extends BaseIdCrudInterface<AgmAgmAssociation> {
 
+	@Operation(summary = "Get agm agm association by component IDs", description = "Look up a specific agm agm association by its component entity IDs and relation")
 	@GET
 	@Path("/findBy")
 	@JsonView(CurationView.FieldsAndLists.class)
 	ObjectResponse<AgmAgmAssociation> getAssociation(@QueryParam("agmSubjectId") Long agmId, @QueryParam("relationName") String relationName, @QueryParam("agmObjectId") Long strId);
 
+	@Operation(summary = "Bulk load agm agm association data", description = "Bulk load agm agm association records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/associationFile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/AgmAlleleAssociationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/AgmAlleleAssociationCrudInterface.java
@@ -20,17 +20,20 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/agmalleleassociation")
 @Tag(name = "CRUD - AGM Allele Associations")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AgmAlleleAssociationCrudInterface extends BaseIdCrudInterface<AgmAlleleAssociation> {
+	@Operation(summary = "Get agm allele association by component IDs", description = "Look up a specific agm allele association by its component entity IDs and relation")
 	@GET
 	@Path("/findBy")
 	@JsonView(CurationView.FieldsAndLists.class)
 	ObjectResponse<AgmAlleleAssociation> getAssociation(@QueryParam("agmId") Long agmId, @QueryParam("relationName") String relationName, @QueryParam("alleleId") Long alleleId);
 
+	@Operation(summary = "Bulk load agm allele association data", description = "Bulk load agm allele association records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/associationFile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/AgmSequenceTargetingReagentAssociationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/AgmSequenceTargetingReagentAssociationCrudInterface.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/agmstrassociation")
 @Tag(name = "CRUD - AGM Sequence Targeting Reagent Associations")
@@ -27,11 +28,13 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AgmSequenceTargetingReagentAssociationCrudInterface extends BaseIdCrudInterface<AgmSequenceTargetingReagentAssociation> {
 
+	@Operation(summary = "Get agm sequence targeting reagent association by component IDs", description = "Look up a specific agm sequence targeting reagent association by its component entity IDs and relation")
 	@GET
 	@Path("/findBy")
 	@JsonView(CurationView.FieldsAndLists.class)
 	ObjectResponse<AgmSequenceTargetingReagentAssociation> getAssociation(@QueryParam("agmId") Long agmId, @QueryParam("relationName") String relationName, @QueryParam("strId") Long strId);
 
+	@Operation(summary = "Bulk load agm sequence targeting reagent association data", description = "Bulk load agm sequence targeting reagent association records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/associationFile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/AlleleConstructAssociationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/AlleleConstructAssociationCrudInterface.java
@@ -22,6 +22,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/alleleconstructassociation")
 @Tag(name = "CRUD - Allele Construct Associations")
@@ -29,21 +30,25 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AlleleConstructAssociationCrudInterface extends BaseIdCrudInterface<AlleleConstructAssociation> {
 
+	@Operation(summary = "Bulk load allele construct association data", description = "Bulk load allele construct association records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/associationFile")
 	@JsonView(CurationView.FieldsAndLists.class)
 	APIResponse updateAlleleConstructAssociations(@PathParam("dataProvider") String dataProvider, List<AlleleConstructAssociationDTO> associationData);
 
+	@Operation(summary = "Get allele construct association by component IDs", description = "Look up a specific allele construct association by its component entity IDs and relation")
 	@GET
 	@Path("/findBy")
 	@JsonView(CurationView.FieldsAndLists.class)
 	ObjectResponse<AlleleConstructAssociation> getAssociation(@QueryParam("alleleId") Long alleleId, @QueryParam("relationName") String relationName, @QueryParam("constructId") Long constructId);
 
+	@Operation(summary = "Validate allele construct association", description = "Validate a allele construct association entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
 	ObjectResponse<AlleleConstructAssociation> validate(AlleleConstructAssociation entity);
 
+	@Operation(summary = "Find allele construct association for public API", description = "Query allele construct association records with public-facing view")
 	@POST
 	@Path("/findForPublic")
 	@JsonView(CurationView.ForPublic.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/AlleleGeneAssociationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/AlleleGeneAssociationCrudInterface.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/allelegeneassociation")
 @Tag(name = "CRUD - Allele Gene Associations")
@@ -27,16 +28,19 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AlleleGeneAssociationCrudInterface extends BaseIdCrudInterface<AlleleGeneAssociation> {
 
+	@Operation(summary = "Bulk load allele gene association data", description = "Bulk load allele gene association records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/associationFile")
 	@JsonView(CurationView.FieldsAndLists.class)
 	APIResponse updateAlleleGeneAssociations(@PathParam("dataProvider") String dataProvider, List<AlleleGeneAssociationDTO> associationData);
 	
+	@Operation(summary = "Get allele gene association by component IDs", description = "Look up a specific allele gene association by its component entity IDs and relation")
 	@GET
 	@Path("/findBy")
 	@JsonView(CurationView.FieldsAndLists.class)
 	ObjectResponse<AlleleGeneAssociation> getAssociation(@QueryParam("alleleId") Long alleleId, @QueryParam("relationName") String relationName, @QueryParam("geneId") Long geneId);
 	
+	@Operation(summary = "Validate allele gene association", description = "Validate a allele gene association entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/ConstructGenomicEntityAssociationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/ConstructGenomicEntityAssociationCrudInterface.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/constructgenomicentityassociation")
 @Tag(name = "CRUD - Construct Genomic Entity Associations")
@@ -27,16 +28,19 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface ConstructGenomicEntityAssociationCrudInterface extends BaseIdCrudInterface<ConstructGenomicEntityAssociation> {
 
+	@Operation(summary = "Bulk load construct genomic entity association data", description = "Bulk load construct genomic entity association records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/associationFile")
 	@JsonView(CurationView.FieldsAndLists.class)
 	APIResponse updateConstructGenomicEntityAssociations(@PathParam("dataProvider") String dataProvider, List<ConstructGenomicEntityAssociationDTO> associationData);
 	
+	@Operation(summary = "Get construct genomic entity association by component IDs", description = "Look up a specific construct genomic entity association by its component entity IDs and relation")
 	@GET
 	@Path("/findBy")
 	@JsonView(CurationView.FieldsAndLists.class)
 	ObjectResponse<ConstructGenomicEntityAssociation> getAssociation(@QueryParam("constructId") Long constructId, @QueryParam("relationName") String relationName, @QueryParam("genomicEntityId") Long genomicEntityId);
 	
+	@Operation(summary = "Validate construct genomic entity association", description = "Validate a construct genomic entity association entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/GeneGenomicLocationAssociationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/GeneGenomicLocationAssociationCrudInterface.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/genegenomiclocation")
 @Tag(name = "CRUD - GeneGenomicLocationAssociation")
@@ -24,6 +25,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneGenomicLocationAssociationCrudInterface extends BaseIdCrudInterface<GeneGenomicLocationAssociation> {
 
+	@Operation(summary = "Bulk load gene genomic location association data", description = "Bulk load gene genomic location association records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}_{assemblyName}/geneLocations")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/SequenceTargetingReagentGeneAssociationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/associations/SequenceTargetingReagentGeneAssociationCrudInterface.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/sqtrgeneassociation")
 @Tag(name = "CRUD - SQTR Gene Associations")
@@ -21,6 +22,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface SequenceTargetingReagentGeneAssociationCrudInterface extends BaseIdCrudInterface<SequenceTargetingReagentGeneAssociation> {
 
+	@Operation(summary = "Get sequence targeting reagent gene association by component IDs", description = "Look up a specific sequence targeting reagent gene association by its component entity IDs and relation")
 	@GET
 	@Path("/findBy")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/bulkloads/BulkLoadFileHistoryCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/bulkloads/BulkLoadFileHistoryCrudInterface.java
@@ -17,28 +17,33 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/bulkloadfilehistory")
 @Tag(name = "Bulk Load - CRUD")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public interface BulkLoadFileHistoryCrudInterface extends BaseIdCrudInterface<BulkLoadFileHistory> {
+	@Operation(summary = "Download bulk load file", description = "Download the file associated with a bulk load file history entry")
 	@GET
 	@Path("/{id}/download")
 	@JsonView(CurationView.BulkLoadFileHistoryView.class)
 	@Produces(MediaType.APPLICATION_JSON)
 	Response download(@PathParam("id") Long id);
 
+	@Operation(summary = "Restart bulk load", description = "Restart a bulk load process by its ID")
 	@GET
 	@Path("/restartload/{id}")
 	@JsonView(CurationView.FieldsOnly.class)
 	ObjectResponse<BulkLoad> restartBulkLoad(@PathParam("id") Long id);
 	
+	@Operation(summary = "Stop bulk load file history", description = "Stop processing of a bulk load file history entry")
 	@GET
 	@Path("/stoploadhistory/{id}")
 	@JsonView(CurationView.FieldsOnly.class)
 	ObjectResponse<BulkLoadFile> stopBulkLoadHistory(@PathParam("id") Long id);
 	
+	@Operation(summary = "Restart bulk load file history", description = "Restart processing of a bulk load file history entry")
 	@GET
 	@Path("/restartloadhistory/{id}")
 	@JsonView(CurationView.FieldsOnly.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ontology/EcoTermCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ontology/EcoTermCrudInterface.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/ecoterm")
 @Tag(name = "CRUD - Ontology")
@@ -16,6 +17,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface EcoTermCrudInterface extends BaseOntologyTermCrudInterface<ECOTerm> {
 
+	@Operation(summary = "Bulk load eco term data", description = "Bulk load eco term records from a data provider submission")
 	@GET
 	@Path("/updateAbbreviations")
 	void updateAbbreviations();

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/orthology/GeneToGeneOrthologyGeneratedCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/orthology/GeneToGeneOrthologyGeneratedCrudInterface.java
@@ -15,6 +15,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/orthologygenerated")
 @Tag(name = "CRUD - Orthology")
@@ -22,6 +23,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneToGeneOrthologyGeneratedCrudInterface extends BaseIdCrudInterface<GeneToGeneOrthologyGenerated> {
 
+	@Operation(summary = "Bulk load gene to gene orthology generated data", description = "Bulk load gene to gene orthology generated records from a data provider submission")
 	@POST
 	@Path("/bulk/{dataProvider}/orthologyfile")
 	@JsonView(CurationView.FieldsAndLists.class)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AgmFullNameSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AgmFullNameSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.AgmFullNameSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/agmfullnameslotannotation")
 @Tag(name = "CRUD - AGM Full Name Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AgmFullNameSlotAnnotationCrudInterface extends BaseIdCrudInterface<AgmFullNameSlotAnnotation> {
 
+	@Operation(summary = "Validate agm full name slot annotation", description = "Validate a agm full name slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface AgmFullNameSlotAnnotationCrudInterface extends BaseIdCrudInterf
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AgmSecondaryIdSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AgmSecondaryIdSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.AgmSecondaryIdSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/agmsecondaryidslotannotation")
 @Tag(name = "CRUD - AGM Secondary ID Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AgmSecondaryIdSlotAnnotationCrudInterface extends BaseIdCrudInterface<AgmSecondaryIdSlotAnnotation> {
 
+	@Operation(summary = "Validate agm secondary id slot annotation", description = "Validate a agm secondary id slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface AgmSecondaryIdSlotAnnotationCrudInterface extends BaseIdCrudInt
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AgmSynonymSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AgmSynonymSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.AgmSynonymSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/agmsynonymslotannotation")
 @Tag(name = "CRUD - AGM Synonym Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AgmSynonymSlotAnnotationCrudInterface extends BaseIdCrudInterface<AgmSynonymSlotAnnotation> {
 
+	@Operation(summary = "Validate agm synonym slot annotation", description = "Validate a agm synonym slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface AgmSynonymSlotAnnotationCrudInterface extends BaseIdCrudInterfa
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleDatabaseStatusSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleDatabaseStatusSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.AlleleDatabaseStatusSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/alleledatabasestatusslotannotation")
 @Tag(name = "CRUD - Allele Database Status Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AlleleDatabaseStatusSlotAnnotationCrudInterface extends BaseIdCrudInterface<AlleleDatabaseStatusSlotAnnotation> {
 
+	@Operation(summary = "Validate allele database status slot annotation", description = "Validate a allele database status slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface AlleleDatabaseStatusSlotAnnotationCrudInterface extends BaseIdC
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleFullNameSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleFullNameSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.AlleleFullNameSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/allelefullnameslotannotation")
 @Tag(name = "CRUD - Allele Full Name Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AlleleFullNameSlotAnnotationCrudInterface extends BaseIdCrudInterface<AlleleFullNameSlotAnnotation> {
 
+	@Operation(summary = "Validate allele full name slot annotation", description = "Validate a allele full name slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface AlleleFullNameSlotAnnotationCrudInterface extends BaseIdCrudInt
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleFunctionalImpactSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleFunctionalImpactSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.AlleleFunctionalImpactSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/allelefunctionalimpactslotannotation")
 @Tag(name = "CRUD - Allele Functional Impact Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AlleleFunctionalImpactSlotAnnotationCrudInterface extends BaseIdCrudInterface<AlleleFunctionalImpactSlotAnnotation> {
 
+	@Operation(summary = "Validate allele functional impact slot annotation", description = "Validate a allele functional impact slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface AlleleFunctionalImpactSlotAnnotationCrudInterface extends BaseI
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleGermlineTransmissionStatusSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleGermlineTransmissionStatusSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.AlleleGermlineTransmissionStatusSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/allelegermlinetransmissionstatusslotannotation")
 @Tag(name = "CRUD - Allele Germline Transmission Status Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AlleleGermlineTransmissionStatusSlotAnnotationCrudInterface extends BaseIdCrudInterface<AlleleGermlineTransmissionStatusSlotAnnotation> {
 
+	@Operation(summary = "Validate allele germline transmission status slot annotation", description = "Validate a allele germline transmission status slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface AlleleGermlineTransmissionStatusSlotAnnotationCrudInterface ext
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleInheritanceModeSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleInheritanceModeSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.AlleleInheritanceModeSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/alleleinheritancemodeslotannotation")
 @Tag(name = "CRUD - Allele Inheritance Mode Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AlleleInheritanceModeSlotAnnotationCrudInterface extends BaseIdCrudInterface<AlleleInheritanceModeSlotAnnotation> {
 
+	@Operation(summary = "Validate allele inheritance mode slot annotation", description = "Validate a allele inheritance mode slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface AlleleInheritanceModeSlotAnnotationCrudInterface extends BaseId
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleMutationTypeSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleMutationTypeSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.AlleleMutationTypeSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/allelemutationtypeslotannotation")
 @Tag(name = "CRUD - Allele Mutation Type Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AlleleMutationTypeSlotAnnotationCrudInterface extends BaseIdCrudInterface<AlleleMutationTypeSlotAnnotation> {
 
+	@Operation(summary = "Validate allele mutation type slot annotation", description = "Validate a allele mutation type slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface AlleleMutationTypeSlotAnnotationCrudInterface extends BaseIdCru
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleNomenclatureEventSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleNomenclatureEventSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.AlleleNomenclatureEventSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/allelenomenclatureeventslotannotation")
 @Tag(name = "CRUD - Allele Nomenclature Event Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AlleleNomenclatureEventSlotAnnotationCrudInterface extends BaseIdCrudInterface<AlleleNomenclatureEventSlotAnnotation> {
 
+	@Operation(summary = "Validate allele nomenclature event slot annotation", description = "Validate a allele nomenclature event slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface AlleleNomenclatureEventSlotAnnotationCrudInterface extends Base
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleSecondaryIdSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleSecondaryIdSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.AlleleSecondaryIdSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/allelesecondaryidslotannotation")
 @Tag(name = "CRUD - Allele Secondary ID Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AlleleSecondaryIdSlotAnnotationCrudInterface extends BaseIdCrudInterface<AlleleSecondaryIdSlotAnnotation> {
 
+	@Operation(summary = "Validate allele secondary id slot annotation", description = "Validate a allele secondary id slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface AlleleSecondaryIdSlotAnnotationCrudInterface extends BaseIdCrud
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleSymbolSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleSymbolSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.AlleleSymbolSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/allelesymbolslotannotation")
 @Tag(name = "CRUD - Allele Symbol Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AlleleSymbolSlotAnnotationCrudInterface extends BaseIdCrudInterface<AlleleSymbolSlotAnnotation> {
 
+	@Operation(summary = "Validate allele symbol slot annotation", description = "Validate a allele symbol slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface AlleleSymbolSlotAnnotationCrudInterface extends BaseIdCrudInter
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleSynonymSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/AlleleSynonymSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.AlleleSynonymSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/allelesynonymslotannotation")
 @Tag(name = "CRUD - Allele Synonym Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface AlleleSynonymSlotAnnotationCrudInterface extends BaseIdCrudInterface<AlleleSynonymSlotAnnotation> {
 
+	@Operation(summary = "Validate allele synonym slot annotation", description = "Validate a allele synonym slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface AlleleSynonymSlotAnnotationCrudInterface extends BaseIdCrudInte
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/ConstructComponentSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/ConstructComponentSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.ConstructComponentSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/constructcomponentslotannotation")
 @Tag(name = "CRUD - Construct Component Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface ConstructComponentSlotAnnotationCrudInterface extends BaseIdCrudInterface<ConstructComponentSlotAnnotation> {
 
+	@Operation(summary = "Validate construct component slot annotation", description = "Validate a construct component slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface ConstructComponentSlotAnnotationCrudInterface extends BaseIdCru
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/ConstructFullNameSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/ConstructFullNameSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.ConstructFullNameSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/constructfullnameslotannotation")
 @Tag(name = "CRUD - Construct Full Name Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface ConstructFullNameSlotAnnotationCrudInterface extends BaseIdCrudInterface<ConstructFullNameSlotAnnotation> {
 
+	@Operation(summary = "Validate construct full name slot annotation", description = "Validate a construct full name slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface ConstructFullNameSlotAnnotationCrudInterface extends BaseIdCrud
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/ConstructSymbolSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/ConstructSymbolSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.ConstructSymbolSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/constructsymbolslotannotation")
 @Tag(name = "CRUD - Construct Symbol Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface ConstructSymbolSlotAnnotationCrudInterface extends BaseIdCrudInterface<ConstructSymbolSlotAnnotation> {
 
+	@Operation(summary = "Validate construct symbol slot annotation", description = "Validate a construct symbol slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface ConstructSymbolSlotAnnotationCrudInterface extends BaseIdCrudIn
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/ConstructSynonymSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/ConstructSynonymSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.ConstructSynonymSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/constructsynonymslotannotation")
 @Tag(name = "CRUD - Construct Synonym Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface ConstructSynonymSlotAnnotationCrudInterface extends BaseIdCrudInterface<ConstructSynonymSlotAnnotation> {
 
+	@Operation(summary = "Validate construct synonym slot annotation", description = "Validate a construct synonym slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface ConstructSynonymSlotAnnotationCrudInterface extends BaseIdCrudI
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/GeneFullNameSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/GeneFullNameSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.GeneFullNameSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/genefullnameslotannotation")
 @Tag(name = "CRUD - Gene Full Name Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneFullNameSlotAnnotationCrudInterface extends BaseIdCrudInterface<GeneFullNameSlotAnnotation> {
 
+	@Operation(summary = "Validate gene full name slot annotation", description = "Validate a gene full name slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface GeneFullNameSlotAnnotationCrudInterface extends BaseIdCrudInter
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/GeneSecondaryIdSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/GeneSecondaryIdSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.GeneSecondaryIdSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/genesecondaryidslotannotation")
 @Tag(name = "CRUD - Gene Secondary ID Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneSecondaryIdSlotAnnotationCrudInterface extends BaseIdCrudInterface<GeneSecondaryIdSlotAnnotation> {
 
+	@Operation(summary = "Validate gene secondary id slot annotation", description = "Validate a gene secondary id slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface GeneSecondaryIdSlotAnnotationCrudInterface extends BaseIdCrudIn
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/GeneSymbolSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/GeneSymbolSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.GeneSymbolSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/genesymbolslotannotation")
 @Tag(name = "CRUD - Gene Symbol Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneSymbolSlotAnnotationCrudInterface extends BaseIdCrudInterface<GeneSymbolSlotAnnotation> {
 
+	@Operation(summary = "Validate gene symbol slot annotation", description = "Validate a gene symbol slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface GeneSymbolSlotAnnotationCrudInterface extends BaseIdCrudInterfa
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/GeneSynonymSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/GeneSynonymSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.GeneSynonymSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/genesynonymslotannotation")
 @Tag(name = "CRUD - Gene Synonym Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneSynonymSlotAnnotationCrudInterface extends BaseIdCrudInterface<GeneSynonymSlotAnnotation> {
 
+	@Operation(summary = "Validate gene synonym slot annotation", description = "Validate a gene synonym slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface GeneSynonymSlotAnnotationCrudInterface extends BaseIdCrudInterf
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/GeneSystematicNameSlotAnnotationCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/slotAnnotations/GeneSystematicNameSlotAnnotationCrudInterface.java
@@ -1,12 +1,10 @@
 package org.alliancegenome.curation_api.interfaces.crud.slotAnnotations;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
-import org.alliancegenome.curation_api.model.Null;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.GeneSystematicNameSlotAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -18,6 +16,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @Path("/genesystematicnameslotannotation")
 @Tag(name = "CRUD - Gene Systematic Name Slot Annotations")
@@ -25,6 +24,7 @@ import jakarta.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface GeneSystematicNameSlotAnnotationCrudInterface extends BaseIdCrudInterface<GeneSystematicNameSlotAnnotation> {
 
+	@Operation(summary = "Validate gene systematic name slot annotation", description = "Validate a gene systematic name slot annotation entity without persisting it")
 	@POST
 	@Path("/validate")
 	@JsonView(CurationView.FieldsAndLists.class)
@@ -32,8 +32,7 @@ public interface GeneSystematicNameSlotAnnotationCrudInterface extends BaseIdCru
 		@APIResponse(
 			description = "Validate Object",
 			content = @Content(
-				mediaType = "application/json",
-				schema = @Schema(implementation = Null.class)
+				mediaType = "application/json"
 			)
 		)
 	)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AGMDiseaseAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AGMDiseaseAnnotation.java
@@ -33,7 +33,7 @@ import lombok.EqualsAndHashCode;
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@Schema(name = "AGM_Disease_Annotation", description = "Annotation class representing a agm disease annotation")
+@Schema(name = "AGM_Disease_Annotation", description = "AGMDiseaseAnnotation: an AGM disease annotation")
 @JsonTypeName("AGMDiseaseAnnotation")
 @AGRCurationSchemaVersion(min = "2.11.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {DiseaseAnnotation.class})
 @JsonPropertyOrder({"type", "diseaseAnnotationSubject", "relation", "diseaseAnnotationObject", "inferredGene", "inferredAllele", "assertedGenes", "assertedAlleles", "dataProvider", "evidenceItem", "dataProviderCrossReference", "evidenceCodes", "diseaseGeneticModifierAgms", "diseaseGeneticModifierRelation", "geneticSex", "negated", "relatedNotes", "annotationType"})

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AGMPhenotypeAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AGMPhenotypeAnnotation.java
@@ -32,7 +32,7 @@ import lombok.EqualsAndHashCode;
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@Schema(name = "AGM_Phenotype_Annotation", description = "Annotation class representing a agm phenotype annotation")
+@Schema(name = "AGM_Phenotype_Annotation", description = "AGMPhenotypeAnnotation: an AGM phenotype annotation")
 @JsonTypeName("AGMPhenotypeAnnotation")
 @AGRCurationSchemaVersion(min = "2.11.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { PhenotypeAnnotation.class })
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AffectedGenomicModel.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AffectedGenomicModel.java
@@ -44,7 +44,7 @@ import lombok.ToString;
 		"agmSequenceTargetingReagentAssociations",
 		"components",
 		"parentalPopulations" }, callSuper = true)
-@Schema(name = "AffectedGenomicModel", description = "POJO that represents the AGM")
+@Schema(name = "AffectedGenomicModel", description = "AffectedGenomicModel: an affected genomic model")
 @AGRCurationSchemaVersion(min = "2.12.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {GenomicEntity.class}, partial = true)
 public class AffectedGenomicModel extends GenomicEntity {
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Allele.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Allele.java
@@ -48,8 +48,10 @@ import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "Allele", description = "Allele: an allele")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AlleleDiseaseAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AlleleDiseaseAnnotation.java
@@ -32,7 +32,7 @@ import lombok.EqualsAndHashCode;
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@Schema(name = "Allele_Disease_Annotation", description = "Annotation class representing a allele disease annotation")
+@Schema(name = "Allele_Disease_Annotation", description = "AlleleDiseaseAnnotation: an allele disease annotation")
 @JsonTypeName("AlleleDiseaseAnnotation")
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { DiseaseAnnotation.class })
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AllelePhenotypeAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AllelePhenotypeAnnotation.java
@@ -32,7 +32,7 @@ import lombok.EqualsAndHashCode;
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@Schema(name = "Allele_Phenotype_Annotation", description = "Annotation class representing a allele phenotype annotation")
+@Schema(name = "Allele_Phenotype_Annotation", description = "AllelePhenotypeAnnotation: an allele phenotype annotation")
 @JsonTypeName("AllelePhenotypeAnnotation")
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { PhenotypeAnnotation.class })
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AllianceMember.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AllianceMember.java
@@ -9,8 +9,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Data
+@Schema(name = "AllianceMember", description = "AllianceMember: an alliance member")
 @Entity
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AnatomicalSite.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AnatomicalSite.java
@@ -38,7 +38,7 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @AGRCurationSchemaVersion(min = "2.7.0", max = LinkMLSchemaConstants.LATEST_RELEASE)
-@Schema(name = "Anatomical_Site", description = "Anatomical part of an expression pattern")
+@Schema(name = "Anatomical_Site", description = "AnatomicalSite: an anatomical site")
 @Table(indexes = {
 	@Index(name = "anatomicalsite_anatomicalstructure_index ", columnList = "anatomicalstructure_id"),
 	@Index(name = "anatomicalsite_anatomicalsubstructure_index", columnList = "anatomicalsubstructure_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Annotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Annotation.java
@@ -38,7 +38,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "annotation", description = "POJO that represents an annotation")
+@Schema(name = "annotation", description = "Annotation: an annotation")
 @AGRCurationSchemaVersion(min = "2.9.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObject.class })
 public class Annotation extends SingleReferenceAssociation {
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AssemblyComponent.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AssemblyComponent.java
@@ -23,7 +23,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "AssemblyComponent", description = "POJO that represents the AssemblyComponent")
+@Schema(name = "AssemblyComponent", description = "AssemblyComponent: an assembly component")
 @AGRCurationSchemaVersion(min = "2.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { GenomicEntity.class })
 @Table(
 	indexes = {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Association.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Association.java
@@ -14,7 +14,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "association", description = "POJO that represents an association")
+@Schema(name = "association", description = "Association: an association")
 @AGRCurationSchemaVersion(min = "1.9.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObject.class })
 public class Association extends AuditedObject {
 	

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/BioSampleAge.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/BioSampleAge.java
@@ -29,7 +29,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "BioSampleAge", description = "POJO that represents the BioSampleAge")
+@Schema(name = "BioSampleAge", description = "BioSampleAge: a bio sample age")
 @AGRCurationSchemaVersion(min = "2.7.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObject.class })
 @Table(indexes = {
 	@Index(name = "biosampleage_stage_index", columnList = "stage_id")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/BioSampleGenomicInformation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/BioSampleGenomicInformation.java
@@ -29,7 +29,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "BioSampleGenomicInformation", description = "POJO that represents the BioSampleGenomicInformation")
+@Schema(name = "BioSampleGenomicInformation", description = "BioSampleGenomicInformation: a bio sample genomic information")
 @AGRCurationSchemaVersion(min = "2.7.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObject.class })
 @Indexed
 @Table(indexes = {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/BiologicalEntity.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/BiologicalEntity.java
@@ -26,6 +26,7 @@ import jakarta.persistence.UniqueConstraint;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Inheritance(strategy = InheritanceType.JOINED)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
@@ -40,6 +41,7 @@ import lombok.ToString;
 	@JsonSubTypes.Type(value = Variant.class, name = "Variant"),
 	@JsonSubTypes.Type(value = SequenceTargetingReagent.class, name = "SequenceTargetingReagent")
 })
+@Schema(name = "BiologicalEntity", description = "BiologicalEntity: a biological entity")
 @Entity
 @TypeBinding(binder = @TypeBinderRef(type = BiologicalEntityTypeBridge.class))
 @Data

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Chromosome.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Chromosome.java
@@ -27,7 +27,9 @@ import jakarta.persistence.UniqueConstraint;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "Chromosome", description = "Chromosome: a chromosome")
 @Entity
 @Data
 @EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/CodingSequence.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/CodingSequence.java
@@ -35,7 +35,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(exclude = {"codingSequenceGenomicLocationAssociations", "transcriptCodingSequenceAssociations"}, callSuper = true)
-@Schema(name = "CodingSequence", description = "POJO that represents the CodingSequence (CDS)")
+@Schema(name = "CodingSequence", description = "CodingSequence: a coding sequence")
 @AGRCurationSchemaVersion(min = "2.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { GenomicEntity.class })
 @Table(indexes = {
 	@Index(name = "codingsequence_uniqueid_index", columnList = "uniqueid"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ConditionRelation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ConditionRelation.java
@@ -38,7 +38,7 @@ import lombok.ToString;
 @Indexed
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "ConditionRelation", description = "POJO that describes the Condition Relation")
+@Schema(name = "ConditionRelation", description = "ConditionRelation: a condition relation")
 @Table(indexes = {
 	@Index(name = "conditionrelation_createdby_index", columnList = "createdBy_id"),
 	@Index(name = "conditionrelation_updatedby_index", columnList = "updatedBy_id")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Construct.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Construct.java
@@ -35,7 +35,7 @@ import lombok.ToString;
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@Schema(name = "construct", description = "POJO that represents a construct")
+@Schema(name = "construct", description = "Construct: a construct")
 @ToString(exclude = {"constructGenomicEntityAssociations", "alleleConstructAssociations", "constructComponents", "constructSymbol", "constructFullName", "constructSynonyms"}, callSuper = true)
 @AGRCurationSchemaVersion(min = "2.1.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { Reagent.class })
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/CrossReference.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/CrossReference.java
@@ -31,7 +31,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 @ToString(callSuper = true)
-@Schema(name = "CrossReference", description = "POJO that represents the Cross Reference")
+@Schema(name = "CrossReference", description = "CrossReference: a cross reference")
 @AGRCurationSchemaVersion(min = "1.6.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {AuditedObject.class})
 @Table(indexes = {
 	@Index(name = "crossreference_createdby_index", columnList = "createdBy_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/DiseaseAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/DiseaseAnnotation.java
@@ -56,7 +56,7 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @AGRCurationSchemaVersion(min = "2.9.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {Annotation.class})
-@Schema(name = "Disease_Annotation", description = "Annotation class representing a disease annotation")
+@Schema(name = "Disease_Annotation", description = "DiseaseAnnotation: a disease annotation")
 @Table(indexes = {
 	@Index(name = "DiseaseAnnotation_internal_index", columnList = "internal"),
 	@Index(name = "DiseaseAnnotation_obsolete_index", columnList = "obsolete"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/EvidenceAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/EvidenceAssociation.java
@@ -23,7 +23,7 @@ import lombok.EqualsAndHashCode;
 @MappedSuperclass
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@Schema(name = "evidenceAssociation", description = "POJO that represents an association supported by any number of information content entities")
+@Schema(name = "evidenceAssociation", description = "EvidenceAssociation: an evidence association")
 @AGRCurationSchemaVersion(min = "1.9.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { Association.class })
 public class EvidenceAssociation extends Association {
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Exon.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Exon.java
@@ -35,7 +35,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(exclude = {"exonGenomicLocationAssociations", "transcriptExonAssociations"}, callSuper = true)
-@Schema(name = "Exon", description = "POJO that represents the Exon")
+@Schema(name = "Exon", description = "Exon: an exon")
 @AGRCurationSchemaVersion(min = "2.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { GenomicEntity.class })
 @Table(indexes = {
 	@Index(name = "exon_uniqueid_index", columnList = "uniqueid"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ExperimentalCondition.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ExperimentalCondition.java
@@ -38,7 +38,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "ExperimentalCondition", description = "POJO that describes the Experimental Condition")
+@Schema(name = "ExperimentalCondition", description = "ExperimentalCondition: an experimental condition")
 @Table(indexes = {
 	@Index(name = "experimentalcondition_createdby_index", columnList = "createdBy_id"),
 	@Index(name = "experimentalcondition_updatedby_index", columnList = "updatedBy_id")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ExpressionAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ExpressionAnnotation.java
@@ -30,7 +30,7 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @AGRCurationSchemaVersion(min = "2.2.3", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { Annotation.class })
-@Schema(name = "Expression_Annotation", description = "Annotation class representing an expression annotation")
+@Schema(name = "Expression_Annotation", description = "ExpressionAnnotation: an expression annotation")
 public abstract class ExpressionAnnotation extends Annotation {
 
 	@IndexedEmbedded(includePaths = {"name", "name_keyword"})

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ExpressionPattern.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ExpressionPattern.java
@@ -24,7 +24,7 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @AGRCurationSchemaVersion(min = "2.2.3", max = LinkMLSchemaConstants.LATEST_RELEASE)
-@Schema(name = "Expression_Pattern", description = "Annotation class representing an expression pattern")
+@Schema(name = "Expression_Pattern", description = "ExpressionPattern: an expression pattern")
 
 @Table(indexes = {
 	@Index(name = "expressionpattern_whenexpressed_index", columnList = "whenexpressed_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ExternalDataBaseEntity.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ExternalDataBaseEntity.java
@@ -35,7 +35,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "ExternalDataBaseEntity", description = "POJO that represents the ExternalDataBaseEntity")
+@Schema(name = "ExternalDataBaseEntity", description = "ExternalDataBaseEntity: an external data base entity")
 @AGRCurationSchemaVersion(min = "2.6.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { CurieObject.class })
 public class ExternalDataBaseEntity extends CurieObject {
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ExternalDatabaseReference.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ExternalDatabaseReference.java
@@ -17,7 +17,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "Reference", description = "POJO that represents the Reference")
+@Schema(name = "Reference", description = "ExternalDatabaseReference: an external database reference")
 @AGRCurationSchemaVersion(min = "2.10.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {InformationContentEntity.class}, partial = true)
 public class ExternalDatabaseReference extends InformationContentEntity {
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Gene.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Gene.java
@@ -65,7 +65,7 @@ import lombok.ToString;
 		"sequenceTargetingReagentGeneAssociations",
 		"transcriptGeneAssociations",
 		"constructGenomicEntityAssociations" }, callSuper = true)
-@Schema(name = "Gene", description = "POJO that represents the Gene")
+@Schema(name = "Gene", description = "Gene: a gene")
 @AGRCurationSchemaVersion(min = "1.5.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { GenomicEntity.class }, partial = true)
 @Table(indexes = {
 		@Index(name = "gene_genetype_index", columnList = "geneType_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GeneDiseaseAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GeneDiseaseAnnotation.java
@@ -25,7 +25,7 @@ import lombok.EqualsAndHashCode;
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@Schema(name = "Gene_Disease_Annotation", description = "Annotation class representing a gene disease annotation")
+@Schema(name = "Gene_Disease_Annotation", description = "GeneDiseaseAnnotation: a gene disease annotation")
 @JsonTypeName("GeneDiseaseAnnotation")
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { DiseaseAnnotation.class })
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GeneExpressionAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GeneExpressionAnnotation.java
@@ -31,7 +31,7 @@ import lombok.EqualsAndHashCode;
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@Schema(name = "Gene_Expression_Annotation", description = "Annotation class representing a gene expression annotation")
+@Schema(name = "Gene_Expression_Annotation", description = "GeneExpressionAnnotation: a gene expression annotation")
 @JsonTypeName("GeneExpressionAnnotation")
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { ExpressionAnnotation.class })
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GeneExpressionExperiment.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GeneExpressionExperiment.java
@@ -9,8 +9,10 @@ import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "GeneExpressionExperiment", description = "GeneExpressionExperiment: a gene expression experiment")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GeneGeneticInteraction.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GeneGeneticInteraction.java
@@ -36,7 +36,7 @@ import lombok.ToString;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@Schema(name = "Gene_Genetic_Interaction", description = "Class representing an interaction between genes")
+@Schema(name = "Gene_Genetic_Interaction", description = "GeneGeneticInteraction: a gene genetic interaction")
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { GeneInteraction.class })
 
 @Table(indexes = {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GeneInteraction.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GeneInteraction.java
@@ -38,7 +38,7 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.2.2", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { Annotation.class })
 @ToString(callSuper = true)
-@Schema(name = "Gene_Interaction", description = "Annotation class representing a gene interaction")
+@Schema(name = "Gene_Interaction", description = "GeneInteraction: a gene interaction")
 public abstract class GeneInteraction extends GeneGeneAssociation {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GeneMolecularInteraction.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GeneMolecularInteraction.java
@@ -27,7 +27,7 @@ import lombok.ToString;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@Schema(name = "Gene_Molecular_Interaction", description = "Class representing an interaction between gene products")
+@Schema(name = "Gene_Molecular_Interaction", description = "GeneMolecularInteraction: a gene molecular interaction")
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { GeneInteraction.class })
 
 @Table(indexes = {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GeneOntologyAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GeneOntologyAnnotation.java
@@ -16,7 +16,7 @@ import lombok.EqualsAndHashCode;
 @Entity
 @Data
 @EqualsAndHashCode
-@Schema(name = "Gene_Disease_Annotation", description = "Annotation class representing a gene disease annotation")
+@Schema(name = "Gene_Disease_Annotation", description = "GeneOntologyAnnotation: a gene ontology annotation")
 @JsonTypeName("GeneOntologyAnnotation")
 @AGRCurationSchemaVersion(min = "2.8.0", max = LinkMLSchemaConstants.LATEST_RELEASE)
 public class GeneOntologyAnnotation extends AuditedObject {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GenePhenotypeAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GenePhenotypeAnnotation.java
@@ -25,7 +25,7 @@ import lombok.EqualsAndHashCode;
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@Schema(name = "Gene_Phenotype_Annotation", description = "Annotation class representing a gene phenotype annotation")
+@Schema(name = "Gene_Phenotype_Annotation", description = "GenePhenotypeAnnotation: a gene phenotype annotation")
 @JsonTypeName("GenePhenotypeAnnotation")
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { PhenotypeAnnotation.class })
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GeneToGeneParalogy.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GeneToGeneParalogy.java
@@ -27,7 +27,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "GeneToGeneParalogy", description = "POJO that represents paralogy between two genes")
+@Schema(name = "GeneToGeneParalogy", description = "GeneToGeneParalogy: a gene to gene paralogy")
 @AGRCurationSchemaVersion(min = "2.3.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObject.class })
 @Table(indexes = {
 		@Index(name = "genetogeneparalogy_createdby_index", columnList = "createdBy_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GenomeAssembly.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GenomeAssembly.java
@@ -27,7 +27,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "GenomeAssembly", description = "POJO that represents a GenomeAssembly")
+@Schema(name = "GenomeAssembly", description = "GenomeAssembly: a genome assembly")
 @AGRCurationSchemaVersion(min = "2.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { BiologicalEntity.class })
 public class GenomeAssembly extends BiologicalEntity {
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GenomicEntity.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GenomicEntity.java
@@ -18,7 +18,9 @@ import jakarta.persistence.OneToMany;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "GenomicEntity", description = "GenomicEntity: a genomic entity")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/HTPExpressionDatasetAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/HTPExpressionDatasetAnnotation.java
@@ -41,7 +41,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "HTPExpressionDatasetAnnotation", description = "POJO that represents the HighThroughputExpressionDatasetAnnotation")
+@Schema(name = "HTPExpressionDatasetAnnotation", description = "HTPExpressionDatasetAnnotation: a HTP expression dataset annotation")
 @AGRCurationSchemaVersion(min = "2.9.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObject.class })
 @Table(indexes = {
 	@Index(name = "htpdatasetannotation_htpExpressionDataset_index", columnList = "htpExpressionDataset_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/HTPExpressionDatasetSampleAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/HTPExpressionDatasetSampleAnnotation.java
@@ -41,7 +41,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "HTPExpressionDatasetSampleAnnotation", description = "POJO that represents the HighThroughputExpressionDatasetSampleAnnotation")
+@Schema(name = "HTPExpressionDatasetSampleAnnotation", description = "HTPExpressionDatasetSampleAnnotation: a HTP expression dataset sample annotation")
 @AGRCurationSchemaVersion(min = "2.9.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObject.class })
 @Table(indexes = {
 	@Index(name = "htpdatasample_htpExpressionSample_index", columnList = "htpExpressionSample_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/InformationContentEntity.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/InformationContentEntity.java
@@ -20,8 +20,10 @@ import jakarta.persistence.UniqueConstraint;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Inheritance(strategy = InheritanceType.JOINED)
+@Schema(name = "InformationContentEntity", description = "InformationContentEntity: an information content entity")
 @Entity
 @Data
 @TypeBinding(binder = @TypeBinderRef(type = InformationContentEntityTypeBridge.class))

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/LocationAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/LocationAssociation.java
@@ -22,7 +22,7 @@ import lombok.EqualsAndHashCode;
 @MappedSuperclass
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@Schema(name = "locationAssociation", description = "POJO that represents a location association")
+@Schema(name = "locationAssociation", description = "LocationAssociation: a location association")
 @AGRCurationSchemaVersion(min = "2.0.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {EvidenceAssociation.class})
 public abstract class LocationAssociation extends EvidenceAssociation {
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/MicroarraySampleDetails.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/MicroarraySampleDetails.java
@@ -25,7 +25,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "MicroarraySampleDetails", description = "POJO that represents the MicroarraySampleDetails")
+@Schema(name = "MicroarraySampleDetails", description = "MicroarraySampleDetails: a microarray sample details")
 @AGRCurationSchemaVersion(min = "2.7.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObject.class })
 @Indexed
 public class MicroarraySampleDetails extends AuditedObject {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Molecule.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Molecule.java
@@ -14,7 +14,7 @@ import lombok.EqualsAndHashCode;
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@Schema(name = "Molecule", description = "POJO that represents the Molecule")
+@Schema(name = "Molecule", description = "Molecule: a molecule")
 
 @AGRCurationSchemaVersion(min = "1.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { ChemicalTerm.class })
 public class Molecule extends ChemicalTerm {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Note.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Note.java
@@ -35,7 +35,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "Note", description = "POJO that represents the Note")
+@Schema(name = "Note", description = "Note: a note")
 @AGRCurationSchemaVersion(min = "1.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObject.class })
 @Table(indexes = {
 		@Index(name = "Note_noteType_index", columnList = "noteType_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Organization.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Organization.java
@@ -27,9 +27,11 @@ import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Inheritance(strategy = InheritanceType.JOINED)
 @Data
+@Schema(name = "Organization", description = "Organization: an organization")
 @Entity
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Person.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Person.java
@@ -25,7 +25,9 @@ import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "Person", description = "Person: a person")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/PersonSetting.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/PersonSetting.java
@@ -19,7 +19,9 @@ import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "PersonSetting", description = "PersonSetting: a person setting")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/PhenotypeAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/PhenotypeAnnotation.java
@@ -45,7 +45,7 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @AGRCurationSchemaVersion(min = "2.2.3", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { Annotation.class })
-@Schema(name = "Phenotype_Annotation", description = "Annotation class representing a phenotype annotation")
+@Schema(name = "Phenotype_Annotation", description = "PhenotypeAnnotation: a phenotype annotation")
 @Table(indexes = {
 	@Index(name = "PhenotypeAnnotation_internal_index", columnList = "internal"),
 	@Index(name = "PhenotypeAnnotation_obsolete_index", columnList = "obsolete"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/PredictedVariantConsequence.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/PredictedVariantConsequence.java
@@ -43,7 +43,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.7.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {AuditedObject.class})
-@Schema(name = "PredictedVariantConsequence", description = "POJO representing VEP predicted variant consequence results")
+@Schema(name = "PredictedVariantConsequence", description = "PredictedVariantConsequence: a predicted variant consequence")
 @Table(indexes = {
 	@Index(name = "predictedvariantconsequence_varianttranscript_index", columnList = "varianttranscript_id"),
 	@Index(name = "predictedvariantconsequence_vepimpact_index", columnList = "vepimpact_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Reagent.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Reagent.java
@@ -38,7 +38,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "reagent", description = "POJO that represents a reagent")
+@Schema(name = "reagent", description = "Reagent: a reagent")
 @AGRCurationSchemaVersion(min = "2.0.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {SubmittedObject.class})
 @Table(indexes = {
 		@Index(name = "reagent_uniqueid_index", columnList = "uniqueid"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Reference.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Reference.java
@@ -35,7 +35,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "Reference", description = "POJO that represents the Reference")
+@Schema(name = "Reference", description = "Reference: a reference")
 @AGRCurationSchemaVersion(min = "1.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {InformationContentEntity.class}, partial = true)
 public class Reference extends InformationContentEntity {
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ResourceDescriptor.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ResourceDescriptor.java
@@ -43,7 +43,7 @@ import lombok.ToString;
 		@Index(name = "resourcedescriptor_createdby_index", columnList = "createdBy_id"),
 		@Index(name = "resourcedescriptor_updatedby_index", columnList = "updatedBy_id")
 })
-@Schema(name = "ResourceDescriptor", description = "Annotation class representing a resource descriptor")
+@Schema(name = "ResourceDescriptor", description = "ResourceDescriptor: a resource descriptor")
 public class ResourceDescriptor extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ResourceDescriptorPage.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ResourceDescriptorPage.java
@@ -36,7 +36,7 @@ import lombok.ToString;
 		@Index(name = "resourcedescriptorpage_createdby_index", columnList = "createdby_id"),
 		@Index(name = "resourcedescriptorpage_updatedby_index", columnList = "updatedby_id")
 })
-@Schema(name = "ResourceDescriptorPage", description = "Annotation class representing a resource descriptor page")
+@Schema(name = "ResourceDescriptorPage", description = "ResourceDescriptorPage: a resource descriptor page")
 public class ResourceDescriptorPage extends AuditedObject {
 
 	@IndexedEmbedded(includeDepth = 1)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/SequenceTargetingReagent.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/SequenceTargetingReagent.java
@@ -38,7 +38,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(exclude = { "sequenceTargetingReagentGeneAssociations", "agmSequenceTargetingReagentAssociations" }, callSuper = true)
-@Schema(name = "SequenceTargetingReagent", description = "POJO that represents the SequenceTargetingReagent")
+@Schema(name = "SequenceTargetingReagent", description = "SequenceTargetingReagent: a sequence targeting reagent")
 @AGRCurationSchemaVersion(min = "2.3.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { GenomicEntity.class }, partial = true)
 public class SequenceTargetingReagent extends GenomicEntity {
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/SingleReferenceAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/SingleReferenceAssociation.java
@@ -18,7 +18,7 @@ import lombok.EqualsAndHashCode;
 @MappedSuperclass
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@Schema(name = "singleReferenceAssociation", description = "POJO that represents an association supported by a single information content entity")
+@Schema(name = "singleReferenceAssociation", description = "SingleReferenceAssociation: a single reference association")
 @AGRCurationSchemaVersion(min = "2.10.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { Association.class })
 public class SingleReferenceAssociation extends Association {
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
@@ -35,7 +35,9 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "Species", description = "Species: a species")
 @Entity
 @Data
 @Indexed

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Synonym.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Synonym.java
@@ -20,7 +20,9 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "Synonym", description = "Synonym: a synonym")
 @Entity
 @Data
 @NoArgsConstructor

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/TemporalContext.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/TemporalContext.java
@@ -35,7 +35,7 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @AGRCurationSchemaVersion(min = "2.2.3", max = LinkMLSchemaConstants.LATEST_RELEASE)
-@Schema(name = "Temporal_Context", description = "Temporal expression pattern")
+@Schema(name = "Temporal_Context", description = "TemporalContext: a temporal context")
 @Table(indexes = {
 	@Index(name = "temporalcontext_developmentalstagestart_index ", columnList = "developmentalstagestart_id"),
 	@Index(name = "temporalcontext_developmentalstagestop_index ", columnList = "developmentalstagestop_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Transcript.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Transcript.java
@@ -37,7 +37,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(exclude = { "transcriptGenomicLocationAssociations", "transcriptGeneAssociations", "transcriptCodingSequenceAssociations", "transcriptExonAssociations" }, callSuper = true)
-@Schema(name = "Transcript", description = "POJO that represents the Transcript")
+@Schema(name = "Transcript", description = "Transcript: a transcript")
 @AGRCurationSchemaVersion(min = "2.8.1", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { GenomicEntity.class })
 @Table(indexes = {
 	@Index(name = "transcript_transcriptId_index", columnList = "transcriptId"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Variant.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Variant.java
@@ -30,8 +30,10 @@ import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "Variant", description = "Variant: a variant")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Vocabulary.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Vocabulary.java
@@ -34,7 +34,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "Vocabulary", description = "POJO that represents the Vocabulary")
+@Schema(name = "Vocabulary", description = "Vocabulary: a vocabulary")
 @AGRCurationSchemaVersion(min = "1.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObject.class })
 @Table(
 	indexes = {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/VocabularyTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/VocabularyTerm.java
@@ -42,7 +42,7 @@ import lombok.ToString;
 	@Index(name = "vocabularyterm_createdby_index", columnList = "createdBy_id"),
 	@Index(name = "vocabularyterm_updatedby_index", columnList = "updatedBy_id")
 })
-@Schema(name = "VocabularyTerm", description = "POJO that represents the Vocabulary Term")
+@Schema(name = "VocabularyTerm", description = "VocabularyTerm: a vocabulary term")
 @AGRCurationSchemaVersion(min = "1.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {AuditedObject.class})
 public class VocabularyTerm extends AuditedObject {
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/VocabularyTermSet.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/VocabularyTermSet.java
@@ -36,7 +36,7 @@ import lombok.ToString;
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@Schema(name = "VocabularyTermSet", description = "POJO that represents the Vocabulary Term Set")
+@Schema(name = "VocabularyTermSet", description = "VocabularyTermSet: a vocabulary term set")
 @ToString(callSuper = true)
 @Table(
 	indexes = {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AgmAgmAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AgmAgmAssociation.java
@@ -29,7 +29,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.8.1", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {Association.class})
-@Schema(name = "AgmAgmAssociation", description = "POJO representing an association between an AGM and another AGM")
+@Schema(name = "AgmAgmAssociation", description = "AgmAgmAssociation: an agm agm association")
 
 @Table(indexes = {
 	@Index(name = "AgmAgmAssociation_internal_index", columnList = "internal"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AgmAlleleAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AgmAlleleAssociation.java
@@ -29,7 +29,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.10.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { Association.class })
-@Schema(name = "AgmAlleleAssociation", description = "POJO representing an association between an AGM and a Allele")
+@Schema(name = "AgmAlleleAssociation", description = "AgmAlleleAssociation: an agm allele association")
 
 @Table(indexes = {
 	@Index(name = "AgmAlleleAssociation_internal_index", columnList = "internal"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AgmSequenceTargetingReagentAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AgmSequenceTargetingReagentAssociation.java
@@ -30,7 +30,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.8.1", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { Association.class })
-@Schema(name = "AgmSequenceTargetingReagentAssociation", description = "POJO representing an association between an AGM and a STR")
+@Schema(name = "AgmSequenceTargetingReagentAssociation", description = "AgmSequenceTargetingReagentAssociation: an agm sequence targeting reagent association")
 
 @Table(indexes = {
 	@Index(name = "AgmStrAssociation_internal_index", columnList = "internal"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AlleleConstructAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AlleleConstructAssociation.java
@@ -29,7 +29,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AlleleGenomicEntityAssociation.class })
-@Schema(name = "AlleleConstructAssociation", description = "POJO representing an association between an allele and a construct")
+@Schema(name = "AlleleConstructAssociation", description = "AlleleConstructAssociation: an allele construct association")
 
 @Table(indexes = {
 	@Index(name = "AlleleConstructAssociation_createdBy_index", columnList = "createdBy_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AlleleGeneAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AlleleGeneAssociation.java
@@ -28,7 +28,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AlleleGenomicEntityAssociation.class })
-@Schema(name = "AlleleGeneAssociation", description = "POJO representing an association between an allele and a gene")
+@Schema(name = "AlleleGeneAssociation", description = "AlleleGeneAssociation: an allele gene association")
 
 @Table(indexes = {
 	@Index(name = "AlleleGeneAssociation_internal_index", columnList = "internal"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AlleleGenomicEntityAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AlleleGenomicEntityAssociation.java
@@ -27,7 +27,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.9.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { EvidenceAssociation.class })
-@Schema(name = "AlleleGenomicEntityAssociation", description = "POJO representing an association between an allele and a genomic entity")
+@Schema(name = "AlleleGenomicEntityAssociation", description = "AlleleGenomicEntityAssociation: an allele genomic entity association")
 public class AlleleGenomicEntityAssociation extends EvidenceAssociation {
 
 	@IndexedEmbedded(includePaths = { "name", "name_keyword" })

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AlleleVariantAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AlleleVariantAssociation.java
@@ -28,7 +28,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AlleleGenomicEntityAssociation.class })
-@Schema(name = "AlleleVariantAssociation", description = "POJO representing an association between an allele and a gene")
+@Schema(name = "AlleleVariantAssociation", description = "AlleleVariantAssociation: an allele variant association")
 
 @Table(indexes = {
 	@Index(name = "AlleleVariantAssociation_internal_index", columnList = "internal"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/CodingSequenceGenomicLocationAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/CodingSequenceGenomicLocationAssociation.java
@@ -37,7 +37,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { LocationAssociation.class })
-@Schema(name = "CodingSequenceGenomicLocationAssociation", description = "POJO representing an association between a CDS and a genomic location")
+@Schema(name = "CodingSequenceGenomicLocationAssociation", description = "CodingSequenceGenomicLocationAssociation: a coding sequence genomic location association")
 
 @Table(
 	indexes = {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/ConstructGenomicEntityAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/ConstructGenomicEntityAssociation.java
@@ -37,7 +37,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {EvidenceAssociation.class})
-@Schema(name = "ConstructGenomicEntityAssociation", description = "POJO representing an association between a construct and a genomic entity")
+@Schema(name = "ConstructGenomicEntityAssociation", description = "ConstructGenomicEntityAssociation: a construct genomic entity association")
 
 @Table(indexes = {
 	@Index(columnList = "internal"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/CuratedVariantGenomicLocationAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/CuratedVariantGenomicLocationAssociation.java
@@ -35,7 +35,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(exclude = "predictedVariantConsequences", callSuper = true)
 @AGRCurationSchemaVersion(min = "2.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {VariantGenomicLocationAssociation.class})
-@Schema(name = "CuratedVariantGenomicLocationAssociation", description = "POJO representing an association between a variant and a curated genomic location")
+@Schema(name = "CuratedVariantGenomicLocationAssociation", description = "CuratedVariantGenomicLocationAssociation: a curated variant genomic location association")
 
 @Table(indexes = {
 		@Index(name = "cvgla_internal_index", columnList = "internal"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/ExonGenomicLocationAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/ExonGenomicLocationAssociation.java
@@ -35,7 +35,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { LocationAssociation.class })
-@Schema(name = "ExonGenomicLocationAssociation", description = "POJO representing an association between an exon and a genomic location")
+@Schema(name = "ExonGenomicLocationAssociation", description = "ExonGenomicLocationAssociation: an exon genomic location association")
 
 @Table(indexes = {
 	@Index(columnList = "internal"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/GeneGeneAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/GeneGeneAssociation.java
@@ -24,7 +24,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { EvidenceAssociation.class })
-@Schema(name = "GeneGeneAssociation", description = "POJO representing an association between a gene and a gene")
+@Schema(name = "GeneGeneAssociation", description = "GeneGeneAssociation: a gene gene association")
 public class GeneGeneAssociation extends EvidenceAssociation {
 
 	@IndexedEmbedded(includePaths = {"curie", "geneSymbol.displayText", "geneSymbol.formatText", "geneFullName.displayText", "geneFullName.formatText",

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/GeneGenomicLocationAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/GeneGenomicLocationAssociation.java
@@ -35,7 +35,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { LocationAssociation.class })
-@Schema(name = "GeneGenomicLocationAssociation", description = "POJO representing an association between a gene and a genomic location")
+@Schema(name = "GeneGenomicLocationAssociation", description = "GeneGenomicLocationAssociation: a gene genomic location association")
 
 @Table(indexes = {
 	@Index(name = "geneGenomicLocationAssociation_internal_index", columnList = "internal"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/SequenceTargetingReagentGeneAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/SequenceTargetingReagentGeneAssociation.java
@@ -31,7 +31,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.3.1", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { EvidenceAssociation.class })
-@Schema(name = "SequenceTargetingReagentGeneAssociation", description = "POJO representing an association between an SQTR and a gene")
+@Schema(name = "SequenceTargetingReagentGeneAssociation", description = "SequenceTargetingReagentGeneAssociation: a sequence targeting reagent gene association")
 
 @Table(
 	indexes = {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/TranscriptCodingSequenceAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/TranscriptCodingSequenceAssociation.java
@@ -28,7 +28,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { EvidenceAssociation.class })
-@Schema(name = "TranscriptCodingSequenceAssociation", description = "POJO representing an association between a transcript and a CDS")
+@Schema(name = "TranscriptCodingSequenceAssociation", description = "TranscriptCodingSequenceAssociation: a transcript coding sequence association")
 
 @Table(indexes = {
 	@Index(columnList = "internal"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/TranscriptExonAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/TranscriptExonAssociation.java
@@ -28,7 +28,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { EvidenceAssociation.class })
-@Schema(name = "TranscriptExonAssociation", description = "POJO representing an association between a transcript and an exon")
+@Schema(name = "TranscriptExonAssociation", description = "TranscriptExonAssociation: a transcript exon association")
 
 @Table(indexes = {
 	@Index(columnList = "internal"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/TranscriptGeneAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/TranscriptGeneAssociation.java
@@ -28,7 +28,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { EvidenceAssociation.class })
-@Schema(name = "TranscriptGeneAssociation", description = "POJO representing an association between a transcript and a gene")
+@Schema(name = "TranscriptGeneAssociation", description = "TranscriptGeneAssociation: a transcript gene association")
 
 @Table(indexes = {
 	@Index(name = "TranscriptGeneAssociation_internal_index", columnList = "internal"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/TranscriptGenomicLocationAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/TranscriptGenomicLocationAssociation.java
@@ -37,7 +37,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { LocationAssociation.class })
-@Schema(name = "TranscriptGenomicLocationAssociation", description = "POJO representing an association between a transcript and a genomic location")
+@Schema(name = "TranscriptGenomicLocationAssociation", description = "TranscriptGenomicLocationAssociation: a transcript genomic location association")
 
 @Table(indexes = {
 	@Index(columnList = "internal"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/VariantGenomicLocationAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/VariantGenomicLocationAssociation.java
@@ -33,7 +33,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@AGRCurationSchemaVersion(min = "2.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {VariantLocationAssociation.class})
+@AGRCurationSchemaVersion(min = "2.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { VariantLocationAssociation.class })
 @Schema(name = "VariantGenomicLocationAssociation", description = "POJO representing an association between a variant and a genomic location")
 public abstract class VariantGenomicLocationAssociation extends VariantLocationAssociation {
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/VariantLocationAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/VariantLocationAssociation.java
@@ -33,7 +33,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {LocationAssociation.class})
-@Schema(name = "VariantLocationAssociation", description = "POJO representing an association between a variant and a location")
+@Schema(name = "VariantLocationAssociation", description = "VariantLocationAssociation: a variant location association")
 public abstract class VariantLocationAssociation extends LocationAssociation {
 
 	@IndexedEmbedded(includePaths = {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/base/AuditedObject.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/base/AuditedObject.java
@@ -48,7 +48,7 @@ import lombok.ToString;
 @ToString(exclude = { "createdBy", "updatedBy" })
 @AGRCurationSchemaVersion(min = "1.2.0", max = LinkMLSchemaConstants.LATEST_RELEASE)
 @MappedSuperclass
-@Schema(name = "AuditedObject", description = "POJO that represents the AuditedObject")
+@Schema(name = "AuditedObject", description = "AuditedObject: an audited object")
 public class AuditedObject implements Serializable {
 
 	@Id

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/base/CurieObject.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/base/CurieObject.java
@@ -23,7 +23,7 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.0.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {AuditedObject.class})
-@Schema(name = "CurieObject", description = "POJO that represents the CurieObject")
+@Schema(name = "CurieObject", description = "CurieObject: a curie object")
 public class CurieObject extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/base/SubmittedObject.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/base/SubmittedObject.java
@@ -42,7 +42,7 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.9.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {CurieObject.class})
-@Schema(name = "SubmittedObject", description = "POJO that represents the SubmittedObject")
+@Schema(name = "SubmittedObject", description = "SubmittedObject: a submitted object")
 public class SubmittedObject extends CurieObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkFMSLoad.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkFMSLoad.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.2.4", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { BulkScheduledLoad.class })
-@Schema(name = "BulkFMSLoad", description = "POJO that represents the BulkFMSLoad")
+@Schema(name = "BulkFMSLoad", description = "BulkFMSLoad: a bulk FMS load")
 @JsonTypeName
 public class BulkFMSLoad extends BulkScheduledLoad {
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkGoogleAnalyticsLoad.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkGoogleAnalyticsLoad.java
@@ -16,7 +16,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.13.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { BulkScheduledLoad.class })
-@Schema(name = "BulkGoogleAnalyticsLoad", description = "POJO that represents the BulkLoadGoogleAnalyticsLoad")
+@Schema(name = "BulkGoogleAnalyticsLoad", description = "BulkGoogleAnalyticsLoad: a bulk google analytics load")
 @JsonTypeName
 public class BulkGoogleAnalyticsLoad extends BulkScheduledLoad {
 	

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoad.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoad.java
@@ -32,8 +32,10 @@ import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({ @Type(value = BulkFMSLoad.class, name = "BulkFMSLoad"), @Type(value = BulkURLLoad.class, name = "BulkURLLoad"), @Type(value = BulkManualLoad.class, name = "BulkManualLoad") })
+@Schema(name = "BulkLoad", description = "BulkLoad: a bulk load")
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Data

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoadFile.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoadFile.java
@@ -22,7 +22,9 @@ import jakarta.persistence.Transient;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "BulkLoadFile", description = "BulkLoadFile: a bulk load file")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoadFileException.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoadFileException.java
@@ -21,7 +21,9 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "BulkLoadFileException", description = "BulkLoadFileException: a bulk load file exception")
 @Entity
 @Data
 @AllArgsConstructor

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoadFileHistory.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoadFileHistory.java
@@ -30,7 +30,9 @@ import jakarta.persistence.Transient;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "BulkLoadFileHistory", description = "BulkLoadFileHistory: a bulk load file history")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoadGroup.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoadGroup.java
@@ -14,7 +14,9 @@ import jakarta.persistence.OneToMany;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "BulkLoadGroup", description = "BulkLoadGroup: a bulk load group")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkManualLoad.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkManualLoad.java
@@ -21,7 +21,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.2.4", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { BulkLoad.class })
-@Schema(name = "BulkManualLoad", description = "POJO that represents the BulkManualLoad")
+@Schema(name = "BulkManualLoad", description = "BulkManualLoad: a bulk manual load")
 @JsonTypeName
 public class BulkManualLoad extends BulkLoad {
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkScheduledLoad.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkScheduledLoad.java
@@ -21,7 +21,9 @@ import jakarta.persistence.Transient;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "BulkScheduledLoad", description = "BulkScheduledLoad: a bulk scheduled load")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkURLLoad.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkURLLoad.java
@@ -17,7 +17,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "BulkURLLoad", description = "POJO that represents the BulkURLLoad")
+@Schema(name = "BulkURLLoad", description = "BulkURLLoad: a bulk URL load")
 @AGRCurationSchemaVersion(min = "1.2.4", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { BulkScheduledLoad.class })
 @JsonTypeName
 public class BulkURLLoad extends BulkScheduledLoad {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/curationreports/CurationReport.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/curationreports/CurationReport.java
@@ -22,7 +22,9 @@ import jakarta.persistence.OrderBy;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "CurationReport", description = "CurationReport: a curation report")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/curationreports/CurationReportGroup.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/curationreports/CurationReportGroup.java
@@ -14,7 +14,9 @@ import jakarta.persistence.OneToMany;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "CurationReportGroup", description = "CurationReportGroup: a curation report group")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/curationreports/CurationReportHistory.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/curationreports/CurationReportHistory.java
@@ -18,7 +18,9 @@ import jakarta.persistence.Transient;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "CurationReportHistory", description = "CurationReportHistory: a curation report history")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/APOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/APOTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "APOTerm", description = "APOTerm: an APO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ATPTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ATPTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "ATPTerm", description = "ATPTerm: an ATP term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/AnatomicalTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/AnatomicalTerm.java
@@ -7,7 +7,9 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "AnatomicalTerm", description = "AnatomicalTerm: an anatomical term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/BSPOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/BSPOTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "BSPOTerm", description = "BSPOTerm: a BSPO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/BTOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/BTOTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "BTOTerm", description = "BTOTerm: a BTO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/CHEBITerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/CHEBITerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "CHEBITerm", description = "CHEBITerm: a CHEBI term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/CLTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/CLTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "CLTerm", description = "CLTerm: a CL term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/CMOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/CMOTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "CMOTerm", description = "CMOTerm: a CMO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ChemicalTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ChemicalTerm.java
@@ -16,7 +16,9 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "ChemicalTerm", description = "ChemicalTerm: a chemical term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/DAOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/DAOTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "DAOTerm", description = "DAOTerm: a DAO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/DOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/DOTerm.java
@@ -19,8 +19,10 @@ import jakarta.persistence.OneToMany;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "DOTerm", description = "DOTerm: a DO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ECOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ECOTerm.java
@@ -16,8 +16,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "ECOTerm", description = "ECOTerm: an ECO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/EMAPATerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/EMAPATerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "EMAPATerm", description = "EMAPATerm: an EMAPA term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ExperimentalConditionOntologyTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ExperimentalConditionOntologyTerm.java
@@ -7,7 +7,9 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "ExperimentalConditionOntologyTerm", description = "ExperimentalConditionOntologyTerm: an experimental condition ontology term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/FBCVTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/FBCVTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "FBCVTerm", description = "FBCVTerm: a FBCV term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/FBDVTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/FBDVTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "FBDVTerm", description = "FBDVTerm: a FBDV term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/GENOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/GENOTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "GENOTerm", description = "GENOTerm: a GENO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/GOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/GOTerm.java
@@ -15,8 +15,10 @@ import jakarta.persistence.OneToMany;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "GOTerm", description = "GOTerm: a GO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/HPTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/HPTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "HPTerm", description = "HPTerm: a HP term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/MATerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/MATerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "MATerm", description = "MATerm: a MA term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/MITerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/MITerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "MITerm", description = "MITerm: a MI term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/MMOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/MMOTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "MMOTerm", description = "MMOTerm: a MMO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/MMUSDVTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/MMUSDVTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "MMUSDVTerm", description = "MMUSDVTerm: a MMUSDV term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/MODTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/MODTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "MODTerm", description = "MODTerm: a MOD term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/MPATHTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/MPATHTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "MPATHTerm", description = "MPATHTerm: a MPATH term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/MPTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/MPTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "MPTerm", description = "MPTerm: a MP term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java
@@ -19,8 +19,10 @@ import jakarta.persistence.Transient;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "NCBITaxonTerm", description = "NCBITaxonTerm: a NCBI taxon term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OBITerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OBITerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "OBITerm", description = "OBITerm: an OBI term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
@@ -37,11 +37,13 @@ import jakarta.persistence.UniqueConstraint;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "OntologyTermType", length = 64)
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
+@Schema(name = "OntologyTerm", description = "OntologyTerm: an ontology term")
 @Entity
 @ToString(exclude = { "ancestors", "descendants", "crossReferences", "synonyms", "secondaryIdentifiers", "subsets" }, callSuper = true)
 @AGRCurationSchemaVersion(min = LinkMLSchemaConstants.MIN_ONTOLOGY_RELEASE, max = LinkMLSchemaConstants.MAX_ONTOLOGY_RELEASE, dependencies = { CurieObject.class })

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTermClosure.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTermClosure.java
@@ -14,9 +14,11 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Data
 @ToString(exclude = { "closureSubject", "closureObject" }, callSuper = true)
+@Schema(name = "OntologyTermClosure", description = "OntologyTermClosure: an ontology term closure")
 @Entity
 @Table(indexes = {
 	@Index(name = "ontologyclosure_closureSubject_index", columnList = "closureSubject_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/PATOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/PATOTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "PATOTerm", description = "PATOTerm: a PATO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/PWTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/PWTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "PWTerm", description = "PWTerm: a PW term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/PhenotypeTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/PhenotypeTerm.java
@@ -7,7 +7,9 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "PhenotypeTerm", description = "PhenotypeTerm: a phenotype term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ROTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ROTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "ROTerm", description = "ROTerm: a RO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/RSTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/RSTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "RSTerm", description = "RSTerm: a RS term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/SOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/SOTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "SOTerm", description = "SOTerm: a SO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/StageTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/StageTerm.java
@@ -7,7 +7,9 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(name = "StageTerm", description = "StageTerm: a stage term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/UBERONTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/UBERONTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "UBERONTerm", description = "UBERONTerm: an UBERON term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/VTTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/VTTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "VTTerm", description = "VTTerm: a VT term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/WBBTTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/WBBTTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "WBBTTerm", description = "WBBTTerm: a WBBT term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/WBLSTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/WBLSTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "WBLSTerm", description = "WBLSTerm: a WBLS term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/WBPhenotypeTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/WBPhenotypeTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "WBPhenotypeTerm", description = "WBPhenotypeTerm: a WB phenotype term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/XBATerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/XBATerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "XBATerm", description = "XBATerm: a XBA term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/XBEDTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/XBEDTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "XBEDTerm", description = "XBEDTerm: a XBED term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/XBSTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/XBSTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "XBSTerm", description = "XBSTerm: a XBS term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/XCOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/XCOTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "XCOTerm", description = "XCOTerm: a XCO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/XPOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/XPOTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "XPOTerm", description = "XPOTerm: a XPO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/XSMOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/XSMOTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "XSMOTerm", description = "XSMOTerm: a XSMO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ZECOTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ZECOTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "ZECOTerm", description = "ZECOTerm: a ZECO term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ZFATerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ZFATerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "ZFATerm", description = "ZFATerm: a ZFA term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ZFSTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/ZFSTerm.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Indexed
+@Schema(name = "ZFSTerm", description = "ZFSTerm: a ZFS term")
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/orthology/GeneToGeneOrthology.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/orthology/GeneToGeneOrthology.java
@@ -27,7 +27,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "GeneToGeneOrthology", description = "POJO that represents orthology between two genes")
+@Schema(name = "GeneToGeneOrthology", description = "GeneToGeneOrthology: a gene to gene orthology")
 @AGRCurationSchemaVersion(min = "1.7.4", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObject.class })
 @Table(indexes = {
 	@Index(name = "genetogeneorthology_createdby_index", columnList = "createdBy_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/orthology/GeneToGeneOrthologyCurated.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/orthology/GeneToGeneOrthologyCurated.java
@@ -25,7 +25,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "GeneToGeneOrthologyCurated", description = "POJO that represents curated orthology between two genes")
+@Schema(name = "GeneToGeneOrthologyCurated", description = "GeneToGeneOrthologyCurated: a gene to gene orthology curated")
 @AGRCurationSchemaVersion(min = "1.7.4", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObject.class, GeneToGeneOrthology.class })
 @Table(indexes = {
 	@Index(name = "genetogeneorthologycurated_singlereference_index", columnList = "singlereference_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/orthology/GeneToGeneOrthologyGenerated.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/orthology/GeneToGeneOrthologyGenerated.java
@@ -36,7 +36,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-@Schema(name = "GeneToGeneOrthologyGenerated", description = "POJO that represents generated orthology between two genes")
+@Schema(name = "GeneToGeneOrthologyGenerated", description = "GeneToGeneOrthologyGenerated: a gene to gene orthology generated")
 @AGRCurationSchemaVersion(min = "1.7.4", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObject.class, GeneToGeneOrthology.class })
 @Table(indexes = {
 	@Index(name = "genetogeneorthologygenerated_isbestscore_index", columnList = "isbestscore_id"),

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AgmFullNameSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AgmFullNameSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.12.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { NameSlotAnnotation.class })
-@Schema(name = "AgmFullNameSlotAnnotation", description = "POJO representing an AGM full name slot annotation")
+@Schema(name = "AgmFullNameSlotAnnotation", description = "AgmFullNameSlotAnnotation: an agm full name slot annotation")
 public class AgmFullNameSlotAnnotation extends NameSlotAnnotation {
 
 	@OneToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AgmSecondaryIdSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AgmSecondaryIdSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {SlotAnnotation.class})
-@Schema(name = "AgmSecondaryIdSlotAnnotation", description = "POJO representing an AGM secondary ID slot annotation")
+@Schema(name = "AgmSecondaryIdSlotAnnotation", description = "AgmSecondaryIdSlotAnnotation: an agm secondary id slot annotation")
 public class AgmSecondaryIdSlotAnnotation extends SecondaryIdSlotAnnotation {
 
 	@ManyToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AgmSynonymSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AgmSynonymSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "2.12.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { NameSlotAnnotation.class })
-@Schema(name = "GeneSynonymSlotAnnotation", description = "POJO representing an AGM synonym slot annotation")
+@Schema(name = "GeneSynonymSlotAnnotation", description = "AgmSynonymSlotAnnotation: an agm synonym slot annotation")
 public class AgmSynonymSlotAnnotation extends NameSlotAnnotation {
 
 	@ManyToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleDatabaseStatusSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleDatabaseStatusSlotAnnotation.java
@@ -25,7 +25,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.5.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { SlotAnnotation.class })
-@Schema(name = "AlleleDatabaseStatusSlotAnnotation", description = "POJO representing an allele database status slot annotation")
+@Schema(name = "AlleleDatabaseStatusSlotAnnotation", description = "AlleleDatabaseStatusSlotAnnotation: an allele database status slot annotation")
 public class AlleleDatabaseStatusSlotAnnotation extends SlotAnnotation {
 
 	@OneToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleFullNameSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleFullNameSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.5.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { NameSlotAnnotation.class })
-@Schema(name = "AlleleFullNameSlotAnnotation", description = "POJO representing an allele full name slot annotation")
+@Schema(name = "AlleleFullNameSlotAnnotation", description = "AlleleFullNameSlotAnnotation: an allele full name slot annotation")
 public class AlleleFullNameSlotAnnotation extends NameSlotAnnotation {
 
 	@OneToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleFunctionalImpactSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleFunctionalImpactSlotAnnotation.java
@@ -39,7 +39,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.5.1", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { SlotAnnotation.class })
-@Schema(name = "AlleleFunctionalImpactSlotAnnotation", description = "POJO representing an allele functional impact slot annotation")
+@Schema(name = "AlleleFunctionalImpactSlotAnnotation", description = "AlleleFunctionalImpactSlotAnnotation: an allele functional impact slot annotation")
 public class AlleleFunctionalImpactSlotAnnotation extends SlotAnnotation {
 
 	@ManyToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleGermlineTransmissionStatusSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleGermlineTransmissionStatusSlotAnnotation.java
@@ -24,7 +24,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { SlotAnnotation.class })
-@Schema(name = "AlleleGermlineTransmissionStatusSlotAnnotation", description = "POJO representing an allele germline transmission status slot annotation")
+@Schema(name = "AlleleGermlineTransmissionStatusSlotAnnotation", description = "AlleleGermlineTransmissionStatusSlotAnnotation: an allele germline transmission status slot annotation")
 public class AlleleGermlineTransmissionStatusSlotAnnotation extends SlotAnnotation {
 
 	@ManyToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleInheritanceModeSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleInheritanceModeSlotAnnotation.java
@@ -31,7 +31,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.5.1", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { SlotAnnotation.class })
-@Schema(name = "AlleleInheritanceModeSlotAnnotation", description = "POJO representing an allele inheritance mode slot annotation")
+@Schema(name = "AlleleInheritanceModeSlotAnnotation", description = "AlleleInheritanceModeSlotAnnotation: an allele inheritance mode slot annotation")
 public class AlleleInheritanceModeSlotAnnotation extends SlotAnnotation {
 
 	@ManyToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleMutationTypeSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleMutationTypeSlotAnnotation.java
@@ -32,7 +32,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { SlotAnnotation.class })
-@Schema(name = "AlleleMutationtTypeSlotAnnotation", description = "POJO representing an allele mutation type slot annotation")
+@Schema(name = "AlleleMutationtTypeSlotAnnotation", description = "AlleleMutationTypeSlotAnnotation: an allele mutation type slot annotation")
 public class AlleleMutationTypeSlotAnnotation extends SlotAnnotation {
 
 	@ManyToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleNomenclatureEventSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleNomenclatureEventSlotAnnotation.java
@@ -24,7 +24,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.5.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { SlotAnnotation.class })
-@Schema(name = "AlleleNomenclatureSlotAnnotation", description = "POJO representing an allele nomenclature event slot annotation")
+@Schema(name = "AlleleNomenclatureSlotAnnotation", description = "AlleleNomenclatureEventSlotAnnotation: an allele nomenclature event slot annotation")
 public class AlleleNomenclatureEventSlotAnnotation extends SlotAnnotation {
 
 	@ManyToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleSecondaryIdSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleSecondaryIdSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.4.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { SlotAnnotation.class })
-@Schema(name = "AlleleSecondaryIdSlotAnnotation", description = "POJO representing an allele secondary ID slot annotation")
+@Schema(name = "AlleleSecondaryIdSlotAnnotation", description = "AlleleSecondaryIdSlotAnnotation: an allele secondary id slot annotation")
 public class AlleleSecondaryIdSlotAnnotation extends SecondaryIdSlotAnnotation {
 
 	@ManyToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleSymbolSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleSymbolSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.5.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { NameSlotAnnotation.class })
-@Schema(name = "AlleleSymbolSlotAnnotation", description = "POJO representing an allele symbol slot annotation")
+@Schema(name = "AlleleSymbolSlotAnnotation", description = "AlleleSymbolSlotAnnotation: an allele symbol slot annotation")
 public class AlleleSymbolSlotAnnotation extends NameSlotAnnotation {
 
 	@OneToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleSynonymSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/AlleleSynonymSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.5.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { NameSlotAnnotation.class })
-@Schema(name = "AlleleSynonymSlotAnnotation", description = "POJO representing an allele synonym slot annotation")
+@Schema(name = "AlleleSynonymSlotAnnotation", description = "AlleleSynonymSlotAnnotation: an allele synonym slot annotation")
 public class AlleleSynonymSlotAnnotation extends NameSlotAnnotation {
 
 	@ManyToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/ConstructComponentSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/ConstructComponentSlotAnnotation.java
@@ -40,7 +40,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.10.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {SlotAnnotation.class})
-@Schema(name = "ConstructComponentSlotAnnotation", description = "POJO representing a construct component slot annotation")
+@Schema(name = "ConstructComponentSlotAnnotation", description = "ConstructComponentSlotAnnotation: a construct component slot annotation")
 public class ConstructComponentSlotAnnotation extends SlotAnnotation {
 
 	@ManyToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/ConstructFullNameSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/ConstructFullNameSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.10.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { NameSlotAnnotation.class })
-@Schema(name = "ConstructFullNameSlotAnnotation", description = "POJO representing a construct full name slot annotation")
+@Schema(name = "ConstructFullNameSlotAnnotation", description = "ConstructFullNameSlotAnnotation: a construct full name slot annotation")
 public class ConstructFullNameSlotAnnotation extends NameSlotAnnotation {
 
 	@OneToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/ConstructSymbolSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/ConstructSymbolSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.10.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { NameSlotAnnotation.class })
-@Schema(name = "ConstructSymbolSlotAnnotation", description = "POJO representing a construct symbol slot annotation")
+@Schema(name = "ConstructSymbolSlotAnnotation", description = "ConstructSymbolSlotAnnotation: a construct symbol slot annotation")
 public class ConstructSymbolSlotAnnotation extends NameSlotAnnotation {
 
 	@OneToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/ConstructSynonymSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/ConstructSynonymSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.10.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { NameSlotAnnotation.class })
-@Schema(name = "ConstructSynonymSlotAnnotation", description = "POJO representing a construct synonym slot annotation")
+@Schema(name = "ConstructSynonymSlotAnnotation", description = "ConstructSynonymSlotAnnotation: a construct synonym slot annotation")
 public class ConstructSynonymSlotAnnotation extends NameSlotAnnotation {
 
 	@ManyToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/GeneFullNameSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/GeneFullNameSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.5.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { NameSlotAnnotation.class })
-@Schema(name = "GeneFullNameSlotAnnotation", description = "POJO representing a gene full name slot annotation")
+@Schema(name = "GeneFullNameSlotAnnotation", description = "GeneFullNameSlotAnnotation: a gene full name slot annotation")
 public class GeneFullNameSlotAnnotation extends NameSlotAnnotation {
 
 	@OneToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/GeneSecondaryIdSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/GeneSecondaryIdSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.7.2", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { SlotAnnotation.class })
-@Schema(name = "GeneSecondaryIdSlotAnnotation", description = "POJO representing a gene secondary ID slot annotation")
+@Schema(name = "GeneSecondaryIdSlotAnnotation", description = "GeneSecondaryIdSlotAnnotation: a gene secondary id slot annotation")
 public class GeneSecondaryIdSlotAnnotation extends SecondaryIdSlotAnnotation {
 
 	@ManyToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/GeneSymbolSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/GeneSymbolSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.5.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { NameSlotAnnotation.class })
-@Schema(name = "GeneSymbolSlotAnnotation", description = "POJO representing a gene symbol slot annotation")
+@Schema(name = "GeneSymbolSlotAnnotation", description = "GeneSymbolSlotAnnotation: a gene symbol slot annotation")
 public class GeneSymbolSlotAnnotation extends NameSlotAnnotation {
 
 	@OneToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/GeneSynonymSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/GeneSynonymSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.5.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { NameSlotAnnotation.class })
-@Schema(name = "GeneSynonymSlotAnnotation", description = "POJO representing a gene synonym slot annotation")
+@Schema(name = "GeneSynonymSlotAnnotation", description = "GeneSynonymSlotAnnotation: a gene synonym slot annotation")
 public class GeneSynonymSlotAnnotation extends NameSlotAnnotation {
 
 	@ManyToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/GeneSystematicNameSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/GeneSystematicNameSlotAnnotation.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.5.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { NameSlotAnnotation.class })
-@Schema(name = "GeneSystematicNameSlotAnnotation", description = "POJO representing a gene systematic name slot annotation")
+@Schema(name = "GeneSystematicNameSlotAnnotation", description = "GeneSystematicNameSlotAnnotation: a gene systematic name slot annotation")
 public class GeneSystematicNameSlotAnnotation extends NameSlotAnnotation {
 
 	@OneToOne

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/NameSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/NameSlotAnnotation.java
@@ -30,7 +30,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.5.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { SlotAnnotation.class })
-@Schema(name = "NameSlotAnnotation", description = "POJO representing a name slot annotation")
+@Schema(name = "NameSlotAnnotation", description = "NameSlotAnnotation: a name slot annotation")
 public abstract class NameSlotAnnotation extends SlotAnnotation {
 
 	@IndexedEmbedded(includeDepth = 1)

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/SecondaryIdSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/SecondaryIdSlotAnnotation.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @AGRCurationSchemaVersion(min = "1.7.2", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { SlotAnnotation.class })
-@Schema(name = "SecondaryIdSlotAnnotation", description = "POJO representing a scondary ID slot annotation")
+@Schema(name = "SecondaryIdSlotAnnotation", description = "SecondaryIdSlotAnnotation: a secondary id slot annotation")
 public abstract class SecondaryIdSlotAnnotation extends SlotAnnotation {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/SlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/SlotAnnotation.java
@@ -31,7 +31,7 @@ import lombok.ToString;
 @Entity
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
-@Schema(name = "SlotAnnotation", description = "POJO that represents a SlotAnnotation")
+@Schema(name = "SlotAnnotation", description = "SlotAnnotation: a slot annotation")
 @ToString(callSuper = true)
 @Table(indexes = {
 	@Index(name = "slotannotation_createdby_index", columnList = "createdBy_id"),

--- a/src/main/java/org/alliancegenome/curation_api/response/APIResponse.java
+++ b/src/main/java/org/alliancegenome/curation_api/response/APIResponse.java
@@ -14,17 +14,24 @@ import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Data;
 
 @Data
+@org.eclipse.microprofile.openapi.annotations.media.Schema(name = "APIResponse", description = "APIResponse: base response wrapper containing error and warning messages common to all API responses")
 public class APIResponse {
 
+	@org.eclipse.microprofile.openapi.annotations.media.Schema(description = "Single error message if the request failed")
 	@JsonView({ CurationView.FieldsOnly.class }) private String errorMessage;
+	@org.eclipse.microprofile.openapi.annotations.media.Schema(description = "Single warning message for non-fatal issues")
 	@JsonView({ CurationView.FieldsOnly.class }) private String warningMessage;
 
+	@org.eclipse.microprofile.openapi.annotations.media.Schema(description = "Field-level error messages keyed by field name")
 	@JsonView({ CurationView.FieldsOnly.class }) private Map<String, String> errorMessages;
+	@org.eclipse.microprofile.openapi.annotations.media.Schema(description = "Field-level warning messages keyed by field name")
 	@JsonView({ CurationView.FieldsOnly.class }) private Map<String, String> warningMessages;
 
+	@org.eclipse.microprofile.openapi.annotations.media.Schema(description = "Additional supplemental data returned with the response")
 	@org.eclipse.microprofile.graphql.Ignore
 	@JsonView({ CurationView.FieldsOnly.class }) private Map<String, Object> supplementalData = new HashMap<>();
 
+	@org.eclipse.microprofile.openapi.annotations.media.Schema(description = "Time taken to process the request")
 	@JsonView({ CurationView.FieldsOnly.class }) private String requestDuration;
 
 	

--- a/src/main/java/org/alliancegenome/curation_api/response/ObjectListResponse.java
+++ b/src/main/java/org/alliancegenome/curation_api/response/ObjectListResponse.java
@@ -16,9 +16,10 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Schema(name = "ObjectListResponse", description = "POJO that represents the Object List Response")
+@Schema(name = "ObjectListResponse", description = "ObjectListResponse: wraps a list of entities with error/warning messages. The 'entities' field contains the returned list.")
 public class ObjectListResponse<E> extends APIResponse {
 
+	@Schema(description = "The list of returned entity objects")
 	@JsonView(CurationView.FieldsOnly.class)
 	private List<E> entities;
 

--- a/src/main/java/org/alliancegenome/curation_api/response/ObjectResponse.java
+++ b/src/main/java/org/alliancegenome/curation_api/response/ObjectResponse.java
@@ -12,9 +12,10 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Schema(name = "ObjectResponse", description = "POJO that represents the ObjectResponse")
+@Schema(name = "ObjectResponse", description = "ObjectResponse: wraps a single entity with error/warning messages. The 'entity' field contains the returned object.")
 public class ObjectResponse<E> extends APIResponse {
 
+	@Schema(description = "The returned entity object")
 	@JsonView({ CurationView.FieldsOnly.class, CurationView.PersonSettingView.class })
 	private E entity;
 	

--- a/src/main/java/org/alliancegenome/curation_api/response/SearchResponse.java
+++ b/src/main/java/org/alliancegenome/curation_api/response/SearchResponse.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Data;
 
 @Data
-@Schema(name = "SearchResponse", description = "POJO that represents the SearchResponse")
+@Schema(name = "SearchResponse", description = "SearchResponse: wraps paginated search results with metadata. The 'results' field contains matching entities, with totalResults, returnedRecords, and aggregations for pagination.")
 @JsonView({
 	CurationView.FieldsOnly.class,
 	CurationView.ForPublic.class,
@@ -33,16 +33,24 @@ import lombok.Data;
 })
 public class SearchResponse<E> extends APIResponse {
 
+	@Schema(description = "The list of matching entity objects")
 	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 	private List<E> results = new ArrayList<>();
 
+	@Schema(description = "Total number of matching results across all pages")
 	private Long totalResults;
+	@Schema(description = "Number of records returned in this page")
 	private Integer returnedRecords;
+	@Schema(description = "Faceted aggregation counts keyed by field name")
 	private Map<String, Map<String, Long>> aggregations;
+	@Schema(description = "Debug information for the search query")
 	private String debug;
+	@Schema(description = "The generated Elasticsearch/OpenSearch query")
 	private String esQuery;
+	@Schema(description = "The generated database query")
 	private String dbQuery;
-	private Long nextCursor; // For cursor-based pagination
+	@Schema(description = "Cursor value for fetching the next page of results")
+	private Long nextCursor;
 
 	public SearchResponse() {
 	}

--- a/src/main/resources/application.properties.defaults
+++ b/src/main/resources/application.properties.defaults
@@ -11,7 +11,8 @@ quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.doc-expansion=none
 quarkus.health.openapi.included=true
 quarkus.smallrye-graphql.ui.always-include=true
-mp.openapi.extensions.smallrye.maximumStaticFileSize=4194304
+mp.openapi.extensions.smallrye.maximumStaticFileSize=52428800
+mp.openapi.filter=org.alliancegenome.curation_api.config.OpenApiSchemaFilter
 
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=postgres


### PR DESCRIPTION
## Background

This is a long-standing issue (SCRUM-2479, opened Jan 2023) where the Curation Swagger UI pages are slow and frequently time out when expanding endpoint details.

**Root cause:** Deep nesting of objects in the entity hierarchy, compounded by SmallRye OpenAPI generating all JSON views as part of the schema nesting, creating excessive schema complexity that crashes the browser.

**Prior attempts that did NOT resolve it:**
- Quarkus upgrade (SCRUM-2814) — no improvement
- GitHub issue filed with SmallRye upstream (SCRUM-2609) — no upstream fix
- Investigation and outreach to SmallRye developers (SCRUM-3469)
- Stop-gap: schemas were turned off entirely in Swagger UI (SCRUM-3740) — made the page functional but removed all schema documentation

**This PR** provides a proper fix by adding an `OASFilter` that breaks circular `$ref` chains and limits schema depth, while also adding comprehensive OpenAPI documentation (`@Schema`, `@Operation`, `@Parameter`, `@APIResponse`, `@ExampleObject`) to all entities and controllers.

## Summary
- Add `OpenApiSchemaFilter` (OASFilter) that breaks circular `$ref` chains, limits schema depth, cleans SmallRye cyclic reference descriptions, and propagates CRUD tags to search/find endpoints for proper Swagger UI grouping
- Add `@Schema` annotations with descriptions to all 180+ entity classes using `ClassName: a camelCase description` format with proper a/an articles
- Add `@Operation`, `@Parameter`, `@APIResponse` documentation to all 13 base controller interfaces and 104 methods across 70 concrete controller interfaces
- Add `@ExampleObject` with structured JSON examples to `/search`, `/find`, and `/findForPublic` endpoints based on SEARCH.md and FIND.md documentation
- Add `@Schema` descriptions to response wrapper fields (`ObjectResponse`, `ObjectListResponse`, `SearchResponse`, `APIResponse`)
- Increase `maximumStaticFileSize` to 50MB to accommodate larger generated spec

## Related
- [SCRUM-2479](https://agr-jira.atlassian.net/browse/SCRUM-2479)
- [SCRUM-2814](https://agr-jira.atlassian.net/browse/SCRUM-2814) — Quarkus upgrade (did not fix)
- [SCRUM-2609](https://agr-jira.atlassian.net/browse/SCRUM-2609) — SmallRye upstream issue
- [SCRUM-3469](https://agr-jira.atlassian.net/browse/SCRUM-3469) — SmallRye developer outreach
- [SCRUM-3740](https://agr-jira.atlassian.net/browse/SCRUM-3740) — Stop-gap (schemas turned off)

## Test plan
- [ ] Verify Swagger UI loads without hanging or excessive lag
- [ ] Verify `/search` endpoints show structured example JSON in the Example Value pane
- [ ] Verify `/find` and `/findForPublic` endpoints show example JSON in the Example Value pane
- [ ] Verify search/find endpoints appear under both their browsing category tag and their entity's CRUD tag
- [ ] Verify entity schema descriptions appear correctly in Swagger UI (e.g. "Gene: a gene")
- [ ] Verify links to SEARCH.md and FIND.md render correctly in endpoint descriptions
- [ ] Verify response wrapper fields (entity, entities, results, totalResults, etc.) have descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-2479]: https://agr-jira.atlassian.net/browse/SCRUM-2479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ