### PR TITLE
Update actions permission to write for auto-retry support

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write  # Required for OIDC
-      actions: read  # Required for reading CI results
+      actions: write  # Required for CI results and auto-retry via run rerun
     runs-on: ubuntu-latest
     timeout-minutes: 30  # Match OIDC session duration to prevent hanging reviews
     


### PR DESCRIPTION
## Summary
- Update `actions: read` → `actions: write` in Claude Code Review caller workflow
- Required for the auto-retry mechanism which uses `gh run rerun` API (see alliance-genome/.github#7)

## Test plan
- [ ] Merge alliance-genome/.github#7 first
- [ ] Merge this PR
- [ ] Verify auto-retry works on next silent drop