### PR TITLE
Fix silent drops: provide explicit prompt for issue_comment events

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -454,6 +454,23 @@ jobs:
             Do NOT just output text - you must use the gh command to post your review to the PR.
             ', github.repository, github.event.pull_request.number) || '' }}
 
+            ${{ github.event_name == 'issue_comment' && format('
+            REPO: {0}
+            PR NUMBER: {1}
+
+            A user has commented on this PR requesting your assistance.
+
+            START by reading their comment: gh pr view {1} --comments --json comments --jq ".comments[-1].body"
+            Then check the PR diff: git diff origin/alpha...HEAD
+
+            If they are asking for a review or check, perform a full code review of the changes.
+
+            IMPORTANT: You MUST post your response as a GitHub PR comment using:
+            gh pr comment {1} --body "YOUR_RESPONSE_HERE"
+
+            Do NOT just output text - you must use the gh command to post your response to the PR.
+            ', github.repository, github.event.issue.number) || '' }}
+
           # CLI arguments (v1 format)
           claude_args: |
             --model ${{ vars.CLAUDE_PR_REVIEW_MODEL }}


### PR DESCRIPTION
## Summary

For `issue_comment` events (when users comment `@claude` on a PR), the `prompt:` field in the Claude Code Action was empty because it only had a `pull_request` format block. This caused Claude to receive no user message, leading to stochastic silent drops where Claude would output a generic greeting instead of performing the requested review or task.

## Changes

- Added an explicit `issue_comment` format block to the `prompt:` field in `.github/workflows/claude-code-review.yml`
- The new block instructs Claude to read the user's comment, check the PR diff, and respond via `gh pr comment`
- Follows the same `format()` pattern and escaping conventions as the existing `pull_request` block

## Test plan

- [ ] Open a PR targeting `alpha`
- [ ] Comment `@claude Please review my changes` on the PR
- [ ] Verify Claude reads the comment and posts a substantive review (not a generic greeting)
- [ ] Verify automated PR open reviews still work as before (the `pull_request` block is unchanged)