### PR TITLE
SCRUM-5834: Fix allele synonym/symbol/fullname editing in table inter…

### DIFF
--- a/src/main/cliapp/src/containers/allelesPage/AllelesTable.js
+++ b/src/main/cliapp/src/containers/allelesPage/AllelesTable.js
@@ -12,10 +12,13 @@ import { InheritanceModesDialog } from './inheritanceModes/InheritanceModesDialo
 import { NomenclatureEventsDialog } from './nomenclatureEvents/NomenclatureEventsDialog';
 import { GermlineTransmissionStatusDialog } from './germlineTransmissionStatus/GermlineTransmissionStatusDialog';
 import { DatabaseStatusDialog } from './databaseStatus/DatabaseStatusDialog';
-import { SymbolDialog } from '../nameSlotAnnotations/dialogs/SymbolDialog';
-import { FullNameDialog } from '../nameSlotAnnotations/dialogs/FullNameDialog';
+import { SymbolEditDialog } from '../nameSlotAnnotations/dialogs/SymbolEditDialog';
+import { SymbolReadOnlyDialog } from '../nameSlotAnnotations/dialogs/SymbolReadOnlyDialog';
+import { FullNameEditDialog } from '../nameSlotAnnotations/dialogs/FullNameEditDialog';
+import { FullNameReadOnlyDialog } from '../nameSlotAnnotations/dialogs/FullNameReadOnlyDialog';
 import { SecondaryIdsDialog } from './secondaryIds/SecondaryIdsDialog';
-import { SynonymsDialog } from '../nameSlotAnnotations/dialogs/SynonymsDialog';
+import { SynonymsEditDialog } from '../nameSlotAnnotations/dialogs/SynonymsEditDialog';
+import { SynonymsReadOnlyDialog } from '../nameSlotAnnotations/dialogs/SynonymsReadOnlyDialog';
 import { RelatedNotesDialog } from '../../components/RelatedNotesDialog';
 import { TaxonTableEditor } from '../../components/Editors/taxon/TaxonTableEditor';
 import { InCollectionTableEditor } from '../../components/Editors/inCollection/InCollectionTableEditor';
