### PR TITLE
SCRUM-5883, SCRUM-5862 Suppress wild-type alleles, fix scheduled loads

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
@@ -239,6 +239,9 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 			SELECT a.id
 			FROM Allele a
 			INNER JOIN BiologicalEntity b ON b.id = a.id AND b.obsolete = false AND b.internal = false
+			LEFT JOIN AlleleFullNameSlotAnnotation afn ON afn.singleallele_id = a.id
+			LEFT JOIN NameSlotAnnotation nsa ON nsa.id = afn.id
+			WHERE nsa.displaytext IS NULL OR nsa.displaytext <> 'wild type'
 			ORDER BY a.id
 			""";
 

--- a/src/main/java/org/alliancegenome/curation_api/jobs/JobScheduler.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/JobScheduler.java
@@ -136,9 +136,10 @@ public class JobScheduler {
 	@Scheduled(every = "1m")
 	public void scheduleCronJobs() {
 		IndexProcessingEvent event = indexProcessingWebsocket.getEvent();
-		Boolean blockedByMassIndexer = true;
-		if (event != null && event instanceof EndIndexProcessingEvent) {
-			blockedByMassIndexer = false;
+		boolean blockedByMassIndexer = event != null && !(event instanceof EndIndexProcessingEvent);
+
+		if (blockedByMassIndexer) {
+			Log.info("Scheduled events blocked by mass indexer");
 		}
 
 		if (loadSchedulingEnabled && !blockedByMassIndexer) {


### PR DESCRIPTION
## Summary
- **SCRUM-5883**: Filter out alleles with fullName "wild type" from the allele summary ID query
  - Alleles without a full name are still included
  - Wild-type alleles remain valid in curation, just excluded from summary/search results
- **SCRUM-5862**: Fix scheduled ontology loads not running after server restart
  - The mass indexer gate defaulted to blocked when no indexing event had ever fired (null after restart)
  - Inverted the logic so loads are only blocked while a mass indexer is actively running
  - Added log line when loads are blocked by the mass indexer

## Test plan
- [ ] Verify wild-type alleles no longer appear in gene page allele/variant tables
- [ ] Verify alleles without a full name still appear
- [ ] Verify wild-type allele pages are still accessible directly by ID
- [ ] Verify scheduled ontology loads run after a server restart without a manual reindex
- [ ] Verify loads are still blocked while a mass indexer is actively running

🤖 Generated with [Claude Code](https://claude.com/claude-code)