### PR TITLE
fix: change SearchResponse.returnedRecords from Integer to long

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/response/SearchResponse.java
+++ b/src/main/java/org/alliancegenome/curation_api/response/SearchResponse.java
@@ -38,7 +38,9 @@ public class SearchResponse<E> extends APIResponse {
 	private List<E> results = new ArrayList<>();
 
 	private long totalResults;
-	private Integer returnedRecords;
+	@Schema(description = "Number of records returned in this page")
+	private long returnedRecords;
+	@Schema(description = "Faceted aggregation counts keyed by field name")
 	private Map<String, Map<String, Long>> aggregations;
 	private String debug;
 	private String esQuery;


### PR DESCRIPTION
## Summary
- Changes `SearchResponse.returnedRecords` from `Integer` (boxed) to `long` (primitive)
- Fixes NullPointerException in the indexer when `getReturnedRecords()` returns null and `.longValue()` is called on it
- This NPE has been crashing IndexerStage repeatedly (10+ consecutive failures)

## Test plan
- [ ] Verify agr_curation compiles
- [ ] Verify agr_java_software compiles against updated artifact
- [ ] Run IndexerStage and confirm it no longer crashes on transgenic allele indexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)