@@ -158,9 +161,8 @@ export const AllelesTable = () => {
 	};
 
 	const handleRelatedNotesOpenInEdit = (event, rowProps, isInEdit) => {
-		const { rows } = rowProps.props;
 		const { rowIndex } = rowProps;
-		const index = rowIndex % rows;
+		const index = rowIndex;
 		let _relatedNotesData = {};
 		_relatedNotesData['originalRelatedNotes'] = rowProps.rowData.relatedNotes;
 		_relatedNotesData['dialog'] = true;
@@ -269,9 +271,8 @@ export const AllelesTable = () => {
 	};
 
 	const handleSymbolOpenInEdit = (event, rowProps, isInEdit) => {
-		const { rows } = rowProps.props;
 		const { rowIndex } = rowProps;
-		const index = rowIndex % rows;
+		const index = rowIndex;
 		let _symbolData = {};
 		_symbolData['originalSymbols'] = [rowProps.rowData.alleleSymbol];
 		_symbolData['dialog'] = true;
@@ -354,9 +355,8 @@ export const AllelesTable = () => {
 	};
 
 	const handleFullNameOpenInEdit = (event, rowProps, isInEdit) => {
-		const { rows } = rowProps.props;
 		const { rowIndex } = rowProps;
-		const index = rowIndex % rows;
+		const index = rowIndex;
 		let _fullNameData = {};
 		_fullNameData['originalFullNames'] = [rowProps.rowData.alleleFullName];
 		_fullNameData['dialog'] = true;
@@ -434,9 +434,8 @@ export const AllelesTable = () => {
 	};
 
 	const handleSynonymsOpenInEdit = (event, rowProps, isInEdit) => {
-		const { rows } = rowProps.props;
 		const { rowIndex } = rowProps;
-		const index = rowIndex % rows;
+		const index = rowIndex;
 		let _synonymsData = {};
 		_synonymsData['originalSynonyms'] = rowProps.rowData.alleleSynonyms;
 		_synonymsData['dialog'] = true;
@@ -514,9 +513,8 @@ export const AllelesTable = () => {
 	};
 
 	const handleInheritanceModesOpenInEdit = (event, rowProps, isInEdit) => {
-		const { rows } = rowProps.props;
 		const { rowIndex } = rowProps;
-		const index = rowIndex % rows;
+		const index = rowIndex;
 		let _inheritanceModesData = {};
 		_inheritanceModesData['originalInheritanceModes'] = rowProps.rowData.alleleInheritanceModes;
 		_inheritanceModesData['dialog'] = true;
@@ -594,9 +592,8 @@ export const AllelesTable = () => {
 	};
 
 	const handleGermlineTransmissionStatusOpenInEdit = (event, rowProps, isInEdit) => {
-		const { rows } = rowProps.props;
 		const { rowIndex } = rowProps;
-		const index = rowIndex % rows;
+		const index = rowIndex;
 		let _germlineTransmissionStatusData = {};
 		_germlineTransmissionStatusData['originalGermlineTransmissionStatuses'] = [
 			rowProps.rowData.alleleGermlineTransmissionStatus,
@@ -676,9 +673,8 @@ export const AllelesTable = () => {
 	};
 
 	const handleNomenclatureEventsOpenInEdit = (event, rowProps, isInEdit) => {
-		const { rows } = rowProps.props;
 		const { rowIndex } = rowProps;
-		const index = rowIndex % rows;
+		const index = rowIndex;
 		let _nomenclatureEventsData = {};
 		_nomenclatureEventsData['originalNomenclatureEvents'] = rowProps.rowData.alleleNomenclatureEvents;
 		_nomenclatureEventsData['dialog'] = true;
@@ -756,9 +752,8 @@ export const AllelesTable = () => {
 	};
 
 	const handleDatabaseStatusOpenInEdit = (event, rowProps, isInEdit) => {
-		const { rows } = rowProps.props;
 		const { rowIndex } = rowProps;
-		const index = rowIndex % rows;
+		const index = rowIndex;
 		let _databaseStatusData = {};
 		_databaseStatusData['originalDatabaseStatuses'] = [rowProps.rowData.alleleDatabaseStatus];
 		_databaseStatusData['dialog'] = true;
@@ -836,9 +831,8 @@ export const AllelesTable = () => {
 	};
 
 	const handleMutationTypesOpenInEdit = (event, rowProps, isInEdit) => {
-		const { rows } = rowProps.props;
 		const { rowIndex } = rowProps;
-		const index = rowIndex % rows;
+		const index = rowIndex;
 		let _mutationTypesData = {};
 		_mutationTypesData['originalMutationTypes'] = rowProps.rowData.alleleMutationTypes;
 		_mutationTypesData['dialog'] = true;
@@ -916,9 +910,8 @@ export const AllelesTable = () => {
 	};
 
 	const handleFunctionalImpactsOpenInEdit = (event, rowProps, isInEdit) => {
-		const { rows } = rowProps.props;
 		const { rowIndex } = rowProps;
-		const index = rowIndex % rows;
+		const index = rowIndex;
 		let _functionalImpactsData = {};
 		_functionalImpactsData['originalFunctionalImpacts'] = rowProps.rowData.alleleFunctionalImpacts;
 		_functionalImpactsData['dialog'] = true;
@@ -995,9 +988,8 @@ export const AllelesTable = () => {
 	};
 
 	const handleSecondaryIdsOpenInEdit = (event, rowProps, isInEdit) => {
-		const { rows } = rowProps.props;
 		const { rowIndex } = rowProps;
-		const index = rowIndex % rows;
+		const index = rowIndex;
 		let _secondaryIdsData = {};
 		_secondaryIdsData['originalSecondaryIds'] = rowProps.rowData.alleleSecondaryIds;
 		_secondaryIdsData['dialog'] = true;
@@ -1344,7 +1336,7 @@ export const AllelesTable = () => {
 					fetching={isFetching || isPending}
 				/>
 			</div>
-			<SymbolDialog
+			<SymbolEditDialog
 				name="Allele Symbol"
 				field="alleleSymbol"
 				endpoint="allelesymbolslotannotation"
@@ -1353,7 +1345,8 @@ export const AllelesTable = () => {
 				errorMessagesMainRow={errorMessages}
 				setErrorMessagesMainRow={setErrorMessages}
 			/>
-			<FullNameDialog
+			<SymbolReadOnlyDialog originalSymbolData={symbolData} setOriginalSymbolData={setSymbolData} />
+			<FullNameEditDialog
 				name="Allele Name"
 				field="alleleFullName"
 				endpoint="allelefullnameslotannotation"
@@ -1362,7 +1355,8 @@ export const AllelesTable = () => {
 				errorMessagesMainRow={errorMessages}
 				setErrorMessagesMainRow={setErrorMessages}
 			/>
-			<SynonymsDialog
+			<FullNameReadOnlyDialog originalFullNameData={fullNameData} setOriginalFullNameData={setFullNameData} />
+			<SynonymsEditDialog
 				name="Allele Synonym"
 				field="alleleSynonyms"
 				endpoint="allelesynonymslotannotation"
@@ -1371,6 +1365,7 @@ export const AllelesTable = () => {
 				errorMessagesMainRow={errorMessages}
 				setErrorMessagesMainRow={setErrorMessages}
 			/>
+			<SynonymsReadOnlyDialog originalSynonymsData={synonymsData} setOriginalSynonymsData={setSynonymsData} />
 			<NomenclatureEventsDialog
 				originalNomenclatureEventsData={nomenclatureEventsData}
 				setOriginalNomenclatureEventsData={setNomenclatureEventsData}

--- a/src/main/cliapp/src/containers/genesPage/GenesTable.js
+++ b/src/main/cliapp/src/containers/genesPage/GenesTable.js
@@ -4,9 +4,12 @@ import { Toast } from 'primereact/toast';
 import { getDefaultTableState } from '../../service/TableStateService';
 import { FILTER_CONFIGS } from '../../constants/FilterFields';
 import { SecondaryIdsDialog } from './SecondaryIdsDialog';
-import { SynonymsDialog } from '../nameSlotAnnotations/dialogs/SynonymsDialog';
-import { SymbolDialog } from '../nameSlotAnnotations/dialogs/SymbolDialog';
-import { FullNameDialog } from '../nameSlotAnnotations/dialogs/FullNameDialog';
+import { SynonymsEditDialog } from '../nameSlotAnnotations/dialogs/SynonymsEditDialog';
+import { SynonymsReadOnlyDialog } from '../nameSlotAnnotations/dialogs/SynonymsReadOnlyDialog';
+import { SymbolEditDialog } from '../nameSlotAnnotations/dialogs/SymbolEditDialog';
+import { SymbolReadOnlyDialog } from '../nameSlotAnnotations/dialogs/SymbolReadOnlyDialog';
+import { FullNameEditDialog } from '../nameSlotAnnotations/dialogs/FullNameEditDialog';
+import { FullNameReadOnlyDialog } from '../nameSlotAnnotations/dialogs/FullNameReadOnlyDialog';
 import { SystematicNameDialog } from './SystematicNameDialog';
 import { CrossReferencesTemplate } from '../../components/Templates/CrossReferencesTemplate';
 import { CrossReferenceTemplate } from '../../components/Templates/CrossReferenceTemplate';
@@ -125,9 +128,8 @@ export const GenesTable = () => {
 	};
 
 	const handleRelatedNotesOpenInEdit = (event, rowProps, isInEdit) => {
-		const { rows } = rowProps.props;
 		const { rowIndex } = rowProps;
-		const index = rowIndex % rows;
+		const index = rowIndex;
 		let _relatedNotesData = {};
 		_relatedNotesData['originalRelatedNotes'] = rowProps.rowData.relatedNotes;
 		_relatedNotesData['dialog'] = true;
@@ -431,27 +433,30 @@ export const GenesTable = () => {
 					fetching={isFetching || isLoading}
 				/>
 			</div>
-			<FullNameDialog
+			<FullNameEditDialog
 				name="Gene Name"
 				field="geneFullName"
 				endpoint="genefullnameslotannotation"
 				originalFullNameData={fullNameData}
 				setOriginalFullNameData={setFullNameData}
 			/>
-			<SymbolDialog
+			<FullNameReadOnlyDialog originalFullNameData={fullNameData} setOriginalFullNameData={setFullNameData} />
+			<SymbolEditDialog
 				name="Gene Symbol"
 				field="geneSymbol"
 				endpoint="genesymbolslotannotation"
 				originalSymbolData={symbolData}
 				setOriginalSymbolData={setSymbolData}
 			/>
-			<SynonymsDialog
+			<SymbolReadOnlyDialog originalSymbolData={symbolData} setOriginalSymbolData={setSymbolData} />
+			<SynonymsEditDialog
 				name="Gene Synonym"
 				field="geneSynonyms"
 				endpoint="genesynonymslotannotation"
 				originalSynonymsData={synonymsData}
 				setOriginalSynonymsData={setSynonymsData}
 			/>
+			<SynonymsReadOnlyDialog originalSynonymsData={synonymsData} setOriginalSynonymsData={setSynonymsData} />
 			<SecondaryIdsDialog
 				originalSecondaryIdsData={secondaryIdsData}
 				setOriginalSecondaryIdsData={setSecondaryIdsData}

--- a/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/FullNameEditDialog.js
+++ b/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/FullNameEditDialog.js
@@ -1,0 +1,428 @@
+import { useRef, useState } from 'react';
+import { Dialog } from 'primereact/dialog';
+import { DataTable } from 'primereact/datatable';
+import { Column } from 'primereact/column';
+import { Button } from 'primereact/button';
+import { Toast } from 'primereact/toast';
+import { ColumnGroup } from 'primereact/columngroup';
+import { Row } from 'primereact/row';
+import { DialogErrorMessageComponent } from '../../../components/Error/DialogErrorMessageComponent';
+import { ValidationService } from '../../../service/ValidationService';
+import { DeleteAction } from '../../../components/Actions/DeletionAction';
+import { TableInputTextEditor } from '../../../components/Editors/TableInputTextEditor';
+import { InternalEditor } from '../../../components/Editors/InternalEditor';
+import { EvidenceEditor } from '../../../components/Editors/EvidenceEditor';
+import { ControlledVocabularyEditor } from '../../../components/Editors/ControlledVocabularyEditor';
+import { useVocabularyTermSetService } from '../../../service/useVocabularyTermSetService';
+import { ControlledVocabularyDropdown } from '../../../components/ControlledVocabularySelector';
+
+export const FullNameEditDialog = ({
+	field,
+	endpoint,
+	originalFullNameData,
+	setOriginalFullNameData,
+	errorMessagesMainRow,
+	setErrorMessagesMainRow,
+}) => {
+	const { originalFullNames, isInEdit, dialog, rowIndex, mainRowProps } = originalFullNameData;
+	const [localFullNames, setLocalFullNames] = useState(null);
+	const [editingRows, setEditingRows] = useState({});
+	const [errorMessages, setErrorMessages] = useState({});
+	const [isValidating, setIsValidating] = useState(false);
+	const validationService = new ValidationService();
+	const tableRef = useRef(null);
+	const toast_topright = useRef(null);
+
+	const fullNameTypeTerms = useVocabularyTermSetService('full_name_type');
+
+	const showDialogHandler = () => {
+		let _localFullNames = cloneFullNames(originalFullNames);
+		setLocalFullNames(_localFullNames);
+
+		let rowsObject = {};
+		if (_localFullNames) {
+			_localFullNames.forEach((fn) => {
+				rowsObject[`${fn.dataKey}`] = true;
+			});
+		}
+		setEditingRows(rowsObject);
+		setErrorMessages({});
+	};
+
+	const onRowEditChange = () => {
+		return null;
+	};
+
+	const hideDialog = () => {
+		setErrorMessages({});
+		setOriginalFullNameData((originalFullNameData) => {
+			return {
+				...originalFullNameData,
+				dialog: false,
+			};
+		});
+		setLocalFullNames([]);
+	};
+
+	const cloneFullNames = (clonableFullNames) => {
+		let _clonableFullNames = [];
+		if (clonableFullNames?.length > 0 && clonableFullNames[0]) {
+			_clonableFullNames = global.structuredClone(clonableFullNames);
+			if (_clonableFullNames) {
+				let counter = 0;
+				_clonableFullNames.forEach((fn) => {
+					fn.dataKey = counter++;
+				});
+			}
+		}
+		return _clonableFullNames;
+	};
+
+	const textOnChangeHandler = (rowIndex, event, field) => {
+		setLocalFullNames((prev) => {
+			const updated = [...prev];
+			updated[rowIndex] = { ...updated[rowIndex], [field]: event.target.value };
+			return updated;
+		});
+	};
+
+	const nameTypeOnChangeHandler = (props, event) => {
+		props.editorCallback(event.value);
+		setLocalFullNames((prev) => {
+			const updated = [...prev];
+			updated[props.rowIndex] = { ...updated[props.rowIndex], nameType: event.value };
+			return updated;
+		});
+	};
+
+	const synonymScopeOnChangeHandler = (props, event) => {
+		props.editorCallback(event.target.value);
+		setLocalFullNames((prev) => {
+			const updated = [...prev];
+			updated[props.rowIndex] = { ...updated[props.rowIndex], synonymScope: event.target.value };
+			return updated;
+		});
+	};
+
+	const internalOnChangeHandler = (props, event) => {
+		props.editorCallback(event.target.value?.name);
+		setLocalFullNames((prev) => {
+			const updated = [...prev];
+			updated[props.rowIndex] = { ...updated[props.rowIndex], internal: event.target?.value?.name };
+			return updated;
+		});
+	};
+
+	const evidenceOnChangeHandler = (event, setFieldValue, props) => {
+		setFieldValue(event.target.value);
+		setLocalFullNames((prev) => {
+			const updated = [...prev];
+			updated[props.rowIndex] = { ...updated[props.rowIndex], evidence: event.target.value };
+			return updated;
+		});
+	};
+
+	const createNewFullNameHandler = () => {
+		let cnt = localFullNames ? localFullNames.length : 0;
+		const _localFullNames = global.structuredClone(localFullNames);
+		_localFullNames.push({
+			dataKey: cnt,
+			internal: false,
+			nameType: fullNameTypeTerms?.[0] || null,
+		});
+		let _editingRows = { ...editingRows, ...{ [`${cnt}`]: true } };
+		setEditingRows(_editingRows);
+		setLocalFullNames(_localFullNames);
+	};
+
+	const handleDeleteFullName = (e, dataKey) => {
+		let _localFullNames = global.structuredClone(localFullNames);
+		_localFullNames = _localFullNames.filter((fn) => fn.dataKey !== dataKey);
+		setLocalFullNames(_localFullNames);
+	};
+
+	const saveDataHandler = () => {
+		setErrorMessages({});
+		const _localFullNames = global.structuredClone(localFullNames);
+		for (const fn of _localFullNames) {
+			delete fn.dataKey;
+		}
+		mainRowProps.rowData[field] = _localFullNames[0] ? _localFullNames[0] : null;
+		let updatedAnnotations = [...mainRowProps.props.value];
+		updatedAnnotations[rowIndex][field] = _localFullNames[0] ? _localFullNames[0] : null;
+		// Signal PrimeReact that editing data changed so the main table re-renders the cell
+		if (mainRowProps.editorCallback) {
+			mainRowProps.editorCallback();
+		}
+
+		const errorMessagesCopy = global.structuredClone(errorMessagesMainRow);
+		let messageObject = {
+			severity: 'warn',
+			message: 'Pending Edits!',
+		};
+		errorMessagesCopy[rowIndex] = {};
+		errorMessagesCopy[rowIndex][field] = messageObject;
+		setErrorMessagesMainRow({ ...errorMessagesCopy });
+
+		setOriginalFullNameData((originalFullNameData) => {
+			return {
+				...originalFullNameData,
+				dialog: false,
+			};
+		});
+	};
+
+	const cleanForValidation = (obj) => {
+		const _obj = global.structuredClone(obj);
+		delete _obj.dataKey;
+		delete _obj.updatedBy;
+		delete _obj.createdBy;
+		delete _obj.dateUpdated;
+		delete _obj.dateCreated;
+		if (_obj.evidence) {
+			_obj.evidence.forEach((ref) => {
+				delete ref.updatedBy;
+				delete ref.createdBy;
+				delete ref.dateUpdated;
+				delete ref.dateCreated;
+			});
+		}
+		return _obj;
+	};
+
+	const validateAndSave = async () => {
+		setIsValidating(true);
+		try {
+			let hasErrors = false;
+			const newErrorMessages = {};
+
+			for (let i = 0; i < localFullNames.length; i++) {
+				const _fn = cleanForValidation(localFullNames[i]);
+				const result = await validationService.validate(endpoint, _fn);
+				const dataKey = localFullNames[i].dataKey;
+				if (result.isError) {
+					hasErrors = true;
+					newErrorMessages[dataKey] = {};
+					if (result.data) {
+						Object.keys(result.data).forEach((field) => {
+							newErrorMessages[dataKey][field] = {
+								severity: 'error',
+								message: result.data[field],
+							};
+						});
+					}
+				}
+			}
+
+			if (hasErrors) {
+				setErrorMessages(newErrorMessages);
+				toast_topright.current.show([
+					{
+						life: 7000,
+						severity: 'error',
+						summary: 'Validation error',
+						detail: 'Please fix validation errors before saving',
+						sticky: false,
+					},
+				]);
+			} else {
+				saveDataHandler();
+			}
+		} finally {
+			setIsValidating(false);
+		}
+	};
+
+	const nameTypeEditor = (props) => {
+		return (
+			<>
+				<ControlledVocabularyDropdown
+					field="nameType"
+					options={fullNameTypeTerms}
+					editorChange={nameTypeOnChangeHandler}
+					props={props}
+					showClear={false}
+					dataKey="id"
+				/>
+				<DialogErrorMessageComponent errorMessages={errorMessages[props?.rowData?.dataKey]} errorField={'nameType'} />
+			</>
+		);
+	};
+
+	const footerTemplate = () => {
+		return (
+			<div>
+				<Button label="Cancel" icon="pi pi-times" onClick={hideDialog} className="p-button-text" />
+				<Button
+					label="New Name"
+					icon="pi pi-plus"
+					onClick={createNewFullNameHandler}
+					disabled={localFullNames?.length > 0}
+				/>
+				<Button
+					label="Keep Edits"
+					icon={isValidating ? 'pi pi-spin pi-spinner' : 'pi pi-check'}
+					onClick={validateAndSave}
+					disabled={isValidating}
+				/>
+			</div>
+		);
+	};
+
+	let headerGroup = (
+		<ColumnGroup>
+			<Row>
+				<Column header="Actions" />
+				<Column header="Display Text" />
+				<Column header="Format Text" />
+				<Column header="Synonym Scope" />
+				<Column header="Name Type" />
+				<Column header="Synonym URL" />
+				<Column header="Internal" />
+				<Column header="Evidence" />
+				<Column header="Updated By" />
+				<Column header="Date Updated" />
+			</Row>
+		</ColumnGroup>
+	);
+
+	return (
+		<div>
+			<Toast ref={toast_topright} position="top-right" />
+			<Dialog
+				visible={dialog && isInEdit}
+				className="w-10"
+				modal
+				onHide={hideDialog}
+				closable={false}
+				onShow={showDialogHandler}
+				footer={footerTemplate}
+			>
+				<h3>Full Name</h3>
+				<DataTable
+					value={localFullNames}
+					dataKey="dataKey"
+					showGridlines
+					editMode="row"
+					headerColumnGroup={headerGroup}
+					editingRows={editingRows}
+					onRowEditChange={onRowEditChange}
+					ref={tableRef}
+					cellMemo={false}
+				>
+					<Column
+						editor={(props) => <DeleteAction deletionHandler={handleDeleteFullName} id={props?.rowData?.dataKey} />}
+						className="max-w-4rem"
+						bodyClassName="text-center"
+						headerClassName="surface-0"
+						frozen
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<TableInputTextEditor
+									value={props.value}
+									rowIndex={props.rowIndex}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									textOnChangeHandler={textOnChangeHandler}
+									field="displayText"
+								/>
+							);
+						}}
+						field="displayText"
+						header="Display Text"
+						headerClassName="surface-0"
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<TableInputTextEditor
+									value={props.value}
+									rowIndex={props.rowIndex}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									textOnChangeHandler={textOnChangeHandler}
+									field="formatText"
+								/>
+							);
+						}}
+						field="formatText"
+						header="Format Text"
+						headerClassName="surface-0"
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<ControlledVocabularyEditor
+									props={props}
+									onChangeHandler={synonymScopeOnChangeHandler}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									rowIndex={props.rowIndex}
+									vocabType="synonym_scope"
+									field="synonymScope"
+									showClear={true}
+								/>
+							);
+						}}
+						field="synonymScope"
+						header="Synonym Scope"
+						headerClassName="surface-0"
+					/>
+					<Column editor={nameTypeEditor} field="nameType" header="Name Type" headerClassName="surface-0" />
+					<Column
+						editor={(props) => {
+							return (
+								<TableInputTextEditor
+									value={props.value}
+									rowIndex={props.rowIndex}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									textOnChangeHandler={textOnChangeHandler}
+									field="synonymUrl"
+								/>
+							);
+						}}
+						field="synonymUrl"
+						header="Synonym URL"
+						headerClassName="surface-0"
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<InternalEditor
+									props={props}
+									rowIndex={props.rowIndex}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									internalOnChangeHandler={internalOnChangeHandler}
+								/>
+							);
+						}}
+						field="internal"
+						header="Internal"
+						headerClassName="surface-0"
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<EvidenceEditor
+									props={props}
+									errorMessages={errorMessages}
+									onChange={evidenceOnChangeHandler}
+									dataKey={props?.rowData?.dataKey}
+								/>
+							);
+						}}
+						field="evidence.curie"
+						header="Evidence"
+						headerClassName="surface-0"
+					/>
+					<Column field="updatedBy.uniqueId" header="Updated By" />
+					<Column field="dateUpdated" header="Date Updated" />
+				</DataTable>
+			</Dialog>
+		</div>
+	);
+};

--- a/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/FullNameEditDialog.js
+++ b/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/FullNameEditDialog.js
@@ -30,12 +30,14 @@ export const FullNameEditDialog = ({
 	const [errorMessages, setErrorMessages] = useState({});
 	const [isValidating, setIsValidating] = useState(false);
 	const validationService = new ValidationService();
+	const dataKeyCounter = useRef(0);
 	const tableRef = useRef(null);
 	const toast_topright = useRef(null);
 
 	const fullNameTypeTerms = useVocabularyTermSetService('full_name_type');
 
 	const showDialogHandler = () => {
+		dataKeyCounter.current = 0;
 		let _localFullNames = cloneFullNames(originalFullNames);
 		setLocalFullNames(_localFullNames);
 
@@ -69,9 +71,8 @@ export const FullNameEditDialog = ({
 		if (clonableFullNames?.length > 0 && clonableFullNames[0]) {
 			_clonableFullNames = global.structuredClone(clonableFullNames);
 			if (_clonableFullNames) {
-				let counter = 0;
 				_clonableFullNames.forEach((fn) => {
-					fn.dataKey = counter++;
+					fn.dataKey = dataKeyCounter.current++;
 				});
 			}
 		}
@@ -123,14 +124,14 @@ export const FullNameEditDialog = ({
 	};
 
 	const createNewFullNameHandler = () => {
-		let cnt = localFullNames ? localFullNames.length : 0;
+		const newKey = dataKeyCounter.current++;
 		const _localFullNames = global.structuredClone(localFullNames);
 		_localFullNames.push({
-			dataKey: cnt,
+			dataKey: newKey,
 			internal: false,
 			nameType: fullNameTypeTerms?.[0] || null,
 		});
-		let _editingRows = { ...editingRows, ...{ [`${cnt}`]: true } };
+		let _editingRows = { ...editingRows, ...{ [`${newKey}`]: true } };
 		setEditingRows(_editingRows);
 		setLocalFullNames(_localFullNames);
 	};

--- a/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/FullNameReadOnlyDialog.js
+++ b/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/FullNameReadOnlyDialog.js
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { Dialog } from 'primereact/dialog';
+import { DataTable } from 'primereact/datatable';
+import { Column } from 'primereact/column';
+import { evidenceTemplate } from '../../../components/EvidenceComponent';
+import {
+	synonymScopeTemplate,
+	nameTypeTemplate,
+	synonymUrlTemplate,
+	displayTextTemplate,
+	formatTextTemplate,
+} from '../../../components/NameSlotAnnotationComponent';
+import { EllipsisTableCell } from '../../../components/EllipsisTableCell';
+
+export const FullNameReadOnlyDialog = ({ originalFullNameData, setOriginalFullNameData }) => {
+	const { originalFullNames, isInEdit, dialog } = originalFullNameData;
+	const [localFullNames, setLocalFullNames] = useState(null);
+
+	const showDialogHandler = () => {
+		let _localFullNames = [];
+		if (originalFullNames?.length > 0 && originalFullNames[0]) {
+			_localFullNames = global.structuredClone(originalFullNames);
+			let counter = 0;
+			_localFullNames.forEach((fn) => {
+				fn.dataKey = counter++;
+			});
+		}
+		setLocalFullNames(_localFullNames);
+	};
+
+	const hideDialog = () => {
+		setOriginalFullNameData((originalFullNameData) => {
+			return {
+				...originalFullNameData,
+				dialog: false,
+			};
+		});
+		setLocalFullNames([]);
+	};
+
+	const internalTemplate = (rowData) => {
+		return <EllipsisTableCell>{JSON.stringify(rowData.internal)}</EllipsisTableCell>;
+	};
+
+	return (
+		<Dialog
+			visible={dialog && !isInEdit}
+			className="w-10"
+			modal
+			onHide={hideDialog}
+			closable
+			onShow={showDialogHandler}
+		>
+			<h3>Full Name</h3>
+			<DataTable value={localFullNames} dataKey="dataKey" showGridlines>
+				<Column field="displayText" header="Display Text" body={displayTextTemplate} />
+				<Column field="formatText" header="Format Text" body={formatTextTemplate} />
+				<Column field="synonymScope" header="Synonym Scope" body={synonymScopeTemplate} />
+				<Column field="nameType" header="Name Type" body={nameTypeTemplate} />
+				<Column field="synonymUrl" header="Synonym URL" body={synonymUrlTemplate} />
+				<Column field="internal" header="Internal" body={internalTemplate} />
+				<Column field="evidence.curie" header="Evidence" body={(rowData) => evidenceTemplate(rowData)} />
+				<Column field="updatedBy.uniqueId" header="Updated By" />
+				<Column field="dateUpdated" header="Date Updated" />
+			</DataTable>
+		</Dialog>
+	);
+};

--- a/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/SymbolEditDialog.js
+++ b/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/SymbolEditDialog.js
@@ -29,12 +29,14 @@ export const SymbolEditDialog = ({
 	const [errorMessages, setErrorMessages] = useState({});
 	const [isValidating, setIsValidating] = useState(false);
 	const validationService = new ValidationService();
+	const dataKeyCounter = useRef(0);
 	const tableRef = useRef(null);
 	const toast_topright = useRef(null);
 
 	const symbolNameTypeTerms = useVocabularyTermSetService('symbol_name_type');
 
 	const showDialogHandler = () => {
+		dataKeyCounter.current = 0;
 		let _localSymbols = cloneSymbols(originalSymbols);
 		setLocalSymbols(_localSymbols);
 
@@ -68,9 +70,8 @@ export const SymbolEditDialog = ({
 		if (clonableSymbols?.length > 0 && clonableSymbols[0]) {
 			_clonableSymbols = global.structuredClone(clonableSymbols);
 			if (_clonableSymbols) {
-				let counter = 0;
 				_clonableSymbols.forEach((sym) => {
-					sym.dataKey = counter++;
+					sym.dataKey = dataKeyCounter.current++;
 				});
 			}
 		}

--- a/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/SymbolEditDialog.js
+++ b/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/SymbolEditDialog.js
@@ -1,0 +1,394 @@
+import { useRef, useState } from 'react';
+import { Dialog } from 'primereact/dialog';
+import { DataTable } from 'primereact/datatable';
+import { Column } from 'primereact/column';
+import { Button } from 'primereact/button';
+import { Toast } from 'primereact/toast';
+import { ColumnGroup } from 'primereact/columngroup';
+import { Row } from 'primereact/row';
+import { DialogErrorMessageComponent } from '../../../components/Error/DialogErrorMessageComponent';
+import { ValidationService } from '../../../service/ValidationService';
+import { TableInputTextEditor } from '../../../components/Editors/TableInputTextEditor';
+import { InternalEditor } from '../../../components/Editors/InternalEditor';
+import { EvidenceEditor } from '../../../components/Editors/EvidenceEditor';
+import { ControlledVocabularyEditor } from '../../../components/Editors/ControlledVocabularyEditor';
+import { useVocabularyTermSetService } from '../../../service/useVocabularyTermSetService';
+import { ControlledVocabularyDropdown } from '../../../components/ControlledVocabularySelector';
+
+export const SymbolEditDialog = ({
+	field,
+	endpoint,
+	originalSymbolData,
+	setOriginalSymbolData,
+	errorMessagesMainRow,
+	setErrorMessagesMainRow,
+}) => {
+	const { originalSymbols, isInEdit, dialog, rowIndex, mainRowProps } = originalSymbolData;
+	const [localSymbols, setLocalSymbols] = useState(null);
+	const [editingRows, setEditingRows] = useState({});
+	const [errorMessages, setErrorMessages] = useState({});
+	const [isValidating, setIsValidating] = useState(false);
+	const validationService = new ValidationService();
+	const tableRef = useRef(null);
+	const toast_topright = useRef(null);
+
+	const symbolNameTypeTerms = useVocabularyTermSetService('symbol_name_type');
+
+	const showDialogHandler = () => {
+		let _localSymbols = cloneSymbols(originalSymbols);
+		setLocalSymbols(_localSymbols);
+
+		let rowsObject = {};
+		if (_localSymbols) {
+			_localSymbols.forEach((sym) => {
+				rowsObject[`${sym.dataKey}`] = true;
+			});
+		}
+		setEditingRows(rowsObject);
+		setErrorMessages({});
+	};
+
+	const onRowEditChange = () => {
+		return null;
+	};
+
+	const hideDialog = () => {
+		setErrorMessages({});
+		setOriginalSymbolData((originalSymbolData) => {
+			return {
+				...originalSymbolData,
+				dialog: false,
+			};
+		});
+		setLocalSymbols([]);
+	};
+
+	const cloneSymbols = (clonableSymbols) => {
+		let _clonableSymbols = [];
+		if (clonableSymbols?.length > 0 && clonableSymbols[0]) {
+			_clonableSymbols = global.structuredClone(clonableSymbols);
+			if (_clonableSymbols) {
+				let counter = 0;
+				_clonableSymbols.forEach((sym) => {
+					sym.dataKey = counter++;
+				});
+			}
+		}
+		return _clonableSymbols;
+	};
+
+	const textOnChangeHandler = (rowIndex, event, field) => {
+		setLocalSymbols((prev) => {
+			const updated = [...prev];
+			updated[rowIndex] = { ...updated[rowIndex], [field]: event.target.value };
+			return updated;
+		});
+	};
+
+	const nameTypeOnChangeHandler = (props, event) => {
+		props.editorCallback(event.value);
+		setLocalSymbols((prev) => {
+			const updated = [...prev];
+			updated[props.rowIndex] = { ...updated[props.rowIndex], nameType: event.value };
+			return updated;
+		});
+	};
+
+	const synonymScopeOnChangeHandler = (props, event) => {
+		props.editorCallback(event.target.value);
+		setLocalSymbols((prev) => {
+			const updated = [...prev];
+			updated[props.rowIndex] = { ...updated[props.rowIndex], synonymScope: event.target.value };
+			return updated;
+		});
+	};
+
+	const internalOnChangeHandler = (props, event) => {
+		props.editorCallback(event.target.value?.name);
+		setLocalSymbols((prev) => {
+			const updated = [...prev];
+			updated[props.rowIndex] = { ...updated[props.rowIndex], internal: event.target?.value?.name };
+			return updated;
+		});
+	};
+
+	const evidenceOnChangeHandler = (event, setFieldValue, props) => {
+		setFieldValue(event.target.value);
+		setLocalSymbols((prev) => {
+			const updated = [...prev];
+			updated[props.rowIndex] = { ...updated[props.rowIndex], evidence: event.target.value };
+			return updated;
+		});
+	};
+
+	const saveDataHandler = () => {
+		setErrorMessages({});
+		const _localSymbols = global.structuredClone(localSymbols);
+		for (const sym of _localSymbols) {
+			delete sym.dataKey;
+		}
+		mainRowProps.rowData[field] = _localSymbols[0] ? _localSymbols[0] : null;
+		let updatedAnnotations = [...mainRowProps.props.value];
+		updatedAnnotations[rowIndex][field] = _localSymbols[0] ? _localSymbols[0] : null;
+		// Signal PrimeReact that editing data changed so the main table re-renders the cell
+		if (mainRowProps.editorCallback) {
+			mainRowProps.editorCallback();
+		}
+
+		const errorMessagesCopy = global.structuredClone(errorMessagesMainRow);
+		let messageObject = {
+			severity: 'warn',
+			message: 'Pending Edits!',
+		};
+		errorMessagesCopy[rowIndex] = {};
+		errorMessagesCopy[rowIndex][field] = messageObject;
+		setErrorMessagesMainRow({ ...errorMessagesCopy });
+
+		setOriginalSymbolData((originalSymbolData) => {
+			return {
+				...originalSymbolData,
+				dialog: false,
+			};
+		});
+	};
+
+	const cleanForValidation = (obj) => {
+		const _obj = global.structuredClone(obj);
+		delete _obj.dataKey;
+		delete _obj.updatedBy;
+		delete _obj.createdBy;
+		delete _obj.dateUpdated;
+		delete _obj.dateCreated;
+		if (_obj.evidence) {
+			_obj.evidence.forEach((ref) => {
+				delete ref.updatedBy;
+				delete ref.createdBy;
+				delete ref.dateUpdated;
+				delete ref.dateCreated;
+			});
+		}
+		return _obj;
+	};
+
+	const validateAndSave = async () => {
+		setIsValidating(true);
+		try {
+			let hasErrors = false;
+			const newErrorMessages = {};
+
+			for (let i = 0; i < localSymbols.length; i++) {
+				const _sym = cleanForValidation(localSymbols[i]);
+				const result = await validationService.validate(endpoint, _sym);
+				const dataKey = localSymbols[i].dataKey;
+				if (result.isError) {
+					hasErrors = true;
+					newErrorMessages[dataKey] = {};
+					if (result.data) {
+						Object.keys(result.data).forEach((field) => {
+							newErrorMessages[dataKey][field] = {
+								severity: 'error',
+								message: result.data[field],
+							};
+						});
+					}
+				}
+			}
+
+			if (hasErrors) {
+				setErrorMessages(newErrorMessages);
+				toast_topright.current.show([
+					{
+						life: 7000,
+						severity: 'error',
+						summary: 'Validation error',
+						detail: 'Please fix validation errors before saving',
+						sticky: false,
+					},
+				]);
+			} else {
+				saveDataHandler();
+			}
+		} finally {
+			setIsValidating(false);
+		}
+	};
+
+	const nameTypeEditor = (props) => {
+		return (
+			<>
+				<ControlledVocabularyDropdown
+					field="nameType"
+					options={symbolNameTypeTerms}
+					editorChange={nameTypeOnChangeHandler}
+					props={props}
+					showClear={false}
+					dataKey="id"
+				/>
+				<DialogErrorMessageComponent errorMessages={errorMessages[props?.rowData?.dataKey]} errorField={'nameType'} />
+			</>
+		);
+	};
+
+	const footerTemplate = () => {
+		return (
+			<div>
+				<Button label="Cancel" icon="pi pi-times" onClick={hideDialog} className="p-button-text" />
+				<Button
+					label="Keep Edits"
+					icon={isValidating ? 'pi pi-spin pi-spinner' : 'pi pi-check'}
+					onClick={validateAndSave}
+					disabled={isValidating}
+				/>
+			</div>
+		);
+	};
+
+	let headerGroup = (
+		<ColumnGroup>
+			<Row>
+				<Column header="Display Text" />
+				<Column header="Format Text" />
+				<Column header="Synonym Scope" />
+				<Column header="Name Type" />
+				<Column header="Synonym URL" />
+				<Column header="Internal" />
+				<Column header="Evidence" />
+				<Column header="Updated By" />
+				<Column header="Date Updated" />
+			</Row>
+		</ColumnGroup>
+	);
+
+	return (
+		<div>
+			<Toast ref={toast_topright} position="top-right" />
+			<Dialog
+				visible={dialog && isInEdit}
+				className="w-10"
+				modal
+				onHide={hideDialog}
+				closable={false}
+				onShow={showDialogHandler}
+				footer={footerTemplate}
+			>
+				<h3>Symbol</h3>
+				<DataTable
+					value={localSymbols}
+					dataKey="dataKey"
+					showGridlines
+					editMode="row"
+					headerColumnGroup={headerGroup}
+					editingRows={editingRows}
+					onRowEditChange={onRowEditChange}
+					ref={tableRef}
+					cellMemo={false}
+				>
+					<Column
+						editor={(props) => {
+							return (
+								<TableInputTextEditor
+									value={props.value}
+									rowIndex={props.rowIndex}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									textOnChangeHandler={textOnChangeHandler}
+									field="displayText"
+								/>
+							);
+						}}
+						field="displayText"
+						header="Display Text"
+						headerClassName="surface-0"
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<TableInputTextEditor
+									value={props.value}
+									rowIndex={props.rowIndex}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									textOnChangeHandler={textOnChangeHandler}
+									field="formatText"
+								/>
+							);
+						}}
+						field="formatText"
+						header="Format Text"
+						headerClassName="surface-0"
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<ControlledVocabularyEditor
+									props={props}
+									onChangeHandler={synonymScopeOnChangeHandler}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									rowIndex={props.rowIndex}
+									vocabType="synonym_scope"
+									field="synonymScope"
+									showClear={true}
+								/>
+							);
+						}}
+						field="synonymScope"
+						header="Synonym Scope"
+						headerClassName="surface-0"
+					/>
+					<Column editor={nameTypeEditor} field="nameType" header="Name Type" headerClassName="surface-0" />
+					<Column
+						editor={(props) => {
+							return (
+								<TableInputTextEditor
+									value={props.value}
+									rowIndex={props.rowIndex}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									textOnChangeHandler={textOnChangeHandler}
+									field="synonymUrl"
+								/>
+							);
+						}}
+						field="synonymUrl"
+						header="Synonym URL"
+						headerClassName="surface-0"
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<InternalEditor
+									props={props}
+									rowIndex={props.rowIndex}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									internalOnChangeHandler={internalOnChangeHandler}
+								/>
+							);
+						}}
+						field="internal"
+						header="Internal"
+						headerClassName="surface-0"
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<EvidenceEditor
+									props={props}
+									errorMessages={errorMessages}
+									onChange={evidenceOnChangeHandler}
+									dataKey={props?.rowData?.dataKey}
+								/>
+							);
+						}}
+						field="evidence.curie"
+						header="Evidence"
+						headerClassName="surface-0"
+					/>
+					<Column field="updatedBy.uniqueId" header="Updated By" />
+					<Column field="dateUpdated" header="Date Updated" />
+				</DataTable>
+			</Dialog>
+		</div>
+	);
+};

--- a/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/SymbolReadOnlyDialog.js
+++ b/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/SymbolReadOnlyDialog.js
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { Dialog } from 'primereact/dialog';
+import { DataTable } from 'primereact/datatable';
+import { Column } from 'primereact/column';
+import { evidenceTemplate } from '../../../components/EvidenceComponent';
+import {
+	synonymScopeTemplate,
+	nameTypeTemplate,
+	synonymUrlTemplate,
+	displayTextTemplate,
+	formatTextTemplate,
+} from '../../../components/NameSlotAnnotationComponent';
+import { EllipsisTableCell } from '../../../components/EllipsisTableCell';
+
+export const SymbolReadOnlyDialog = ({ originalSymbolData, setOriginalSymbolData }) => {
+	const { originalSymbols, isInEdit, dialog } = originalSymbolData;
+	const [localSymbols, setLocalSymbols] = useState(null);
+
+	const showDialogHandler = () => {
+		let _localSymbols = [];
+		if (originalSymbols?.length > 0 && originalSymbols[0]) {
+			_localSymbols = global.structuredClone(originalSymbols);
+			let counter = 0;
+			_localSymbols.forEach((sym) => {
+				sym.dataKey = counter++;
+			});
+		}
+		setLocalSymbols(_localSymbols);
+	};
+
+	const hideDialog = () => {
+		setOriginalSymbolData((originalSymbolData) => {
+			return {
+				...originalSymbolData,
+				dialog: false,
+			};
+		});
+		setLocalSymbols([]);
+	};
+
+	const internalTemplate = (rowData) => {
+		return <EllipsisTableCell>{JSON.stringify(rowData.internal)}</EllipsisTableCell>;
+	};
+
+	return (
+		<Dialog
+			visible={dialog && !isInEdit}
+			className="w-10"
+			modal
+			onHide={hideDialog}
+			closable
+			onShow={showDialogHandler}
+		>
+			<h3>Symbol</h3>
+			<DataTable value={localSymbols} dataKey="dataKey" showGridlines>
+				<Column field="displayText" header="Display Text" body={displayTextTemplate} />
+				<Column field="formatText" header="Format Text" body={formatTextTemplate} />
+				<Column field="synonymScope" header="Synonym Scope" body={synonymScopeTemplate} />
+				<Column field="nameType" header="Name Type" body={nameTypeTemplate} />
+				<Column field="synonymUrl" header="Synonym URL" body={synonymUrlTemplate} />
+				<Column field="internal" header="Internal" body={internalTemplate} />
+				<Column field="evidence.curie" header="Evidence" body={(rowData) => evidenceTemplate(rowData)} />
+				<Column field="updatedBy.uniqueId" header="Updated By" />
+				<Column field="dateUpdated" header="Date Updated" />
+			</DataTable>
+		</Dialog>
+	);
+};

--- a/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/SynonymsEditDialog.js
+++ b/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/SynonymsEditDialog.js
@@ -28,12 +28,14 @@ export const SynonymsEditDialog = ({
 	const [errorMessages, setErrorMessages] = useState({});
 	const [isValidating, setIsValidating] = useState(false);
 	const validationService = new ValidationService();
+	const dataKeyCounter = useRef(0);
 	const tableRef = useRef(null);
 	const toast_topright = useRef(null);
 
 	const synonymTypeTerms = useControlledVocabularyService('name_type');
 
 	const showDialogHandler = () => {
+		dataKeyCounter.current = 0;
 		let _localSynonyms = cloneSynonyms(originalSynonyms);
 		setLocalSynonyms(_localSynonyms);
 
@@ -67,9 +69,8 @@ export const SynonymsEditDialog = ({
 		if (clonableSynonyms?.length > 0 && clonableSynonyms[0]) {
 			_clonableSynonyms = global.structuredClone(clonableSynonyms);
 			if (_clonableSynonyms) {
-				let counter = 0;
 				_clonableSynonyms.forEach((syn) => {
-					syn.dataKey = counter++;
+					syn.dataKey = dataKeyCounter.current++;
 				});
 			}
 		}
@@ -121,14 +122,14 @@ export const SynonymsEditDialog = ({
 	};
 
 	const createNewSynonymHandler = () => {
-		let cnt = localSynonyms ? localSynonyms.length : 0;
+		const newKey = dataKeyCounter.current++;
 		const _localSynonyms = global.structuredClone(localSynonyms);
 		_localSynonyms.push({
-			dataKey: cnt,
+			dataKey: newKey,
 			internal: false,
 			nameType: synonymTypeTerms?.[0] || null,
 		});
-		let _editingRows = { ...editingRows, ...{ [`${cnt}`]: true } };
+		let _editingRows = { ...editingRows, ...{ [`${newKey}`]: true } };
 		setEditingRows(_editingRows);
 		setLocalSynonyms(_localSynonyms);
 	};

--- a/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/SynonymsEditDialog.js
+++ b/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/SynonymsEditDialog.js
@@ -1,0 +1,423 @@
+import { useRef, useState } from 'react';
+import { Dialog } from 'primereact/dialog';
+import { DataTable } from 'primereact/datatable';
+import { Column } from 'primereact/column';
+import { Button } from 'primereact/button';
+import { Toast } from 'primereact/toast';
+import { ColumnGroup } from 'primereact/columngroup';
+import { Row } from 'primereact/row';
+import { ValidationService } from '../../../service/ValidationService';
+import { DeleteAction } from '../../../components/Actions/DeletionAction';
+import { TableInputTextEditor } from '../../../components/Editors/TableInputTextEditor';
+import { InternalEditor } from '../../../components/Editors/InternalEditor';
+import { EvidenceEditor } from '../../../components/Editors/EvidenceEditor';
+import { ControlledVocabularyEditor } from '../../../components/Editors/ControlledVocabularyEditor';
+import { useControlledVocabularyService } from '../../../service/useControlledVocabularyService';
+
+export const SynonymsEditDialog = ({
+	field,
+	endpoint,
+	originalSynonymsData,
+	setOriginalSynonymsData,
+	errorMessagesMainRow,
+	setErrorMessagesMainRow,
+}) => {
+	const { originalSynonyms, isInEdit, dialog, rowIndex, mainRowProps } = originalSynonymsData;
+	const [localSynonyms, setLocalSynonyms] = useState(null);
+	const [editingRows, setEditingRows] = useState({});
+	const [errorMessages, setErrorMessages] = useState({});
+	const [isValidating, setIsValidating] = useState(false);
+	const validationService = new ValidationService();
+	const tableRef = useRef(null);
+	const toast_topright = useRef(null);
+
+	const synonymTypeTerms = useControlledVocabularyService('name_type');
+
+	const showDialogHandler = () => {
+		let _localSynonyms = cloneSynonyms(originalSynonyms);
+		setLocalSynonyms(_localSynonyms);
+
+		let rowsObject = {};
+		if (_localSynonyms) {
+			_localSynonyms.forEach((syn) => {
+				rowsObject[`${syn.dataKey}`] = true;
+			});
+		}
+		setEditingRows(rowsObject);
+		setErrorMessages({});
+	};
+
+	const onRowEditChange = () => {
+		return null;
+	};
+
+	const hideDialog = () => {
+		setErrorMessages({});
+		setOriginalSynonymsData((originalSynonymsData) => {
+			return {
+				...originalSynonymsData,
+				dialog: false,
+			};
+		});
+		setLocalSynonyms([]);
+	};
+
+	const cloneSynonyms = (clonableSynonyms) => {
+		let _clonableSynonyms = [];
+		if (clonableSynonyms?.length > 0 && clonableSynonyms[0]) {
+			_clonableSynonyms = global.structuredClone(clonableSynonyms);
+			if (_clonableSynonyms) {
+				let counter = 0;
+				_clonableSynonyms.forEach((syn) => {
+					syn.dataKey = counter++;
+				});
+			}
+		}
+		return _clonableSynonyms;
+	};
+
+	const textOnChangeHandler = (rowIndex, event, field) => {
+		setLocalSynonyms((prev) => {
+			const updated = [...prev];
+			updated[rowIndex] = { ...updated[rowIndex], [field]: event.target.value };
+			return updated;
+		});
+	};
+
+	const nameTypeOnChangeHandler = (props, event) => {
+		props.editorCallback(event.value);
+		setLocalSynonyms((prev) => {
+			const updated = [...prev];
+			updated[props.rowIndex] = { ...updated[props.rowIndex], nameType: event.value };
+			return updated;
+		});
+	};
+
+	const synonymScopeOnChangeHandler = (props, event) => {
+		props.editorCallback(event.target.value);
+		setLocalSynonyms((prev) => {
+			const updated = [...prev];
+			updated[props.rowIndex] = { ...updated[props.rowIndex], synonymScope: event.target.value };
+			return updated;
+		});
+	};
+
+	const internalOnChangeHandler = (props, event) => {
+		props.editorCallback(event.target.value?.name);
+		setLocalSynonyms((prev) => {
+			const updated = [...prev];
+			updated[props.rowIndex] = { ...updated[props.rowIndex], internal: event.target?.value?.name };
+			return updated;
+		});
+	};
+
+	const evidenceOnChangeHandler = (event, setFieldValue, props) => {
+		setFieldValue(event.target.value);
+		setLocalSynonyms((prev) => {
+			const updated = [...prev];
+			updated[props.rowIndex] = { ...updated[props.rowIndex], evidence: event.target.value };
+			return updated;
+		});
+	};
+
+	const createNewSynonymHandler = () => {
+		let cnt = localSynonyms ? localSynonyms.length : 0;
+		const _localSynonyms = global.structuredClone(localSynonyms);
+		_localSynonyms.push({
+			dataKey: cnt,
+			internal: false,
+			nameType: synonymTypeTerms?.[0] || null,
+		});
+		let _editingRows = { ...editingRows, ...{ [`${cnt}`]: true } };
+		setEditingRows(_editingRows);
+		setLocalSynonyms(_localSynonyms);
+	};
+
+	const handleDeleteSynonym = (e, dataKey) => {
+		let _localSynonyms = global.structuredClone(localSynonyms);
+		_localSynonyms = _localSynonyms.filter((syn) => syn.dataKey !== dataKey);
+		setLocalSynonyms(_localSynonyms);
+	};
+
+	const saveDataHandler = () => {
+		setErrorMessages({});
+		const _localSynonyms = global.structuredClone(localSynonyms);
+		for (const syn of _localSynonyms) {
+			delete syn.dataKey;
+		}
+		mainRowProps.rowData[field] = _localSynonyms;
+		let updatedAnnotations = [...mainRowProps.props.value];
+		updatedAnnotations[rowIndex][field] = _localSynonyms;
+		// Signal PrimeReact that editing data changed so the main table re-renders the cell
+		if (mainRowProps.editorCallback) {
+			mainRowProps.editorCallback();
+		}
+
+		const errorMessagesCopy = global.structuredClone(errorMessagesMainRow);
+		let messageObject = {
+			severity: 'warn',
+			message: 'Pending Edits!',
+		};
+		errorMessagesCopy[rowIndex] = {};
+		errorMessagesCopy[rowIndex][field] = messageObject;
+		setErrorMessagesMainRow({ ...errorMessagesCopy });
+
+		setOriginalSynonymsData((originalSynonymsData) => {
+			return {
+				...originalSynonymsData,
+				dialog: false,
+			};
+		});
+	};
+
+	const cleanForValidation = (obj) => {
+		const _obj = global.structuredClone(obj);
+		delete _obj.dataKey;
+		delete _obj.updatedBy;
+		delete _obj.createdBy;
+		delete _obj.dateUpdated;
+		delete _obj.dateCreated;
+		if (_obj.evidence) {
+			_obj.evidence.forEach((ref) => {
+				delete ref.updatedBy;
+				delete ref.createdBy;
+				delete ref.dateUpdated;
+				delete ref.dateCreated;
+			});
+		}
+		return _obj;
+	};
+
+	const validateAndSave = async () => {
+		setIsValidating(true);
+		try {
+			let hasErrors = false;
+			const newErrorMessages = {};
+
+			for (let i = 0; i < localSynonyms.length; i++) {
+				const _syn = cleanForValidation(localSynonyms[i]);
+				const result = await validationService.validate(endpoint, _syn);
+				const dataKey = localSynonyms[i].dataKey;
+				if (result.isError) {
+					hasErrors = true;
+					newErrorMessages[dataKey] = {};
+					if (result.data) {
+						Object.keys(result.data).forEach((field) => {
+							newErrorMessages[dataKey][field] = {
+								severity: 'error',
+								message: result.data[field],
+							};
+						});
+					}
+				}
+			}
+
+			if (hasErrors) {
+				setErrorMessages(newErrorMessages);
+				toast_topright.current.show([
+					{
+						life: 7000,
+						severity: 'error',
+						summary: 'Validation error',
+						detail: 'Please fix validation errors before saving',
+						sticky: false,
+					},
+				]);
+			} else {
+				saveDataHandler();
+			}
+		} finally {
+			setIsValidating(false);
+		}
+	};
+
+	const footerTemplate = () => {
+		return (
+			<div>
+				<Button label="Cancel" icon="pi pi-times" onClick={hideDialog} className="p-button-text" />
+				<Button label="New Synonym" icon="pi pi-plus" onClick={createNewSynonymHandler} />
+				<Button
+					label="Keep Edits"
+					icon={isValidating ? 'pi pi-spin pi-spinner' : 'pi pi-check'}
+					onClick={validateAndSave}
+					disabled={isValidating}
+				/>
+			</div>
+		);
+	};
+
+	let headerGroup = (
+		<ColumnGroup>
+			<Row>
+				<Column header="Actions" />
+				<Column header="Display Text" />
+				<Column header="Format Text" />
+				<Column header="Synonym Scope" />
+				<Column header="Name Type" />
+				<Column header="Synonym URL" />
+				<Column header="Internal" />
+				<Column header="Evidence" />
+				<Column header="Updated By" />
+				<Column header="Date Updated" />
+			</Row>
+		</ColumnGroup>
+	);
+
+	return (
+		<div>
+			<Toast ref={toast_topright} position="top-right" />
+			<Dialog
+				visible={dialog && isInEdit}
+				className="w-10"
+				modal
+				onHide={hideDialog}
+				closable={false}
+				onShow={showDialogHandler}
+				footer={footerTemplate}
+			>
+				<h3>Synonyms</h3>
+				<DataTable
+					value={localSynonyms}
+					dataKey="dataKey"
+					showGridlines
+					editMode="row"
+					headerColumnGroup={headerGroup}
+					editingRows={editingRows}
+					onRowEditChange={onRowEditChange}
+					ref={tableRef}
+					cellMemo={false}
+				>
+					<Column
+						editor={(props) => <DeleteAction deletionHandler={handleDeleteSynonym} id={props?.rowData?.dataKey} />}
+						className="max-w-4rem"
+						bodyClassName="text-center"
+						headerClassName="surface-0"
+						frozen
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<TableInputTextEditor
+									value={props.value}
+									rowIndex={props.rowIndex}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									textOnChangeHandler={textOnChangeHandler}
+									field="displayText"
+								/>
+							);
+						}}
+						field="displayText"
+						header="Display Text"
+						headerClassName="surface-0"
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<TableInputTextEditor
+									value={props.value}
+									rowIndex={props.rowIndex}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									textOnChangeHandler={textOnChangeHandler}
+									field="formatText"
+								/>
+							);
+						}}
+						field="formatText"
+						header="Format Text"
+						headerClassName="surface-0"
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<ControlledVocabularyEditor
+									props={props}
+									onChangeHandler={synonymScopeOnChangeHandler}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									rowIndex={props.rowIndex}
+									vocabType="synonym_scope"
+									field="synonymScope"
+									showClear={true}
+								/>
+							);
+						}}
+						field="synonymScope"
+						header="Synonym Scope"
+						headerClassName="surface-0"
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<ControlledVocabularyEditor
+									props={props}
+									onChangeHandler={nameTypeOnChangeHandler}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									rowIndex={props.rowIndex}
+									vocabType="name_type"
+									field="nameType"
+									showClear={false}
+								/>
+							);
+						}}
+						field="nameType"
+						header="Name Type"
+						headerClassName="surface-0"
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<TableInputTextEditor
+									value={props.value}
+									rowIndex={props.rowIndex}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									textOnChangeHandler={textOnChangeHandler}
+									field="synonymUrl"
+								/>
+							);
+						}}
+						field="synonymUrl"
+						header="Synonym URL"
+						headerClassName="surface-0"
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<InternalEditor
+									props={props}
+									rowIndex={props.rowIndex}
+									errorMessages={errorMessages}
+									dataKey={props?.rowData?.dataKey}
+									internalOnChangeHandler={internalOnChangeHandler}
+								/>
+							);
+						}}
+						field="internal"
+						header="Internal"
+						headerClassName="surface-0"
+					/>
+					<Column
+						editor={(props) => {
+							return (
+								<EvidenceEditor
+									props={props}
+									errorMessages={errorMessages}
+									onChange={evidenceOnChangeHandler}
+									dataKey={props?.rowData?.dataKey}
+								/>
+							);
+						}}
+						field="evidence.curie"
+						header="Evidence"
+						headerClassName="surface-0"
+					/>
+					<Column field="updatedBy.uniqueId" header="Updated By" />
+					<Column field="dateUpdated" header="Date Updated" />
+				</DataTable>
+			</Dialog>
+		</div>
+	);
+};

