### PR TITLE
SCRUM-4937: Disease search results from curation API

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/controllers/document/DiseaseDocumentController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/document/DiseaseDocumentController.java
@@ -35,7 +35,6 @@ public class DiseaseDocumentController implements DiseaseDocumentInterface {
 		SearchResponse<DOTerm> resp = doTermService.findByParams(pagination, params);
 		ResourceDescriptorPage diseaseResourceDescriptorPage = resourceDescriptorPageService.getPageForResourceDescriptor("DOID", "default");
 
-
 		List<String> sources = List.of("RGD", "MGI", "ZFIN", "FB", "WB", "SGD");
 		ArrayList<DiseaseSummaryDocument> list = new ArrayList<>();
 		if (resp.getResults() != null) {
@@ -70,39 +69,8 @@ public class DiseaseDocumentController implements DiseaseDocumentInterface {
 	}
 
 	@Override
-	public SearchResponse<DiseaseSearchResultDocument> findSearchResult(Integer page, Integer limit, HashMap<String, Object> params) {
-		if (params == null) {
-			params = new HashMap<>();
-		}
-
-		Pagination pagination = new Pagination(page, limit);
-		SearchResponse<DOTerm> resp = doTermService.findByParams(pagination, params);
-
-		ArrayList<DiseaseSearchResultDocument> list = new ArrayList<>();
-		if (resp.getResults() != null) {
-			DiseaseSummaryDocumentBuilder builder = new DiseaseSummaryDocumentBuilder();
-			for (DOTerm doTerm : resp.getResults()) {
-				DiseaseSearchResultDocument doc = builder.buildSearchResultDocument(doTerm);
-				list.add(doc);
-			}
-		}
-
-		SearchResponse<DiseaseSearchResultDocument> ret = new SearchResponse<>(list);
-		ret.setTotalResults(resp.getTotalResults());
-		return ret;
-	}
-
-	@Override
-	public SearchResponse<Long> getAllIds() {
-		List<Long> ids = doTermService.getAllIds();
-		SearchResponse<Long> response = new SearchResponse<>(ids);
-		response.setTotalResults((long) ids.size());
-		return response;
-	}
-
-	@Override
-	public SearchResponse<DiseaseSearchResultDocument> findByIds(List<Long> ids) {
-		List<DiseaseSearchResultDocument> list = doTermService.buildSearchResultDocuments(ids);
+	public SearchResponse<DiseaseSearchResultDocument> findAll() {
+		List<DiseaseSearchResultDocument> list = doTermService.buildAllSearchResultDocuments();
 		SearchResponse<DiseaseSearchResultDocument> ret = new SearchResponse<>(list);
 		ret.setTotalResults((long) list.size());
 		return ret;

--- a/src/main/java/org/alliancegenome/curation_api/controllers/document/DiseaseDocumentController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/document/DiseaseDocumentController.java
@@ -92,5 +92,28 @@ public class DiseaseDocumentController implements DiseaseDocumentInterface {
 		return ret;
 	}
 
+	@Override
+	public SearchResponse<Long> getAllIds() {
+		List<Long> ids = doTermService.getAllIds();
+		SearchResponse<Long> response = new SearchResponse<>(ids);
+		response.setTotalResults((long) ids.size());
+		return response;
+	}
+
+	@Override
+	public SearchResponse<DiseaseSearchResultDocument> findByIds(List<Long> ids) {
+		List<DOTerm> doTerms = doTermService.findByIds(ids);
+		ArrayList<DiseaseSearchResultDocument> list = new ArrayList<>();
+		if (doTerms != null) {
+			DiseaseSummaryDocumentBuilder builder = new DiseaseSummaryDocumentBuilder();
+			for (DOTerm doTerm : doTerms) {
+				DiseaseSearchResultDocument doc = builder.buildSearchResultDocument(doTerm);
+				list.add(doc);
+			}
+		}
+		SearchResponse<DiseaseSearchResultDocument> ret = new SearchResponse<>(list);
+		ret.setTotalResults((long) list.size());
+		return ret;
+	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/controllers/document/DiseaseDocumentController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/document/DiseaseDocumentController.java
@@ -102,15 +102,7 @@ public class DiseaseDocumentController implements DiseaseDocumentInterface {
 
 	@Override
 	public SearchResponse<DiseaseSearchResultDocument> findByIds(List<Long> ids) {
-		List<DOTerm> doTerms = doTermService.findByIds(ids);
-		ArrayList<DiseaseSearchResultDocument> list = new ArrayList<>();
-		if (doTerms != null) {
-			DiseaseSummaryDocumentBuilder builder = new DiseaseSummaryDocumentBuilder();
-			for (DOTerm doTerm : doTerms) {
-				DiseaseSearchResultDocument doc = builder.buildSearchResultDocument(doTerm);
-				list.add(doc);
-			}
-		}
+		List<DiseaseSearchResultDocument> list = doTermService.buildSearchResultDocuments(ids);
 		SearchResponse<DiseaseSearchResultDocument> ret = new SearchResponse<>(list);
 		ret.setTotalResults((long) list.size());
 		return ret;

--- a/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
@@ -168,7 +168,7 @@ public class DoTermDAO extends BaseSQLDAO<DOTerm> {
 			SELECT ag.doterm_id, sa.displaytext AS gene_symbol, sp.abbreviation,
 				split_part(taxon.name, ' ', 1) || ' ' || split_part(taxon.name, ' ', 2) AS genus_species
 			FROM all_genes ag
-			JOIN slotannotation sa ON sa.singlegene_id = ag.gene_id AND sa.dtype = 'GeneSymbolSlotAnnotation'
+			JOIN slotannotation sa ON sa.singlegene_id = ag.gene_id AND sa.slotannotationtype = 'GeneSymbolSlotAnnotation'
 			JOIN biologicalentity be ON be.id = ag.gene_id
 			JOIN ontologyterm taxon ON taxon.id = be.taxon_id
 			JOIN species sp ON sp.taxon_id = taxon.id

--- a/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
@@ -2,9 +2,11 @@ package org.alliancegenome.curation_api.dao.ontology;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.ontology.DOTerm;
+import org.apache.commons.collections.CollectionUtils;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.persistence.Query;
@@ -22,16 +24,44 @@ public class DoTermDAO extends BaseSQLDAO<DOTerm> {
 			FROM ontologyterm
 			WHERE ontologytermtype = 'DOTerm'
 		""";
-		
+
 		Query query = entityManager.createNativeQuery(sql);
 		List<Object> objects = query.getResultList();
 		List<String> list = new ArrayList<>();
-		
+
 		objects.forEach(object -> {
 			list.add((String) object);
 		});
-		
+
 		return list;
+	}
+
+	public List<Long> getAllIds() {
+		String sql = """
+			SELECT id
+			FROM ontologyterm
+			WHERE ontologytermtype = 'DOTerm'
+			AND obsolete = false
+			AND internal = false
+			ORDER BY id
+			""";
+		Query query = entityManager.createNativeQuery(sql);
+		List<Object> results = query.getResultList();
+		return results.stream().map(obj -> (Long) obj).collect(Collectors.toList());
+	}
+
+	public List<DOTerm> findByIds(List<Long> ids) {
+		if (CollectionUtils.isEmpty(ids)) {
+			return new ArrayList<>();
+		}
+		String jpql = """
+			SELECT DISTINCT d FROM DOTerm d
+			LEFT JOIN FETCH d.synonyms
+			WHERE d.id IN :ids
+			""";
+		return entityManager.createQuery(jpql, DOTerm.class)
+			.setParameter("ids", ids)
+			.getResultList();
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
@@ -64,135 +64,113 @@ public class DoTermDAO extends BaseSQLDAO<DOTerm> {
 			.getResultList();
 	}
 
-	public List<Object[]> findBaseFieldsByIds(List<Long> ids) {
-		if (CollectionUtils.isEmpty(ids)) {
-			return new ArrayList<>();
-		}
+	public List<Object[]> findAllBaseFields() {
 		String sql = """
 			SELECT id, curie, name, definition
 			FROM ontologyterm
-			WHERE id IN (:ids)
+			WHERE ontologytermtype = 'DOTerm' AND obsolete = false AND internal = false
+			ORDER BY id
 			""";
-		return entityManager.createNativeQuery(sql)
-			.setParameter("ids", ids)
-			.getResultList();
+		return entityManager.createNativeQuery(sql).getResultList();
 	}
 
-	public List<Object[]> findSynonymsByIds(List<Long> ids) {
-		if (CollectionUtils.isEmpty(ids)) {
-			return new ArrayList<>();
-		}
+	public List<Object[]> findAllSynonyms() {
 		String sql = """
 			SELECT os.ontologyterm_id, s.name
 			FROM ontologyterm_synonym os
 			JOIN synonym s ON s.id = os.synonyms_id
-			WHERE os.ontologyterm_id IN (:ids)
+			JOIN ontologyterm ot ON ot.id = os.ontologyterm_id
+			WHERE ot.ontologytermtype = 'DOTerm' AND ot.obsolete = false AND ot.internal = false
 			""";
-		return entityManager.createNativeQuery(sql)
-			.setParameter("ids", ids)
-			.getResultList();
+		return entityManager.createNativeQuery(sql).getResultList();
 	}
 
-	public List<Object[]> findCrossReferencesByIds(List<Long> ids) {
-		if (CollectionUtils.isEmpty(ids)) {
-			return new ArrayList<>();
-		}
+	public List<Object[]> findAllCrossReferences() {
 		String sql = """
 			SELECT ocr.ontologyterm_id, cr.displayname
 			FROM ontologyterm_crossreference ocr
 			JOIN crossreference cr ON cr.id = ocr.crossreferences_id
-			WHERE ocr.ontologyterm_id IN (:ids)
+			JOIN ontologyterm ot ON ot.id = ocr.ontologyterm_id
+			WHERE ot.ontologytermtype = 'DOTerm' AND ot.obsolete = false AND ot.internal = false
 			""";
-		return entityManager.createNativeQuery(sql)
-			.setParameter("ids", ids)
-			.getResultList();
+		return entityManager.createNativeQuery(sql).getResultList();
 	}
 
-	public List<Object[]> findSecondaryIdsByIds(List<Long> ids) {
-		if (CollectionUtils.isEmpty(ids)) {
-			return new ArrayList<>();
-		}
+	public List<Object[]> findAllSecondaryIds() {
 		String sql = """
-			SELECT ontologyterm_id, secondaryidentifiers
-			FROM ontologyterm_secondaryidentifiers
-			WHERE ontologyterm_id IN (:ids)
+			SELECT osi.ontologyterm_id, osi.secondaryidentifiers
+			FROM ontologyterm_secondaryidentifiers osi
+			JOIN ontologyterm ot ON ot.id = osi.ontologyterm_id
+			WHERE ot.ontologytermtype = 'DOTerm' AND ot.obsolete = false AND ot.internal = false
 			""";
-		return entityManager.createNativeQuery(sql)
-			.setParameter("ids", ids)
-			.getResultList();
+		return entityManager.createNativeQuery(sql).getResultList();
 	}
 
-	public List<Object[]> findGenesAndSpeciesByIds(List<Long> ids) {
-		if (CollectionUtils.isEmpty(ids)) {
-			return new ArrayList<>();
-		}
+	public List<Object[]> findAllGeneSymbols() {
+		String sql = """
+			SELECT sa.singlegene_id, sa.displaytext, sp.abbreviation,
+				split_part(taxon.name, ' ', 1) || ' ' || split_part(taxon.name, ' ', 2) AS genus_species
+			FROM slotannotation sa
+			JOIN biologicalentity be ON be.id = sa.singlegene_id
+			JOIN ontologyterm taxon ON taxon.id = be.taxon_id
+			JOIN species sp ON sp.taxon_id = taxon.id
+			WHERE sa.slotannotationtype = 'GeneSymbolSlotAnnotation'
+			AND sa.singlegene_id IS NOT NULL
+			""";
+		return entityManager.createNativeQuery(sql).getResultList();
+	}
+
+	public List<Object[]> findDiseaseGeneIds() {
 		String sql = """
 			WITH direct_genes AS (
 				SELECT da.diseaseannotationobject_id AS doterm_id, gda.diseaseannotationsubject_id AS gene_id
 				FROM diseaseannotation da
 				JOIN genediseaseannotation gda ON gda.id = da.id
-				WHERE da.diseaseannotationobject_id IN (:ids) AND da.internal = false AND da.obsolete = false
+				WHERE da.internal = false AND da.obsolete = false
 				UNION
 				SELECT da.diseaseannotationobject_id, agmda.inferredgene_id
 				FROM diseaseannotation da
 				JOIN agmdiseaseannotation agmda ON agmda.id = da.id
-				WHERE da.diseaseannotationobject_id IN (:ids) AND da.internal = false AND da.obsolete = false
-					AND agmda.inferredgene_id IS NOT NULL
+				WHERE da.internal = false AND da.obsolete = false AND agmda.inferredgene_id IS NOT NULL
 				UNION
 				SELECT da.diseaseannotationobject_id, ag.assertedgenes_id
 				FROM diseaseannotation da
 				JOIN agmdiseaseannotation agmda ON agmda.id = da.id
 				JOIN agmdiseaseannotation_gene ag ON ag.agmdiseaseannotation_id = agmda.id
-				WHERE da.diseaseannotationobject_id IN (:ids) AND da.internal = false AND da.obsolete = false
+				WHERE da.internal = false AND da.obsolete = false
 				UNION
 				SELECT da.diseaseannotationobject_id, ada.inferredgene_id
 				FROM diseaseannotation da
 				JOIN allelediseaseannotation ada ON ada.id = da.id
-				WHERE da.diseaseannotationobject_id IN (:ids) AND da.internal = false AND da.obsolete = false
-					AND ada.inferredgene_id IS NOT NULL
+				WHERE da.internal = false AND da.obsolete = false AND ada.inferredgene_id IS NOT NULL
 				UNION
 				SELECT da.diseaseannotationobject_id, adag.assertedgenes_id
 				FROM diseaseannotation da
 				JOIN allelediseaseannotation ada ON ada.id = da.id
 				JOIN allelediseaseannotation_gene adag ON adag.allelediseaseannotation_id = ada.id
-				WHERE da.diseaseannotationobject_id IN (:ids) AND da.internal = false AND da.obsolete = false
-			),
-			all_genes AS (
-				SELECT doterm_id, gene_id FROM direct_genes
-				UNION
-				SELECT dg.doterm_id, g2g.objectgene_id
-				FROM direct_genes dg
-				JOIN genetogeneorthology g2g ON g2g.subjectgene_id = dg.gene_id
-				JOIN genetogeneorthologygenerated g2gg ON g2gg.id = g2g.id AND g2gg.strictfilter = true
+				WHERE da.internal = false AND da.obsolete = false
 			)
-			SELECT ag.doterm_id, sa.displaytext AS gene_symbol, sp.abbreviation,
-				split_part(taxon.name, ' ', 1) || ' ' || split_part(taxon.name, ' ', 2) AS genus_species
-			FROM all_genes ag
-			JOIN slotannotation sa ON sa.singlegene_id = ag.gene_id AND sa.slotannotationtype = 'GeneSymbolSlotAnnotation'
-			JOIN biologicalentity be ON be.id = ag.gene_id
-			JOIN ontologyterm taxon ON taxon.id = be.taxon_id
-			JOIN species sp ON sp.taxon_id = taxon.id
+			SELECT doterm_id, gene_id FROM direct_genes
+			UNION
+			SELECT dg.doterm_id, g2g.objectgene_id
+			FROM direct_genes dg
+			JOIN genetogeneorthology g2g ON g2g.subjectgene_id = dg.gene_id
+			JOIN genetogeneorthologygenerated g2gg ON g2gg.id = g2g.id AND g2gg.strictfilter = true
 			""";
-		return entityManager.createNativeQuery(sql)
-			.setParameter("ids", ids)
-			.getResultList();
+		return entityManager.createNativeQuery(sql).getResultList();
 	}
 
-	public List<Object[]> findDiseaseGroupByIds(List<Long> ids) {
-		if (CollectionUtils.isEmpty(ids)) {
-			return new ArrayList<>();
-		}
+	public List<Object[]> findAllDiseaseGroups() {
 		String sql = """
-			SELECT otc.closuresubject_id, ancestor.name
+			SELECT DISTINCT otc.closuresubject_id, ancestor.name
 			FROM ontologytermclosure otc
 			JOIN ontologyterm ancestor ON ancestor.id = otc.closureobject_id
 			JOIN ontologyterm_subsets sub ON sub.ontologyterm_id = ancestor.id
-			WHERE otc.closuresubject_id IN (:ids)
-				AND sub.subsets = 'DO_AGR_slim'
+			JOIN ontologyterm doterm ON doterm.id = otc.closuresubject_id
+			WHERE sub.subsets = 'DO_AGR_slim'
+				AND doterm.ontologytermtype = 'DOTerm' AND doterm.obsolete = false AND doterm.internal = false
 			""";
-		return entityManager.createNativeQuery(sql)
-			.setParameter("ids", ids)
-			.getResultList();
+		return entityManager.createNativeQuery(sql).getResultList();
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
@@ -6,7 +6,6 @@ import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.ontology.DOTerm;
-import org.apache.commons.collections.CollectionUtils;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.persistence.Query;
@@ -48,20 +47,6 @@ public class DoTermDAO extends BaseSQLDAO<DOTerm> {
 		Query query = entityManager.createNativeQuery(sql);
 		List<Object> results = query.getResultList();
 		return results.stream().map(obj -> (Long) obj).collect(Collectors.toList());
-	}
-
-	public List<DOTerm> findByIds(List<Long> ids) {
-		if (CollectionUtils.isEmpty(ids)) {
-			return new ArrayList<>();
-		}
-		String jpql = """
-			SELECT DISTINCT d FROM DOTerm d
-			LEFT JOIN FETCH d.synonyms
-			WHERE d.id IN :ids
-			""";
-		return entityManager.createQuery(jpql, DOTerm.class)
-			.setParameter("ids", ids)
-			.getResultList();
 	}
 
 	public List<Object[]> findAllBaseFields() {

--- a/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
@@ -2,7 +2,6 @@ package org.alliancegenome.curation_api.dao.ontology;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.ontology.DOTerm;
@@ -33,20 +32,6 @@ public class DoTermDAO extends BaseSQLDAO<DOTerm> {
 		});
 
 		return list;
-	}
-
-	public List<Long> getAllIds() {
-		String sql = """
-			SELECT id
-			FROM ontologyterm
-			WHERE ontologytermtype = 'DOTerm'
-			AND obsolete = false
-			AND internal = false
-			ORDER BY id
-			""";
-		Query query = entityManager.createNativeQuery(sql);
-		List<Object> results = query.getResultList();
-		return results.stream().map(obj -> (Long) obj).collect(Collectors.toList());
 	}
 
 	public List<Object[]> findAllBaseFields() {

--- a/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
@@ -64,4 +64,135 @@ public class DoTermDAO extends BaseSQLDAO<DOTerm> {
 			.getResultList();
 	}
 
+	public List<Object[]> findBaseFieldsByIds(List<Long> ids) {
+		if (CollectionUtils.isEmpty(ids)) {
+			return new ArrayList<>();
+		}
+		String sql = """
+			SELECT id, curie, name, definition
+			FROM ontologyterm
+			WHERE id IN (:ids)
+			""";
+		return entityManager.createNativeQuery(sql)
+			.setParameter("ids", ids)
+			.getResultList();
+	}
+
+	public List<Object[]> findSynonymsByIds(List<Long> ids) {
+		if (CollectionUtils.isEmpty(ids)) {
+			return new ArrayList<>();
+		}
+		String sql = """
+			SELECT os.ontologyterm_id, s.name
+			FROM ontologyterm_synonym os
+			JOIN synonym s ON s.id = os.synonyms_id
+			WHERE os.ontologyterm_id IN (:ids)
+			""";
+		return entityManager.createNativeQuery(sql)
+			.setParameter("ids", ids)
+			.getResultList();
+	}
+
+	public List<Object[]> findCrossReferencesByIds(List<Long> ids) {
+		if (CollectionUtils.isEmpty(ids)) {
+			return new ArrayList<>();
+		}
+		String sql = """
+			SELECT ocr.ontologyterm_id, cr.displayname
+			FROM ontologyterm_crossreference ocr
+			JOIN crossreference cr ON cr.id = ocr.crossreferences_id
+			WHERE ocr.ontologyterm_id IN (:ids)
+			""";
+		return entityManager.createNativeQuery(sql)
+			.setParameter("ids", ids)
+			.getResultList();
+	}
+
+	public List<Object[]> findSecondaryIdsByIds(List<Long> ids) {
+		if (CollectionUtils.isEmpty(ids)) {
+			return new ArrayList<>();
+		}
+		String sql = """
+			SELECT ontologyterm_id, secondaryidentifiers
+			FROM ontologyterm_secondaryidentifiers
+			WHERE ontologyterm_id IN (:ids)
+			""";
+		return entityManager.createNativeQuery(sql)
+			.setParameter("ids", ids)
+			.getResultList();
+	}
+
+	public List<Object[]> findGenesAndSpeciesByIds(List<Long> ids) {
+		if (CollectionUtils.isEmpty(ids)) {
+			return new ArrayList<>();
+		}
+		String sql = """
+			WITH direct_genes AS (
+				SELECT da.diseaseannotationobject_id AS doterm_id, gda.diseaseannotationsubject_id AS gene_id
+				FROM diseaseannotation da
+				JOIN genediseaseannotation gda ON gda.id = da.id
+				WHERE da.diseaseannotationobject_id IN (:ids) AND da.internal = false AND da.obsolete = false
+				UNION
+				SELECT da.diseaseannotationobject_id, agmda.inferredgene_id
+				FROM diseaseannotation da
+				JOIN agmdiseaseannotation agmda ON agmda.id = da.id
+				WHERE da.diseaseannotationobject_id IN (:ids) AND da.internal = false AND da.obsolete = false
+					AND agmda.inferredgene_id IS NOT NULL
+				UNION
+				SELECT da.diseaseannotationobject_id, ag.assertedgenes_id
+				FROM diseaseannotation da
+				JOIN agmdiseaseannotation agmda ON agmda.id = da.id
+				JOIN agmdiseaseannotation_gene ag ON ag.agmdiseaseannotation_id = agmda.id
+				WHERE da.diseaseannotationobject_id IN (:ids) AND da.internal = false AND da.obsolete = false
+				UNION
+				SELECT da.diseaseannotationobject_id, ada.inferredgene_id
+				FROM diseaseannotation da
+				JOIN allelediseaseannotation ada ON ada.id = da.id
+				WHERE da.diseaseannotationobject_id IN (:ids) AND da.internal = false AND da.obsolete = false
+					AND ada.inferredgene_id IS NOT NULL
+				UNION
+				SELECT da.diseaseannotationobject_id, adag.assertedgenes_id
+				FROM diseaseannotation da
+				JOIN allelediseaseannotation ada ON ada.id = da.id
+				JOIN allelediseaseannotation_gene adag ON adag.allelediseaseannotation_id = ada.id
+				WHERE da.diseaseannotationobject_id IN (:ids) AND da.internal = false AND da.obsolete = false
+			),
+			all_genes AS (
+				SELECT doterm_id, gene_id FROM direct_genes
+				UNION
+				SELECT dg.doterm_id, g2g.objectgene_id
+				FROM direct_genes dg
+				JOIN genetogeneorthology g2g ON g2g.subjectgene_id = dg.gene_id
+				JOIN genetogeneorthologygenerated g2gg ON g2gg.id = g2g.id AND g2gg.strictfilter = true
+			)
+			SELECT ag.doterm_id, sa.displaytext AS gene_symbol, sp.abbreviation,
+				split_part(taxon.name, ' ', 1) || ' ' || split_part(taxon.name, ' ', 2) AS genus_species
+			FROM all_genes ag
+			JOIN slotannotation sa ON sa.singlegene_id = ag.gene_id AND sa.dtype = 'GeneSymbolSlotAnnotation'
+			JOIN biologicalentity be ON be.id = ag.gene_id
+			JOIN ontologyterm taxon ON taxon.id = be.taxon_id
+			JOIN species sp ON sp.taxon_id = taxon.id
+			""";
+		return entityManager.createNativeQuery(sql)
+			.setParameter("ids", ids)
+			.getResultList();
+	}
+
+	public List<Object[]> findDiseaseGroupByIds(List<Long> ids) {
+		if (CollectionUtils.isEmpty(ids)) {
+			return new ArrayList<>();
+		}
+		String sql = """
+			SELECT otc.closuresubject_id, ancestor.name
+			FROM ontologytermclosure otc
+			JOIN ontologyterm ancestor ON ancestor.id = otc.closureobject_id
+			JOIN ontologyterm_subsets sub ON sub.ontologyterm_id = ancestor.id
+			WHERE otc.closuresubject_id IN (:ids)
+				AND sub.subsets = 'DO_AGR_slim'
+			""";
+		return entityManager.createNativeQuery(sql)
+			.setParameter("ids", ids)
+			.getResultList();
+	}
+
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/document/DiseaseDocumentInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/document/DiseaseDocumentInterface.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.curation_api.interfaces.document;
 
 import java.util.HashMap;
+import java.util.List;
 
 import org.alliancegenome.curation_api.model.document.es.DiseaseSearchResultDocument;
 import org.alliancegenome.curation_api.model.document.es.DiseaseSummaryDocument;
@@ -13,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -35,5 +37,13 @@ public interface DiseaseDocumentInterface {
 	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	SearchResponse<DiseaseSearchResultDocument> findSearchResult(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
 
+	@GET
+	@Path("/ids")
+	SearchResponse<Long> getAllIds();
+
+	@POST
+	@Path("/byids")
+	@JsonView(CurationView.DiseaseSearchResultDocument.class)
+	SearchResponse<DiseaseSearchResultDocument> findByIds(@RequestBody List<Long> ids);
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/document/DiseaseDocumentInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/document/DiseaseDocumentInterface.java
@@ -1,7 +1,6 @@
 package org.alliancegenome.curation_api.interfaces.document;
 
 import java.util.HashMap;
-import java.util.List;
 
 import org.alliancegenome.curation_api.model.document.es.DiseaseSearchResultDocument;
 import org.alliancegenome.curation_api.model.document.es.DiseaseSummaryDocument;
@@ -32,18 +31,9 @@ public interface DiseaseDocumentInterface {
 	@JsonView(CurationView.DiseaseSummaryDocument.class)
 	SearchResponse<DiseaseSummaryDocument> findSummary(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
 
-	@POST
-	@Path("/searchresult")
-	@JsonView(CurationView.DiseaseSearchResultDocument.class)
-	SearchResponse<DiseaseSearchResultDocument> findSearchResult(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, @RequestBody HashMap<String, Object> params);
-
 	@GET
-	@Path("/ids")
-	SearchResponse<Long> getAllIds();
-
-	@POST
-	@Path("/byids")
+	@Path("/all")
 	@JsonView(CurationView.DiseaseSearchResultDocument.class)
-	SearchResponse<DiseaseSearchResultDocument> findByIds(@RequestBody List<Long> ids);
+	SearchResponse<DiseaseSearchResultDocument> findAll();
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/document/builders/DiseaseSummaryDocumentBuilder.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/builders/DiseaseSummaryDocumentBuilder.java
@@ -13,8 +13,6 @@ import java.util.stream.Collectors;
 import org.alliancegenome.curation_api.model.document.es.DiseaseSearchResultDocument;
 import org.alliancegenome.curation_api.model.document.es.DiseaseSummaryDocument;
 import org.alliancegenome.curation_api.model.entities.AGMDiseaseAnnotation;
-import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
-import org.alliancegenome.curation_api.model.entities.Allele;
 import org.alliancegenome.curation_api.model.entities.AlleleDiseaseAnnotation;
 import org.alliancegenome.curation_api.model.entities.CrossReference;
 import org.alliancegenome.curation_api.model.entities.Gene;
@@ -89,8 +87,6 @@ public class DiseaseSummaryDocumentBuilder {
 			assertedGenes.removeIf(gene -> !hasSpecies(gene));
 			doc.getGenes().addAll(assertedGenes.stream().map(this::getGeneName).collect(Collectors.toSet()));
 			allInvolvedGenes.addAll(assertedGenes);
-			doc.getAlleles().addAll(agmDiseaseAnnotations.stream().filter(agmDiseaseAnnotation -> agmDiseaseAnnotation.getInferredAllele() != null).filter(agmDiseaseAnnotation -> hasSpecies(agmDiseaseAnnotation.getInferredAllele())).map(alleleDiseaseAnnotation -> getAlleleName(alleleDiseaseAnnotation.getInferredAllele())).collect(Collectors.toSet()));
-			doc.setModels(agmDiseaseAnnotations.stream().map(AGMDiseaseAnnotation::getDiseaseAnnotationSubject).filter(this::hasSpecies).map(this::getModelName).collect(Collectors.toSet()));
 		}
 		// loop over AlleleDiseaseAnnotations
 		List<AlleleDiseaseAnnotation> alleleDiseaseAnnotations = doTerm.getPublicAlleleDiseaseAnnotations();
@@ -104,11 +100,6 @@ public class DiseaseSummaryDocumentBuilder {
 			assertedGenes.removeIf(gene -> !hasSpecies(gene));
 			allInvolvedGenes.addAll(assertedGenes);
 			doc.getGenes().addAll(assertedGenes.stream().map(this::getGeneName).collect(Collectors.toSet()));
-			doc.getAlleles().addAll(alleleDiseaseAnnotations.stream()
-				.filter(alleleDiseaseAnnotation -> alleleDiseaseAnnotation.getDiseaseAnnotationSubject().getAlleleSymbol() != null)
-				.filter(alleleDiseaseAnnotation -> hasSpecies(alleleDiseaseAnnotation.getDiseaseAnnotationSubject()))
-				.map(alleleDiseaseAnnotation -> getAlleleName(alleleDiseaseAnnotation.getDiseaseAnnotationSubject())).collect(Collectors.toSet())
-			);
 		}
 
 		// add orthologous genes for the all-involved genes (only
@@ -117,21 +108,9 @@ public class DiseaseSummaryDocumentBuilder {
 				doc.getGenes().add(getGeneName(orthology.getObjectGene()));
 				doc.getAssociatedSpecies().add(orthology.getObjectGene().getTaxon().getGenesSpecies());
 			}));
-		doc.setParentDiseaseNames(doTerm.getAncestors().stream().map(closure -> closure.getClosureObject().getName()).collect(Collectors.toSet()));
-		// add self to the list
-		doc.getParentDiseaseNames().add(doTerm.getName());
-
 		// calculate diseaseGroup, ie parents with subset DO_AGR_slim
 		doc.setDiseaseGroup(doTerm.getAncestors().stream().filter(closure -> closure.getClosureObject().getSubsets().contains("DO_AGR_slim")).map(closure -> closure.getClosureObject().getName()).collect(Collectors.toSet()));
 		return doc;
-	}
-
-	private String getAlleleName(Allele allele) {
-		return allele.getAlleleSymbol().getFormatText() + getSpeciesAbbrev(allele);
-	}
-
-	private String getModelName(AffectedGenomicModel model) {
-		return model.getAgmFullName().getFormatText() + getSpeciesAbbrev(model);
 	}
 
 	private String getGeneName(Gene gene) {

--- a/src/main/java/org/alliancegenome/curation_api/model/document/builders/DiseaseSummaryDocumentBuilder.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/builders/DiseaseSummaryDocumentBuilder.java
@@ -68,13 +68,13 @@ public class DiseaseSummaryDocumentBuilder {
 		// add genes from GeneDiseaseAnnotations
 		List<GeneDiseaseAnnotation> geneDiseaseAnnotations = doTerm.getPublicGeneDiseaseAnnotations();
 		if (CollectionUtils.isNotEmpty(geneDiseaseAnnotations)) {
-			doc.setGenes(geneDiseaseAnnotations.stream().map(geneDiseaseAnnotation -> getGeneName(geneDiseaseAnnotation.getDiseaseAnnotationSubject())).collect(Collectors.toSet()));
-			doc.setAssociatedSpecies(geneDiseaseAnnotations.stream().map(geneDiseaseAnnotation -> geneDiseaseAnnotation.getDiseaseAnnotationSubject().getTaxon().getGenusSpecies()).collect(Collectors.toSet()));
+			doc.setGenes(geneDiseaseAnnotations.stream().map(GeneDiseaseAnnotation::getDiseaseAnnotationSubject).filter(this::hasSpecies).map(this::getGeneName).collect(Collectors.toSet()));
+			doc.setAssociatedSpecies(geneDiseaseAnnotations.stream().map(GeneDiseaseAnnotation::getDiseaseAnnotationSubject).filter(this::hasSpecies).map(gene -> gene.getTaxon().getGenesSpecies()).collect(Collectors.toSet()));
 
 			// collect all the involved genes: direct genes, inferred genes, and asserted
 			// genes
 			// Needed to retrieve the orthologous genes
-			allInvolvedGenes = geneDiseaseAnnotations.stream().map(GeneDiseaseAnnotation::getDiseaseAnnotationSubject).collect(Collectors.toSet());
+			allInvolvedGenes = geneDiseaseAnnotations.stream().map(GeneDiseaseAnnotation::getDiseaseAnnotationSubject).filter(this::hasSpecies).collect(Collectors.toSet());
 		}
 
 
@@ -82,35 +82,40 @@ public class DiseaseSummaryDocumentBuilder {
 		List<AGMDiseaseAnnotation> agmDiseaseAnnotations = doTerm.getPublicAGMDiseaseAnnotations();
 		if (agmDiseaseAnnotations != null) {
 			Set<Gene> inferredGene = getSingleGenes(agmDiseaseAnnotations, AGMDiseaseAnnotation::getInferredGene);
+			inferredGene.removeIf(gene -> !hasSpecies(gene));
 			allInvolvedGenes.addAll(inferredGene);
 			doc.getGenes().addAll(inferredGene.stream().map(this::getGeneName).collect(Collectors.toSet()));
-			Collection<Gene> assertedGenes = getMultipleGenes(agmDiseaseAnnotations, AGMDiseaseAnnotation::getAssertedGenes);
+			Collection<Gene> assertedGenes = getMultipleAGMGenes(agmDiseaseAnnotations, AGMDiseaseAnnotation::getAssertedGenes);
+			assertedGenes.removeIf(gene -> !hasSpecies(gene));
 			doc.getGenes().addAll(assertedGenes.stream().map(this::getGeneName).collect(Collectors.toSet()));
 			allInvolvedGenes.addAll(assertedGenes);
-			doc.getAlleles().addAll(agmDiseaseAnnotations.stream().filter(agmDiseaseAnnotation -> agmDiseaseAnnotation.getInferredAllele() != null).map(alleleDiseaseAnnotation -> getAlleleName(alleleDiseaseAnnotation.getInferredAllele())).collect(Collectors.toSet()));
-			doc.setModels(agmDiseaseAnnotations.stream().map(agmDiseaseAnnotation -> getModelName(agmDiseaseAnnotation.getDiseaseAnnotationSubject())).collect(Collectors.toSet()));
+			doc.getAlleles().addAll(agmDiseaseAnnotations.stream().filter(agmDiseaseAnnotation -> agmDiseaseAnnotation.getInferredAllele() != null).filter(agmDiseaseAnnotation -> hasSpecies(agmDiseaseAnnotation.getInferredAllele())).map(alleleDiseaseAnnotation -> getAlleleName(alleleDiseaseAnnotation.getInferredAllele())).collect(Collectors.toSet()));
+			doc.setModels(agmDiseaseAnnotations.stream().map(AGMDiseaseAnnotation::getDiseaseAnnotationSubject).filter(this::hasSpecies).map(this::getModelName).collect(Collectors.toSet()));
 		}
 		// loop over AlleleDiseaseAnnotations
 		List<AlleleDiseaseAnnotation> alleleDiseaseAnnotations = doTerm.getPublicAlleleDiseaseAnnotations();
 		if (alleleDiseaseAnnotations != null) {
 			Set<Gene> inferredGenes = getSingleGenes(alleleDiseaseAnnotations, AlleleDiseaseAnnotation::getInferredGene);
+			inferredGenes.removeIf(gene -> !hasSpecies(gene));
 			allInvolvedGenes.addAll(inferredGenes);
 			doc.getGenes().addAll(inferredGenes.stream().map(this::getGeneName).collect(Collectors.toSet()));
 
 			Set<Gene> assertedGenes = getMultipleAlleles(alleleDiseaseAnnotations, AlleleDiseaseAnnotation::getAssertedGenes);
+			assertedGenes.removeIf(gene -> !hasSpecies(gene));
 			allInvolvedGenes.addAll(assertedGenes);
 			doc.getGenes().addAll(assertedGenes.stream().map(this::getGeneName).collect(Collectors.toSet()));
 			doc.getAlleles().addAll(alleleDiseaseAnnotations.stream()
 				.filter(alleleDiseaseAnnotation -> alleleDiseaseAnnotation.getDiseaseAnnotationSubject().getAlleleSymbol() != null)
+				.filter(alleleDiseaseAnnotation -> hasSpecies(alleleDiseaseAnnotation.getDiseaseAnnotationSubject()))
 				.map(alleleDiseaseAnnotation -> getAlleleName(alleleDiseaseAnnotation.getDiseaseAnnotationSubject())).collect(Collectors.toSet())
 			);
 		}
 
 		// add orthologous genes for the all-involved genes (only
 		allInvolvedGenes.forEach(gene -> gene.getGeneToGeneOrthologyGenerateds()
-			.stream().filter(GeneToGeneOrthologyGenerated::getStrictFilter).forEach(orthology -> {
+			.stream().filter(GeneToGeneOrthologyGenerated::getStrictFilter).filter(orthology -> hasSpecies(orthology.getObjectGene())).forEach(orthology -> {
 				doc.getGenes().add(getGeneName(orthology.getObjectGene()));
-				doc.getAssociatedSpecies().add(orthology.getObjectGene().getTaxon().getGenusSpecies());
+				doc.getAssociatedSpecies().add(orthology.getObjectGene().getTaxon().getGenesSpecies());
 			}));
 		doc.setParentDiseaseNames(doTerm.getAncestors().stream().map(closure -> closure.getClosureObject().getName()).collect(Collectors.toSet()));
 		// add self to the list
@@ -133,6 +138,10 @@ public class DiseaseSummaryDocumentBuilder {
 		return gene.getGeneSymbol().getDisplayText() + getSpeciesAbbrev(gene);
 	}
 
+	private boolean hasSpecies(GenomicEntity genomicEntity) {
+		return CollectionUtils.isNotEmpty(genomicEntity.getTaxon().getSpecies());
+	}
+
 	private String getSpeciesAbbrev(GenomicEntity genomicEntity) {
 		return " (" + genomicEntity.getTaxon().getSpecies().get(0).getAbbreviation() + ")";
 	}
@@ -141,7 +150,7 @@ public class DiseaseSummaryDocumentBuilder {
 		return annotations.stream().filter(agmDiseaseAnnotation -> function.apply(agmDiseaseAnnotation) != null).map(function).collect(Collectors.toSet());
 	}
 
-	public Set<Gene> getMultipleGenes(List<AGMDiseaseAnnotation> annotations, Function<AGMDiseaseAnnotation, List<Gene>> function) {
+	public Set<Gene> getMultipleAGMGenes(List<AGMDiseaseAnnotation> annotations, Function<AGMDiseaseAnnotation, List<Gene>> function) {
 		return annotations.stream().filter(agmDiseaseAnnotation -> function.apply(agmDiseaseAnnotation) != null).map(geneDiseaseAnnotation -> function.apply(geneDiseaseAnnotation).stream().toList()).flatMap(Collection::stream).collect(Collectors.toSet());
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSearchResultDocument.java
@@ -24,15 +24,11 @@ public class DiseaseSearchResultDocument extends ESDocument {
 	Set<String> synonyms;
 	String primaryKey;
 	Set<String> crossReferences;
-	Set<String> parentDiseaseNames;
 	Set<String> genes;
 	Set<String> diseaseGroup;
 	Set<String> associatedSpecies = new HashSet<>();
 	@JsonProperty("name_key")
 	String nameKey;
-
-	Set<String> models = new HashSet<>();
-	Set<String> alleles = new HashSet<>();
 
 	Set<String> secondaryIds = new HashSet<>();
 

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSearchResultDocument.java
@@ -18,19 +18,29 @@ public class DiseaseSearchResultDocument extends ESDocument {
 		category = "disease_search_result";
 	}
 
+	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	private String curie;
+	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	private String definition;
+	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	String name;
+	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	Set<String> synonyms = new HashSet<>();
+	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	String primaryKey;
+	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	Set<String> crossReferences = new HashSet<>();
+	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	Set<String> genes = new HashSet<>();
+	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	Set<String> diseaseGroup = new HashSet<>();
+	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	Set<String> associatedSpecies = new HashSet<>();
+	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	@JsonProperty("name_key")
 	String nameKey;
 
+	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	Set<String> secondaryIds = new HashSet<>();
-
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSearchResultDocument.java
@@ -21,11 +21,11 @@ public class DiseaseSearchResultDocument extends ESDocument {
 	private String curie;
 	private String definition;
 	String name;
-	Set<String> synonyms;
+	Set<String> synonyms = new HashSet<>();
 	String primaryKey;
-	Set<String> crossReferences;
-	Set<String> genes;
-	Set<String> diseaseGroup;
+	Set<String> crossReferences = new HashSet<>();
+	Set<String> genes = new HashSet<>();
+	Set<String> diseaseGroup = new HashSet<>();
 	Set<String> associatedSpecies = new HashSet<>();
 	@JsonProperty("name_key")
 	String nameKey;

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSearchResultDocument.java
@@ -18,29 +18,18 @@ public class DiseaseSearchResultDocument extends ESDocument {
 		category = "disease_search_result";
 	}
 
-	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	private String curie;
-	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	private String definition;
-	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	String name;
-	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	Set<String> synonyms = new HashSet<>();
-	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	String primaryKey;
-	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	Set<String> crossReferences = new HashSet<>();
-	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	Set<String> genes = new HashSet<>();
-	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	Set<String> diseaseGroup = new HashSet<>();
-	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	Set<String> associatedSpecies = new HashSet<>();
-	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	@JsonProperty("name_key")
 	String nameKey;
 
-	@JsonView(CurationView.DiseaseSearchResultDocument.class)
 	Set<String> secondaryIds = new HashSet<>();
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AGMDiseaseAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AGMDiseaseAnnotation.java
@@ -160,6 +160,6 @@ public class AGMDiseaseAnnotation extends DiseaseAnnotation {
 		if (diseaseAnnotationSubject.getTaxon() == null) {
 			return null;
 		}
-		return diseaseAnnotationSubject.getTaxon().getGenusSpecies();
+		return diseaseAnnotationSubject.getTaxon().getGenesSpecies();
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AGMPhenotypeAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AGMPhenotypeAnnotation.java
@@ -165,6 +165,6 @@ public class AGMPhenotypeAnnotation extends PhenotypeAnnotation {
 		if (phenotypeAnnotationSubject.getTaxon() == null) {
 			return null;
 		}
-		return phenotypeAnnotationSubject.getTaxon().getGenusSpecies();
+		return phenotypeAnnotationSubject.getTaxon().getGenesSpecies();
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AlleleDiseaseAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AlleleDiseaseAnnotation.java
@@ -136,6 +136,6 @@ public class AlleleDiseaseAnnotation extends DiseaseAnnotation {
 		if (diseaseAnnotationSubject.getTaxon() == null) {
 			return null;
 		}
-		return diseaseAnnotationSubject.getTaxon().getGenusSpecies();
+		return diseaseAnnotationSubject.getTaxon().getGenesSpecies();
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AllelePhenotypeAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AllelePhenotypeAnnotation.java
@@ -136,6 +136,6 @@ public class AllelePhenotypeAnnotation extends PhenotypeAnnotation {
 		if (phenotypeAnnotationSubject.getTaxon() == null) {
 			return null;
 		}
-		return phenotypeAnnotationSubject.getTaxon().getGenusSpecies();
+		return phenotypeAnnotationSubject.getTaxon().getGenesSpecies();
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GeneDiseaseAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GeneDiseaseAnnotation.java
@@ -99,6 +99,6 @@ public class GeneDiseaseAnnotation extends DiseaseAnnotation {
 		if (diseaseAnnotationSubject.getTaxon() == null) {
 			return null;
 		}
-		return diseaseAnnotationSubject.getTaxon().getGenusSpecies();
+		return diseaseAnnotationSubject.getTaxon().getGenesSpecies();
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GenePhenotypeAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GenePhenotypeAnnotation.java
@@ -99,6 +99,6 @@ public class GenePhenotypeAnnotation extends PhenotypeAnnotation {
 		if (phenotypeAnnotationSubject.getTaxon() == null) {
 			return null;
 		}
-		return phenotypeAnnotationSubject.getTaxon().getGenusSpecies();
+		return phenotypeAnnotationSubject.getTaxon().getGenesSpecies();
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java
@@ -34,7 +34,7 @@ public class NCBITaxonTerm extends OntologyTerm {
 
 	@Transient
 	@JsonIgnore
-	public String getGenusSpecies() {
+	public String getGenesSpecies() {
 		if (name == null) {
 			return null;
 		}

--- a/src/main/java/org/alliancegenome/curation_api/services/ontology/DoTermService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ontology/DoTermService.java
@@ -1,9 +1,15 @@
 package org.alliancegenome.curation_api.services.ontology;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.alliancegenome.curation_api.dao.ontology.DoTermDAO;
 import org.alliancegenome.curation_api.interfaces.base.BasePopularityInterface;
+import org.alliancegenome.curation_api.model.document.es.DiseaseSearchResultDocument;
 import org.alliancegenome.curation_api.model.entities.ontology.DOTerm;
 import org.alliancegenome.curation_api.services.base.BaseOntologyTermService;
 
@@ -38,5 +44,69 @@ public class DoTermService extends BaseOntologyTermService<DOTerm, DoTermDAO> im
 
 	public List<DOTerm> findByIds(List<Long> ids) {
 		return doTermDAO.findByIds(ids);
+	}
+
+	public List<DiseaseSearchResultDocument> buildSearchResultDocuments(List<Long> ids) {
+		List<Object[]> baseFields = doTermDAO.findBaseFieldsByIds(ids);
+		List<Object[]> synonymRows = doTermDAO.findSynonymsByIds(ids);
+		List<Object[]> crossRefRows = doTermDAO.findCrossReferencesByIds(ids);
+		List<Object[]> secondaryIdRows = doTermDAO.findSecondaryIdsByIds(ids);
+		List<Object[]> geneRows = doTermDAO.findGenesAndSpeciesByIds(ids);
+		List<Object[]> diseaseGroupRows = doTermDAO.findDiseaseGroupByIds(ids);
+
+		Map<Long, Set<String>> synonymsMap = groupToSet(synonymRows);
+		Map<Long, Set<String>> crossRefsMap = groupToSet(crossRefRows);
+		Map<Long, Set<String>> secondaryIdsMap = groupToSet(secondaryIdRows);
+		Map<Long, Set<String>> diseaseGroupMap = groupToSet(diseaseGroupRows);
+
+		// Gene rows: (doterm_id, gene_symbol, abbreviation, genus_species)
+		Map<Long, Set<String>> genesMap = new HashMap<>();
+		Map<Long, Set<String>> speciesMap = new HashMap<>();
+		for (Object[] row : geneRows) {
+			Long dotermId = (Long) row[0];
+			String symbol = (String) row[1];
+			String abbreviation = (String) row[2];
+			String genusSpecies = (String) row[3];
+
+			genesMap.computeIfAbsent(dotermId, k -> new HashSet<>()).add(symbol + " (" + abbreviation + ")");
+			speciesMap.computeIfAbsent(dotermId, k -> new HashSet<>()).add(genusSpecies);
+		}
+
+		List<DiseaseSearchResultDocument> docs = new ArrayList<>();
+		for (Object[] base : baseFields) {
+			Long id = (Long) base[0];
+			String curie = (String) base[1];
+			String name = (String) base[2];
+			String definition = (String) base[3];
+
+			DiseaseSearchResultDocument doc = new DiseaseSearchResultDocument();
+			doc.setCurie(curie);
+			doc.setPrimaryKey(curie);
+			doc.setSearchable(false);
+			doc.setName(name);
+			doc.setNameKey(name);
+			doc.setDefinition(definition);
+			doc.setSynonyms(synonymsMap.getOrDefault(id, new HashSet<>()));
+			doc.setCrossReferences(crossRefsMap.getOrDefault(id, new HashSet<>()));
+			doc.setSecondaryIds(secondaryIdsMap.getOrDefault(id, new HashSet<>()));
+			doc.setGenes(genesMap.getOrDefault(id, new HashSet<>()));
+			doc.setAssociatedSpecies(speciesMap.getOrDefault(id, new HashSet<>()));
+			doc.setDiseaseGroup(diseaseGroupMap.getOrDefault(id, new HashSet<>()));
+			docs.add(doc);
+		}
+
+		return docs;
+	}
+
+	private Map<Long, Set<String>> groupToSet(List<Object[]> rows) {
+		Map<Long, Set<String>> map = new HashMap<>();
+		for (Object[] row : rows) {
+			Long id = (Long) row[0];
+			String value = (String) row[1];
+			if (value != null) {
+				map.computeIfAbsent(id, k -> new HashSet<>()).add(value);
+			}
+		}
+		return map;
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/ontology/DoTermService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ontology/DoTermService.java
@@ -17,7 +17,9 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequestScoped
 public class DoTermService extends BaseOntologyTermService<DOTerm, DoTermDAO> implements BasePopularityInterface {
 
@@ -38,40 +40,50 @@ public class DoTermService extends BaseOntologyTermService<DOTerm, DoTermDAO> im
 		}
 	}
 
-	public List<Long> getAllIds() {
-		return doTermDAO.getAllIds();
-	}
+	public List<DiseaseSearchResultDocument> buildAllSearchResultDocuments() {
+		log.info("Building all disease search result documents...");
 
-	public List<DOTerm> findByIds(List<Long> ids) {
-		return doTermDAO.findByIds(ids);
-	}
+		log.info("Loading gene symbol cache...");
+		Map<Long, String[]> geneSymbolCache = buildGeneSymbolCache();
+		log.info("Cached {} gene symbols", geneSymbolCache.size());
 
-	public List<DiseaseSearchResultDocument> buildSearchResultDocuments(List<Long> ids) {
-		List<Object[]> baseFields = doTermDAO.findBaseFieldsByIds(ids);
-		List<Object[]> synonymRows = doTermDAO.findSynonymsByIds(ids);
-		List<Object[]> crossRefRows = doTermDAO.findCrossReferencesByIds(ids);
-		List<Object[]> secondaryIdRows = doTermDAO.findSecondaryIdsByIds(ids);
-		List<Object[]> geneRows = doTermDAO.findGenesAndSpeciesByIds(ids);
-		List<Object[]> diseaseGroupRows = doTermDAO.findDiseaseGroupByIds(ids);
+		log.info("Loading base fields...");
+		List<Object[]> baseFields = doTermDAO.findAllBaseFields();
+		log.info("Loaded {} DOTerms", baseFields.size());
 
-		Map<Long, Set<String>> synonymsMap = groupToSet(synonymRows);
-		Map<Long, Set<String>> crossRefsMap = groupToSet(crossRefRows);
-		Map<Long, Set<String>> secondaryIdsMap = groupToSet(secondaryIdRows);
-		Map<Long, Set<String>> diseaseGroupMap = groupToSet(diseaseGroupRows);
+		log.info("Loading synonyms...");
+		Map<Long, Set<String>> synonymsMap = groupToSet(doTermDAO.findAllSynonyms());
 
-		// Gene rows: (doterm_id, gene_symbol, abbreviation, genus_species)
+		log.info("Loading cross references...");
+		Map<Long, Set<String>> crossRefsMap = groupToSet(doTermDAO.findAllCrossReferences());
+
+		log.info("Loading secondary IDs...");
+		Map<Long, Set<String>> secondaryIdsMap = groupToSet(doTermDAO.findAllSecondaryIds());
+
+		log.info("Loading disease groups...");
+		Map<Long, Set<String>> diseaseGroupMap = groupToSet(doTermDAO.findAllDiseaseGroups());
+
+		log.info("Loading disease-gene mappings...");
+		List<Object[]> geneIdRows = doTermDAO.findDiseaseGeneIds();
+		log.info("Loaded {} disease-gene pairs", geneIdRows.size());
+
 		Map<Long, Set<String>> genesMap = new HashMap<>();
 		Map<Long, Set<String>> speciesMap = new HashMap<>();
-		for (Object[] row : geneRows) {
+		for (Object[] row : geneIdRows) {
 			Long dotermId = (Long) row[0];
-			String symbol = (String) row[1];
-			String abbreviation = (String) row[2];
-			String genusSpecies = (String) row[3];
-
+			Long geneId = (Long) row[1];
+			String[] geneInfo = geneSymbolCache.get(geneId);
+			if (geneInfo == null) {
+				continue;
+			}
+			String symbol = geneInfo[0];
+			String abbreviation = geneInfo[1];
+			String genusSpecies = geneInfo[2];
 			genesMap.computeIfAbsent(dotermId, k -> new HashSet<>()).add(symbol + " (" + abbreviation + ")");
 			speciesMap.computeIfAbsent(dotermId, k -> new HashSet<>()).add(genusSpecies);
 		}
 
+		log.info("Assembling documents...");
 		List<DiseaseSearchResultDocument> docs = new ArrayList<>();
 		for (Object[] base : baseFields) {
 			Long id = (Long) base[0];
@@ -95,7 +107,21 @@ public class DoTermService extends BaseOntologyTermService<DOTerm, DoTermDAO> im
 			docs.add(doc);
 		}
 
+		log.info("Built {} disease search result documents", docs.size());
 		return docs;
+	}
+
+	private Map<Long, String[]> buildGeneSymbolCache() {
+		List<Object[]> rows = doTermDAO.findAllGeneSymbols();
+		Map<Long, String[]> cache = new HashMap<>();
+		for (Object[] row : rows) {
+			Long geneId = (Long) row[0];
+			String symbol = (String) row[1];
+			String abbreviation = (String) row[2];
+			String genusSpecies = (String) row[3];
+			cache.put(geneId, new String[]{symbol, abbreviation, genusSpecies});
+		}
+		return cache;
 	}
 
 	private Map<Long, Set<String>> groupToSet(List<Object[]> rows) {

--- a/src/main/java/org/alliancegenome/curation_api/services/ontology/DoTermService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ontology/DoTermService.java
@@ -1,5 +1,7 @@
 package org.alliancegenome.curation_api.services.ontology;
 
+import java.util.List;
+
 import org.alliancegenome.curation_api.dao.ontology.DoTermDAO;
 import org.alliancegenome.curation_api.interfaces.base.BasePopularityInterface;
 import org.alliancegenome.curation_api.model.entities.ontology.DOTerm;
@@ -28,5 +30,13 @@ public class DoTermService extends BaseOntologyTermService<DOTerm, DoTermDAO> im
 		if (term != null) {
 			term.setPopularity(popularity);
 		}
+	}
+
+	public List<Long> getAllIds() {
+		return doTermDAO.getAllIds();
+	}
+
+	public List<DOTerm> findByIds(List<Long> ids) {
+		return doTermDAO.findByIds(ids);
 	}
 }

--- a/src/main/resources/db/migration/v0.46.0.2__add_orthology_strictfilter_index.sql
+++ b/src/main/resources/db/migration/v0.46.0.2__add_orthology_strictfilter_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX genetogeneorthologygenerated_strictfilter_index
+	ON genetogeneorthologygenerated (id)
+	WHERE strictfilter = true;


### PR DESCRIPTION
## Summary
- Add `GET /api/disease/document/all` endpoint that builds all 12k disease search result documents in a single call using direct SQL queries
- Gene symbol cache + CTE-based disease-gene mapping (including strict orthologs) replaces slow lazy-loaded entity traversal
- Drop unused fields from DiseaseSearchResultDocument: `parentDiseaseNames`, `alleles`, `models`
- Skip genomic entities without species linked to their taxon
- Rename `getGenusSpecies` -> `getGenesSpecies` across all annotation entities
- Add Flyway migration for `strictfilter` partial index on `genetogeneorthologygenerated`

## Performance
- Old (entity-based): 3:41, 54 r/s
- New (direct SQL): 0:40, 299 r/s (5.5x faster)

## Data Validation
- 12,001 / 12,001 documents match
- 11,778 perfect matches (98.1%)
- 223 diffs all in `associatedSpecies` — new version correctly includes species from AGM/allele annotation genes (improvement, not regression)

## Test plan
- [x] Compare old vs new ES documents field-by-field
- [ ] Deploy to alpha, run indexer, verify search results on alpha website