### PR TITLE
release/v0.46.16: Add alterationType to SequenceSummaryDocument

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/SequenceSummaryDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/SequenceSummaryDocument.java
@@ -26,6 +26,8 @@ public class SequenceSummaryDocument extends ESDocument {
 	private PredictedVariantConsequence consequence;
 	private HashSet<String> geneIds;
 	private String sequenceSummaryCategory;
+	private String alterationType;
+	private Integer alterationTypeSortOrder;
 	private Boolean hasPhenotype;
 	private Boolean hasDisease;
 


### PR DESCRIPTION
## Summary
- Adds `alterationType` (String) and `alterationTypeSortOrder` (Integer) fields to `SequenceSummaryDocument`
- Required by SCRUM-4854 for the allele category filter and default sort on the allele-variant-detail page
- Fields are inherited from the class-level `@JsonView(CurationView.SequenceSummaryDocument.class)` annotation

## Test plan
- [ ] Build succeeds: `mvn clean install -DskipTests`
- [ ] Fields serialize correctly when AlleleSequenceSummaryConverter populates them (agr_java_software change)