### PR TITLE
release/v0.46.29: SCRUM-4854 intron/exon location + Transcript.name JsonView

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
@@ -585,6 +585,71 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 			}
 		}
 
+		// Intron/Exon location computation
+		Map<Long, PredictedVariantConsequence> pvcById = new HashMap<>();
+		for (Map<Long, Variant> variantMap : alleleVariantMap.values()) {
+			for (Variant v : variantMap.values()) {
+				for (CuratedVariantGenomicLocationAssociation loc : v.getCuratedVariantGenomicLocations()) {
+					for (PredictedVariantConsequence pvc : loc.getPredictedVariantConsequences()) {
+						if (pvc.getId() != null && pvc.getVariantTranscript() != null) {
+							pvcById.put(pvc.getId(), pvc);
+						}
+					}
+				}
+			}
+		}
+
+		if (!pvcById.isEmpty()) {
+			String intronExonQueryString = """
+				WITH exon_data AS (
+					SELECT pvc.id as pvc_id,
+						cvg.start as vstart,
+						egla.start as estart, egla.end as eend,
+						egla.strand,
+						COUNT(*) OVER (PARTITION BY pvc.id) as total_exons,
+						CASE WHEN egla.strand = '-'
+							THEN ROW_NUMBER() OVER (PARTITION BY pvc.id ORDER BY egla.start DESC)
+							ELSE ROW_NUMBER() OVER (PARTITION BY pvc.id ORDER BY egla.start ASC)
+						END as exon_num,
+						CASE WHEN cvg.start BETWEEN egla.start AND egla.end THEN true ELSE false END as in_exon
+					FROM predictedvariantconsequence pvc
+					JOIN curatedvariantgenomiclocation cvg ON cvg.id = pvc.variantgenomiclocation_id
+					JOIN transcriptexonassociation tea ON tea.transcriptassociationsubject_id = pvc.varianttranscript_id
+					JOIN exongenomiclocationassociation egla ON egla.exonassociationsubject_id = tea.transcriptexonassociationobject_id
+					WHERE pvc.id IN :pvcIds
+				)
+				SELECT pvc_id,
+					CASE
+						WHEN bool_or(in_exon) THEN
+							MAX(CASE WHEN in_exon THEN exon_num END) || '/' || MAX(total_exons)
+						ELSE NULL
+					END as exon_location,
+					CASE
+						WHEN NOT bool_or(in_exon) THEN
+							(CASE WHEN MAX(strand) = '-'
+								THEN MAX(total_exons) - MIN(CASE WHEN estart > vstart THEN exon_num END)
+								ELSE MIN(CASE WHEN estart > vstart THEN exon_num END) - 1
+							END) || '/' || (MAX(total_exons) - 1)
+						ELSE NULL
+					END as intron_location
+				FROM exon_data
+				GROUP BY pvc_id
+				""";
+
+			Query intronExonQuery = entityManager.createNativeQuery(intronExonQueryString);
+			intronExonQuery.setParameter("pvcIds", pvcById.keySet());
+			List<Object[]> intronExonResults = intronExonQuery.getResultList();
+
+			for (Object[] row : intronExonResults) {
+				Long pvcId = (Long) row[0];
+				PredictedVariantConsequence pvc = pvcById.get(pvcId);
+				if (pvc != null) {
+					pvc.setExons((String) row[1]);
+					pvc.setIntrons((String) row[2]);
+				}
+			}
+		}
+
 		// Phenotype existence
 		String phenotypeQueryString = """
 				SELECT DISTINCT phenotypeannotationsubject_id as allele_id

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Transcript.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Transcript.java
@@ -50,7 +50,7 @@ public class Transcript extends GenomicEntity {
 	@JsonView({ CurationView.FieldsOnly.class, CurationView.VariantSummaryDocument.class })
 	private String transcriptId;
 
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
 	private String name;
 
 	@IndexedEmbedded(includePaths = {"curie", "name", "curie_keyword", "name_keyword"})


### PR DESCRIPTION
## Summary
- **AlleleDAO**: Compute intron/exon positions for each PredictedVariantConsequence by joining to exon genomic location tables. Sets `@Transient` introns/exons fields so `getIntronExonLocation()` returns values like "Exon 5/5" or "Intron 1/3". Handles both forward (+) and reverse (-) strand numbering.
- **Transcript.name**: Add `SequenceSummaryDocument` to `@JsonView` so transcript name survives SSD serialization into ES.

## Test plan
- [x] SQL computation verified against sample PVCs (correct exon/intron numbering)
- [x] Build succeeds
- [x] Run TestSynonyms against local API to verify intronExonLocation populated
- [x] After indexer run, verify Variant Location column on allele-details page