### PR TITLE
fix: populate gene symbol for variant transcript genes in AlleleSummaryDocument

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
@@ -454,7 +454,9 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 				ot_tt.name as transcript_type,
 				pvc.genelevelconsequence,
 				be_g.primaryexternalid as gene_id,
-				cvg.id as cvg_id
+				cvg.id as cvg_id,
+				sa_g.displaytext as gene_symbol,
+				sa_g.formattext as gene_symbol_format
 			FROM allelevariantassociation ava
 				JOIN variant v ON v.id = ava.allelevariantassociationobject_id
 				JOIN ontologyterm o ON o.id = v.varianttype_id
@@ -471,6 +473,7 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 				LEFT JOIN ontologyterm ot_tt ON ot_tt.id = t.transcripttype_id
 				LEFT JOIN transcriptgeneassociation tga ON tga.transcriptassociationsubject_id = t.id
 				LEFT JOIN biologicalentity be_g ON be_g.id = tga.transcriptgeneassociationobject_id
+				LEFT JOIN slotannotation sa_g ON sa_g.singlegene_id = be_g.id AND sa_g.slotannotationtype = 'GeneSymbolSlotAnnotation'
 				WHERE ava.alleleassociationsubject_id IN :alleleIds
 			AND ava.obsolete = false AND ava.internal = false
 			""";
@@ -557,6 +560,12 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 					if (row[19] != null) {
 						Gene gene = new Gene();
 						gene.setPrimaryExternalId((String) row[19]);
+						if (row[21] != null) {
+							GeneSymbolSlotAnnotation annotation = new GeneSymbolSlotAnnotation();
+							annotation.setDisplayText((String) row[21]);
+							annotation.setFormatText((String) row[22]);
+							gene.setGeneSymbol(annotation);
+						}
 						TranscriptGeneAssociation tga = new TranscriptGeneAssociation();
 						tga.setTranscriptGeneAssociationObject(gene);
 						transcript.setTranscriptGeneAssociations(List.of(tga));

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/CuratedVariantGenomicLocationAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/CuratedVariantGenomicLocationAssociation.java
@@ -120,6 +120,7 @@ public class CuratedVariantGenomicLocationAssociation extends VariantGenomicLoca
 				.collect(Collectors.toList());
 	}
 
+	@Deprecated
 	@Transient
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	@JsonView({CurationView.VariantSummaryDocument.class})
@@ -140,7 +141,10 @@ public class CuratedVariantGenomicLocationAssociation extends VariantGenomicLoca
 				})
 				.flatMap(Collection::stream)
 				.distinct()
-				.sorted(Comparator.comparing(gene -> gene.getGeneSymbol().getDisplayText()))
+				.sorted(Comparator.comparing(
+						gene -> gene.getGeneSymbol() != null ? gene.getGeneSymbol().getDisplayText() : null,
+						Comparator.nullsLast(Comparator.naturalOrder())
+				))
 				.collect(Collectors.toList());
 	}
 


### PR DESCRIPTION
## Summary
- Fixed NPE in AlleleSummary indexer caused by null geneSymbol on Gene objects in transcriptGeneAssociations
- AlleleDAO native SQL query now JOINs slotannotation to fetch gene symbol displayText/formatText
- Deprecated `getOverlapGenes()` on CuratedVariantGenomicLocationAssociation and made its comparator null-safe

## Root Cause
The AlleleDAO.enrichAllelesAndBuildDTOs() native query constructed Gene objects for variant transcript gene associations with only `primaryExternalId` — never fetching the gene symbol. When Jackson serialized AlleleSummaryDocument and called `getOverlapGenes()`, the comparator invoked `gene.getGeneSymbol().getDisplayText()` on genes with null geneSymbol, causing NPE for alleles with 2+ distinct overlap genes.

## Test plan
- Run TestSynonyms (agr_java_software) with allele ID 6277 against local curation API — should no longer NPE
- Verify AlleleSummary indexer completes without errors on stage