### PR TITLE
release/v0.46.15

### DIFF
--- a/.github/workflows/github-release-build-and-deploy.yml
+++ b/.github/workflows/github-release-build-and-deploy.yml
@@ -55,6 +55,12 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+      - name: Slack Notification
+        uses: tokorom/action-slack-incoming-webhook@main
+        env:
+          INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          text: "Publication of ${{ github.event.release.tag_name }} to Maven Central completed! :tada:"
   generate-deployment-package:
     needs: [build-release-image]
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- Add Slack notification when Maven Central package publication completes in the release deployment workflow

## Changes
- Added Slack notification step to `build-deploy-maven-central-package` job in `github-release-build-and-deploy.yml`, matching the existing pattern used by deploy-to-production and deploy-to-beta jobs