### PR TITLE
SCRUM-4854 fix SequenceSummaryDocument JsonView for allele-variant-detail

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Allele.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Allele.java
@@ -150,7 +150,7 @@ public class Allele extends GenomicEntity {
 	)
 	@OneToMany(mappedBy = "singleAllele", cascade = CascadeType.ALL, orphanRemoval = true)
 	@JsonManagedReference
-	@JsonView({ CurationView.FieldsAndLists.class, CurationView.AlleleView.class, CurationView.AlleleDetailView.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class })
+	@JsonView({ CurationView.FieldsAndLists.class, CurationView.AlleleView.class, CurationView.AlleleDetailView.class, CurationView.AlleleSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.ForPublic.class })
 	private List<AlleleSynonymSlotAnnotation> alleleSynonyms;
 
 	@IndexedEmbedded(includePaths = { "secondaryId", "evidence.curie", "secondaryId_keyword"})


### PR DESCRIPTION
## Summary
- Add `CurationView.SequenceSummaryDocument` to `@JsonView` on `alleleSynonyms` field in `Allele.java`
- This causes synonyms to be included in sequence_summary ES documents used by the allele-variant-detail table
- May find additional fields that need the same fix as we continue testing

## Test plan
- Reindex after merge
- Verify allele synonyms appear in allele-variant-detail table on gene pages