### PR TITLE
SCRUM-5821 Add HTP dataset document batch endpoints and GAF NPE fix

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/controllers/document/HTPDatasetDocumentController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/document/HTPDatasetDocumentController.java
@@ -2,6 +2,7 @@ package org.alliancegenome.curation_api.controllers.document;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import org.alliancegenome.curation_api.interfaces.document.HTPDatasetDocumentInterface;
 import org.alliancegenome.curation_api.model.document.builders.HTPDatasetDocumentBuilder;
@@ -36,6 +37,31 @@ public class HTPDatasetDocumentController implements HTPDatasetDocumentInterface
 
 		SearchResponse<HTPDatasetSearchResultDocument> ret = new SearchResponse<HTPDatasetSearchResultDocument>(list);
 		ret.setTotalResults(resp.getTotalResults());
+		return ret;
+	}
+
+	@Override
+	public SearchResponse<Long> getAllIds() {
+		List<Long> ids = htpDatasetService.getAllHTPDatasetSearchResultIds();
+		SearchResponse<Long> response = new SearchResponse<>(ids);
+		response.setTotalResults((long) ids.size());
+		return response;
+	}
+
+	@Override
+	public SearchResponse<HTPDatasetSearchResultDocument> findByIds(List<Long> ids) {
+		List<HTPExpressionDatasetAnnotation> annotations = htpDatasetService.findByIds(ids);
+
+		ArrayList<HTPDatasetSearchResultDocument> list = new ArrayList<>();
+		if (annotations != null) {
+			for (HTPExpressionDatasetAnnotation annotation : annotations) {
+				HTPDatasetSearchResultDocument doc = HTPDatasetDocumentBuilder.buildSearchResultDocument(annotation);
+				list.add(doc);
+			}
+		}
+
+		SearchResponse<HTPDatasetSearchResultDocument> ret = new SearchResponse<>(list);
+		ret.setTotalResults((long) list.size());
 		return ret;
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/HTPExpressionDatasetAnnotationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/HTPExpressionDatasetAnnotationDAO.java
@@ -1,14 +1,50 @@
 package org.alliancegenome.curation_api.dao;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.HTPExpressionDatasetAnnotation;
+import org.apache.commons.collections.CollectionUtils;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.Query;
 
 @ApplicationScoped
 public class HTPExpressionDatasetAnnotationDAO extends BaseSQLDAO<HTPExpressionDatasetAnnotation> {
-	
+
 	protected HTPExpressionDatasetAnnotationDAO() {
 		super(HTPExpressionDatasetAnnotation.class);
+	}
+
+	public List<Long> getAllHTPDatasetSearchResultIds() {
+		String sql = """
+				SELECT id
+				FROM htpexpressiondatasetannotation
+				WHERE obsolete = false
+				AND internal = false
+				ORDER BY id
+				""";
+		Query query = entityManager.createNativeQuery(sql);
+		List<Object> results = query.getResultList();
+		return results.stream().map(obj -> (Long) obj).collect(Collectors.toList());
+	}
+
+	public List<HTPExpressionDatasetAnnotation> findByIds(List<Long> ids) {
+		if (CollectionUtils.isEmpty(ids)) {
+			return new ArrayList<>();
+		}
+		String jpql = """
+				SELECT DISTINCT h FROM HTPExpressionDatasetAnnotation h
+				LEFT JOIN FETCH h.htpExpressionDataset
+				LEFT JOIN FETCH h.dataProvider
+				LEFT JOIN FETCH h.relatedNote
+				LEFT JOIN FETCH h.categoryTags
+				WHERE h.id IN :ids
+				""";
+		return entityManager.createQuery(jpql, HTPExpressionDatasetAnnotation.class)
+			.setParameter("ids", ids)
+			.getResultList();
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/document/HTPDatasetDocumentInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/document/HTPDatasetDocumentInterface.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.curation_api.interfaces.document;
 
 import java.util.HashMap;
+import java.util.List;
 
 import org.alliancegenome.curation_api.model.document.es.HTPDatasetSearchResultDocument;
 import org.alliancegenome.curation_api.response.SearchResponse;
@@ -12,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -28,5 +30,14 @@ public interface HTPDatasetDocumentInterface {
 	@Path("/searchresult")
 	@JsonView(CurationView.HTPDatasetSearchResultDocument.class)
 	SearchResponse<HTPDatasetSearchResultDocument> findSearchResult(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
+
+	@GET
+	@Path("/ids")
+	SearchResponse<Long> getAllIds();
+
+	@POST
+	@Path("/byids")
+	@JsonView(CurationView.HTPDatasetSearchResultDocument.class)
+	SearchResponse<HTPDatasetSearchResultDocument> findByIds(@RequestBody List<Long> ids);
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/HTPDatasetSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/HTPDatasetSearchResultDocument.java
@@ -6,7 +6,6 @@ import org.alliancegenome.curation_api.view.CurationView;
 
 import com.fasterxml.jackson.annotation.JsonView;
 
-import jakarta.json.bind.annotation.JsonbProperty;
 import lombok.Data;
 
 @Data
@@ -15,6 +14,7 @@ public class HTPDatasetSearchResultDocument extends ESDocument {
 
 	{
 		category = "htp_dataset_search_result";
+		searchable = true;
 	}
 
 	private String dataProvider;
@@ -23,7 +23,6 @@ public class HTPDatasetSearchResultDocument extends ESDocument {
 	private String species;
 	private String summary;
 	private String href;
-	@JsonbProperty("name_key")
 	private String nameKey;
 	private Set<String> tags;
 	private Set<String> variantType;

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/HTPExpressionDatasetAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/HTPExpressionDatasetAnnotation.java
@@ -114,7 +114,7 @@ public class HTPExpressionDatasetAnnotation extends AuditedObject {
 	@Fetch(FetchMode.SELECT)
 	@JsonView({ CurationView.FieldsOnly.class })
 	protected Organization dataProvider;
-	
+
 	@IndexedEmbedded(includePaths = {"displayName", "referencedCurie", "displayName_keyword", "referencedCurie_keyword"})
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@OneToOne(orphanRemoval = true)

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneOntologyAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneOntologyAnnotationService.java
@@ -108,6 +108,10 @@ public class GeneOntologyAnnotationService extends BaseEntityCrudService<GeneOnt
 	@Override
 	@Transactional
 	public GeneOntologyAnnotation deprecateOrDelete(Long id, Boolean throwApiError, String requestSource, Boolean deprecate) {
+		GeneOntologyAnnotation entity = gafDAO.find(id);
+		if (entity == null) {
+			return null;
+		}
 		return gafDAO.remove(id);
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/services/HTPExpressionDatasetAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/HTPExpressionDatasetAnnotationService.java
@@ -45,4 +45,12 @@ public class HTPExpressionDatasetAnnotationService extends BaseEntityCrudService
 		return ids;
 	}
 
+	public List<Long> getAllHTPDatasetSearchResultIds() {
+		return htpExpressionDatasetAnnotationDAO.getAllHTPDatasetSearchResultIds();
+	}
+
+	public List<HTPExpressionDatasetAnnotation> findByIds(List<Long> ids) {
+		return htpExpressionDatasetAnnotationDAO.findByIds(ids);
+	}
+
 }


### PR DESCRIPTION
Add /ids and /byids endpoints to HTPDatasetDocumentController for curation indexer batch fetching (follows GO search result pattern). Set searchable=true on HTPDatasetSearchResultDocument.

Fix null check in GeneOntologyAnnotationService.deprecateOrDelete to prevent NPE when entity not found.