### PR TITLE
release/v0.46.13: Add SequenceSummaryDocument fields for curated alleles

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/SequenceSummaryDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/SequenceSummaryDocument.java
@@ -25,5 +25,8 @@ public class SequenceSummaryDocument extends ESDocument {
 	private CuratedVariantGenomicLocationAssociation variant;
 	private PredictedVariantConsequence consequence;
 	private HashSet<String> geneIds;
+	private String sequenceSummaryCategory;
+	private Boolean hasPhenotype;
+	private Boolean hasDisease;
 
 }


### PR DESCRIPTION
## Summary
- Add `sequenceSummaryCategory`, `hasPhenotype`, `hasDisease` fields to `SequenceSummaryDocument`
- Supports SCRUM-4758: passing curated alleles to the GeneAlleleDetailsTable alongside HTP variant data

## Test plan
- Build: `mvn clean install -DskipTests` passes
- Verified new fields are used by `AlleleSequenceSummaryConverter` in agr_java_software