### PR TITLE
SCRUM-5803: Update logs server link to new log viewer

### DIFF
--- a/src/main/cliapp/src/containers/layout/SiteLayout.js
+++ b/src/main/cliapp/src/containers/layout/SiteLayout.js
@@ -399,7 +399,7 @@ export const SiteLayout = (props) => {
 						{
 							label: 'Logs Server UI',
 							icon: 'pi pi-fw pi-home',
-							url: `http://logs.alliancegenome.org:5601/app/logtrail#/?q=*&h=agr.curation.${apiVersion?.env}.api.server&t=Now&i=logstash*&_g=()`,
+							url: `https://logs.alliancegenome.org/?service=agr.curation.${apiVersion?.env}.api.server`,
 							target: '_blank',
 						},
 						{


### PR DESCRIPTION
## Summary
- Updates the "Logs Server UI" link in the curation UI sidebar from the old Kibana/LogTrail URL (`http://logs.alliancegenome.org:5601/...`) to the new AGR log viewer (`https://logs.alliancegenome.org/?service=...`)
- Uses the new `?service=` URL parameter to pre-select the curation API server for the current environment

## Before
```
http://logs.alliancegenome.org:5601/app/logtrail#/?q=*&h=agr.curation.${env}.api.server&t=Now&i=logstash*&_g=()
```

## After
```
https://logs.alliancegenome.org/?service=agr.curation.${env}.api.server
```

## Test plan
- [ ] Click "Logs Server UI" from the curation UI menu and verify it opens the new log viewer with the correct service pre-selected