### PR TITLE
Release/v0.46.19

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Allele.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Allele.java
@@ -148,7 +148,7 @@ public class Allele extends GenomicEntity {
 	)
 	@OneToMany(mappedBy = "singleAllele", cascade = CascadeType.ALL, orphanRemoval = true)
 	@JsonManagedReference
-	@JsonView({ CurationView.FieldsAndLists.class, CurationView.AlleleView.class, CurationView.AlleleDetailView.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class })
+	@JsonView({ CurationView.FieldsAndLists.class, CurationView.AlleleView.class, CurationView.AlleleDetailView.class, CurationView.AlleleSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.ForPublic.class })
 	private List<AlleleSynonymSlotAnnotation> alleleSynonyms;
 
 	@IndexedEmbedded(includePaths = { "secondaryId", "evidence.curie", "secondaryId_keyword", "evidence.curie_keyword"})


### PR DESCRIPTION
## Summary
- Add `CurationView.SequenceSummaryDocument` to `@JsonView` on `alleleSynonyms` in `Allele.java`
- Fixes synonyms being excluded from sequence_summary ES documents used by the allele-variant-detail table
- May add additional JsonView fixes to this release as testing continues

## Test plan
- Reindex after deploy
- Verify allele synonyms appear in allele-variant-detail table on gene pages