--- a/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/SynonymsReadOnlyDialog.js
+++ b/src/main/cliapp/src/containers/nameSlotAnnotations/dialogs/SynonymsReadOnlyDialog.js
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { Dialog } from 'primereact/dialog';
+import { DataTable } from 'primereact/datatable';
+import { Column } from 'primereact/column';
+import { evidenceTemplate } from '../../../components/EvidenceComponent';
+import {
+	synonymScopeTemplate,
+	nameTypeTemplate,
+	synonymUrlTemplate,
+	displayTextTemplate,
+	formatTextTemplate,
+} from '../../../components/NameSlotAnnotationComponent';
+import { EllipsisTableCell } from '../../../components/EllipsisTableCell';
+
+export const SynonymsReadOnlyDialog = ({ originalSynonymsData, setOriginalSynonymsData }) => {
+	const { originalSynonyms, isInEdit, dialog } = originalSynonymsData;
+	const [localSynonyms, setLocalSynonyms] = useState(null);
+
+	const showDialogHandler = () => {
+		let _localSynonyms = [];
+		if (originalSynonyms?.length > 0 && originalSynonyms[0]) {
+			_localSynonyms = global.structuredClone(originalSynonyms);
+			let counter = 0;
+			_localSynonyms.forEach((syn) => {
+				syn.dataKey = counter++;
+			});
+		}
+		setLocalSynonyms(_localSynonyms);
+	};
+
+	const hideDialog = () => {
+		setOriginalSynonymsData((originalSynonymsData) => {
+			return {
+				...originalSynonymsData,
+				dialog: false,
+			};
+		});
+		setLocalSynonyms([]);
+	};
+
+	const internalTemplate = (rowData) => {
+		return <EllipsisTableCell>{JSON.stringify(rowData.internal)}</EllipsisTableCell>;
+	};
+
+	return (
+		<Dialog
+			visible={dialog && !isInEdit}
+			className="w-10"
+			modal
+			onHide={hideDialog}
+			closable
+			onShow={showDialogHandler}
+		>
+			<h3>Synonyms</h3>
+			<DataTable value={localSynonyms} dataKey="dataKey" showGridlines>
+				<Column field="displayText" header="Display Text" body={displayTextTemplate} />
+				<Column field="formatText" header="Format Text" body={formatTextTemplate} />
+				<Column field="synonymScope" header="Synonym Scope" body={synonymScopeTemplate} />
+				<Column field="nameType" header="Name Type" body={nameTypeTemplate} />
+				<Column field="synonymUrl" header="Synonym URL" body={synonymUrlTemplate} />
+				<Column field="internal" header="Internal" body={internalTemplate} />
+				<Column field="evidence.curie" header="Evidence" body={(rowData) => evidenceTemplate(rowData)} />
+				<Column field="updatedBy.uniqueId" header="Updated By" />
+				<Column field="dateUpdated" header="Date Updated" />
+			</DataTable>
+		</Dialog>
+	);
+};

