### PR TITLE
SCRUM-5831 Fix "t.findIndex is not a function" error on Vocabulary/Vo…

### DIFF
--- a/src/main/cliapp/src/containers/controlledVocabularyPage/ControlledVocabularyTable.js
+++ b/src/main/cliapp/src/containers/controlledVocabularyPage/ControlledVocabularyTable.js
@@ -198,7 +198,7 @@ export const ControlledVocabularyTable = () => {
 		return (
 			<>
 				<TrueFalseDropdown
-					options={obsoleteTerms}
+					options={obsoleteTerms?.terms || []}
 					editorChange={onObsoleteEditorValueChange}
 					props={props}
 					field={'obsolete'}

--- a/src/main/cliapp/src/containers/vocabularyPage/VocabulariesTable.js
+++ b/src/main/cliapp/src/containers/vocabularyPage/VocabulariesTable.js
@@ -60,7 +60,7 @@ export const VocabulariesTable = () => {
 		return (
 			<>
 				<TrueFalseDropdown
-					options={obsoleteTerms}
+					options={obsoleteTerms?.terms || []}
 					editorChange={onObsoleteEditorValueChange}
 					props={props}
 					field={'obsolete'}


### PR DESCRIPTION
…cabTerms edit

  Extract .terms array from obsoleteTerms vocabulary object before passing
  to TrueFalseDropdown, matching the fix applied in aa60ef130.