--- a/src/main/cliapp/src/containers/variantsPage/VariantsTable.js
+++ b/src/main/cliapp/src/containers/variantsPage/VariantsTable.js
@@ -98,9 +98,8 @@ export const VariantsTable = () => {
 	};
 
 	const handleRelatedNotesOpenInEdit = (event, rowProps, isInEdit) => {
-		const { rows } = rowProps.props;
 		const { rowIndex } = rowProps;
-		const index = rowIndex % rows;
+		const index = rowIndex;
 		let _relatedNotesData = {};
 		_relatedNotesData['originalRelatedNotes'] = rowProps.rowData.relatedNotes;
 		_relatedNotesData['dialog'] = true;

--- a/src/main/cliapp/src/serviceWorker.js
+++ b/src/main/cliapp/src/serviceWorker.js
@@ -12,10 +12,10 @@
 
 const isLocalhost = Boolean(
 	window.location.hostname === 'localhost' ||
-		// [::1] is the IPv6 localhost address.
-		window.location.hostname === '[::1]' ||
-		// 127.0.0.1/8 is considered localhost for IPv4.
-		window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
+	// [::1] is the IPv6 localhost address.
+	window.location.hostname === '[::1]' ||
+	// 127.0.0.1/8 is considered localhost for IPv4.
+	window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
 );
 
 export function register(config) {

--- a/src/main/cliapp/src/serviceWorker.js
+++ b/src/main/cliapp/src/serviceWorker.js
@@ -12,10 +12,10 @@
 
 const isLocalhost = Boolean(
 	window.location.hostname === 'localhost' ||
-	// [::1] is the IPv6 localhost address.
-	window.location.hostname === '[::1]' ||
-	// 127.0.0.1/8 is considered localhost for IPv4.
-	window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
+		// [::1] is the IPv6 localhost address.
+		window.location.hostname === '[::1]' ||
+		// 127.0.0.1/8 is considered localhost for IPv4.
+		window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
 );
 
 export function register(config) {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Person.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Person.java
@@ -12,7 +12,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextFi
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 
 import jakarta.persistence.Column;

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Person.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Person.java
@@ -67,13 +67,11 @@ public class Person extends Agent {
 
 	@KeywordField(aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES)
 	@ElementCollection
-	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	@JoinTable(indexes = @Index(columnList = "person_id"))
 	private List<String> emails;
 
 	@KeywordField(aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES)
 	@ElementCollection
-	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	@JoinTable(indexes = @Index(columnList = "person_id"))
 	private List<String> oldEmails;
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Person.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Person.java
@@ -12,6 +12,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextFi
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 
 import jakarta.persistence.Column;
@@ -66,13 +67,13 @@ public class Person extends Agent {
 
 	@KeywordField(aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES)
 	@ElementCollection
-	@JsonView({ CurationView.FieldsAndLists.class, CurationView.PersonSettingView.class })
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	@JoinTable(indexes = @Index(columnList = "person_id"))
 	private List<String> emails;
 
 	@KeywordField(aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES)
 	@ElementCollection
-	@JsonView({ CurationView.FieldsAndLists.class, CurationView.PersonSettingView.class })
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	@JoinTable(indexes = @Index(columnList = "person_id"))
 	private List<String> oldEmails;
 


### PR DESCRIPTION
…face

The curation table dialogs for synonyms, symbols, and full names were broken after the PrimeReact 8→10 migration — row editing had stale closure races, rows swapped positions, and Keep Edits was unresponsive.

Split each dialog into Edit + ReadOnly components using the always-edit DataTable pattern (no per-row save/cancel) with batch validation on Keep Edits. Read-only dialogs are simple display tables.

Also fixes:
- rowIndex % rows bug in all handleXXXOpenInEdit functions across AllelesTable, GenesTable, and VariantsTable
- Person.emails/oldEmails LazyInitializationException on validate endpoints via @JsonProperty(access = WRITE_ONLY)
- Main table cell not re-rendering after dialog save (synonym count and Pending Edits warning) via PrimeReact editorCallback()