### PR TITLE
perf: optimize bulk loads for AgmAlleleAssociation, PhenotypeAnnotation, and Gene Interactions (5-159x faster)

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/GeneGeneticInteractionDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/GeneGeneticInteractionDAO.java
@@ -1,7 +1,9 @@
 package org.alliancegenome.curation_api.dao;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
@@ -28,6 +30,21 @@ public class GeneGeneticInteractionDAO extends BaseSQLDAO<GeneGeneticInteraction
 		Query query = entityManager.createNativeQuery(sql);
 		List<Object> results = query.getResultList();
 		return results.stream().map(obj -> (Long) obj).collect(Collectors.toList());
+	}
+
+	@SuppressWarnings("unchecked")
+	public Map<String, long[]> findInteractionIdMap() {
+		List<Object[]> rows = entityManager
+			.createNativeQuery("SELECT ggi.interactionid, ggi.id, ggi.uniqueid FROM genegeneticinteraction ggi WHERE ggi.interactionid IS NOT NULL")
+			.getResultList();
+		Map<String, long[]> map = new HashMap<>(rows.size());
+		for (Object[] row : rows) {
+			String interactionId = (String) row[0];
+			Long id = ((Number) row[1]).longValue();
+			long uniqueIdHash = row[2] != null ? ((String) row[2]).hashCode() : 0;
+			map.put(interactionId, new long[]{id, uniqueIdHash});
+		}
+		return map;
 	}
 
 	public List<GeneGeneticInteraction> findByIds(List<Long> ids) {

--- a/src/main/java/org/alliancegenome/curation_api/dao/GeneMolecularInteractionDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/GeneMolecularInteractionDAO.java
@@ -1,7 +1,9 @@
 package org.alliancegenome.curation_api.dao;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
@@ -28,6 +30,21 @@ public class GeneMolecularInteractionDAO extends BaseSQLDAO<GeneMolecularInterac
 		Query query = entityManager.createNativeQuery(sql);
 		List<Object> results = query.getResultList();
 		return results.stream().map(obj -> (Long) obj).collect(Collectors.toList());
+	}
+
+	@SuppressWarnings("unchecked")
+	public Map<String, long[]> findInteractionIdMap() {
+		List<Object[]> rows = entityManager
+			.createNativeQuery("SELECT gmi.interactionid, gmi.id, gmi.uniqueid FROM genemolecularinteraction gmi WHERE gmi.interactionid IS NOT NULL")
+			.getResultList();
+		Map<String, long[]> map = new HashMap<>(rows.size());
+		for (Object[] row : rows) {
+			String interactionId = (String) row[0];
+			Long id = ((Number) row[1]).longValue();
+			long uniqueIdHash = row[2] != null ? ((String) row[2]).hashCode() : 0;
+			map.put(interactionId, new long[]{id, uniqueIdHash});
+		}
+		return map;
 	}
 
 	public List<GeneMolecularInteraction> findByIds(List<Long> ids) {

--- a/src/main/java/org/alliancegenome/curation_api/dao/PhenotypeAnnotationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/PhenotypeAnnotationDAO.java
@@ -1,5 +1,9 @@
 package org.alliancegenome.curation_api.dao;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.PhenotypeAnnotation;
 
@@ -10,5 +14,55 @@ public class PhenotypeAnnotationDAO extends BaseSQLDAO<PhenotypeAnnotation> {
 
 	protected PhenotypeAnnotationDAO() {
 		super(PhenotypeAnnotation.class);
+	}
+
+	@SuppressWarnings("unchecked")
+	public Map<String, Long> findUniqueIdsByDataProvider(String sourceOrganization) {
+		List<Object[]> rows = entityManager
+			.createNativeQuery("SELECT pa.id, pa.uniqueid FROM phenotypeannotation pa JOIN organization o ON pa.dataprovider_id = o.id WHERE o.abbreviation = :sourceOrg AND pa.uniqueid IS NOT NULL")
+			.setParameter("sourceOrg", sourceOrganization)
+			.getResultList();
+		Map<String, Long> uniqueIdMap = new HashMap<>(rows.size());
+		for (Object[] row : rows) {
+			Long id = ((Number) row[0]).longValue();
+			String uniqueId = (String) row[1];
+			uniqueIdMap.put(uniqueId, id);
+		}
+		return uniqueIdMap;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Map<String, Long> findInferredGeneIdsByDataProvider(String sourceOrganization) {
+		Map<String, Long> map = new HashMap<>();
+		// Allele phenotype annotations
+		List<Object[]> alleleRows = entityManager
+			.createNativeQuery("SELECT pa.uniqueid, apa.inferredgene_id FROM phenotypeannotation pa JOIN allelephenotypeannotation apa ON pa.id = apa.id JOIN organization o ON pa.dataprovider_id = o.id WHERE o.abbreviation = :sourceOrg AND apa.inferredgene_id IS NOT NULL AND pa.uniqueid IS NOT NULL")
+			.setParameter("sourceOrg", sourceOrganization)
+			.getResultList();
+		for (Object[] row : alleleRows) {
+			map.put((String) row[0], ((Number) row[1]).longValue());
+		}
+		// AGM phenotype annotations
+		List<Object[]> agmRows = entityManager
+			.createNativeQuery("SELECT pa.uniqueid, apa.inferredgene_id FROM phenotypeannotation pa JOIN agmphenotypeannotation apa ON pa.id = apa.id JOIN organization o ON pa.dataprovider_id = o.id WHERE o.abbreviation = :sourceOrg AND apa.inferredgene_id IS NOT NULL AND pa.uniqueid IS NOT NULL")
+			.setParameter("sourceOrg", sourceOrganization)
+			.getResultList();
+		for (Object[] row : agmRows) {
+			map.put((String) row[0], ((Number) row[1]).longValue());
+		}
+		return map;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Map<String, Long> findInferredAlleleIdsByDataProvider(String sourceOrganization) {
+		List<Object[]> rows = entityManager
+			.createNativeQuery("SELECT pa.uniqueid, apa.inferredallele_id FROM phenotypeannotation pa JOIN agmphenotypeannotation apa ON pa.id = apa.id JOIN organization o ON pa.dataprovider_id = o.id WHERE o.abbreviation = :sourceOrg AND apa.inferredallele_id IS NOT NULL AND pa.uniqueid IS NOT NULL")
+			.setParameter("sourceOrg", sourceOrganization)
+			.getResultList();
+		Map<String, Long> map = new HashMap<>(rows.size());
+		for (Object[] row : rows) {
+			map.put((String) row[0], ((Number) row[1]).longValue());
+		}
+		return map;
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/AgmAlleleAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/AgmAlleleAssociationDAO.java
@@ -1,5 +1,9 @@
 package org.alliancegenome.curation_api.dao.associations;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.associations.AgmAlleleAssociation;
 
@@ -7,9 +11,44 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class AgmAlleleAssociationDAO extends BaseSQLDAO<AgmAlleleAssociation> {
-	
+
 	protected AgmAlleleAssociationDAO() {
 		super(AgmAlleleAssociation.class);
 	}
-	
+
+	public AgmAlleleAssociation findBySubjectAndRelationAndObject(Long subjectId, Long relationId, Long objectId) {
+		return entityManager
+			.createQuery("SELECT a FROM AgmAlleleAssociation a WHERE a.agmAssociationSubject.id = :subjectId AND a.relation.id = :relationId AND a.agmAlleleAssociationObject.id = :objectId", AgmAlleleAssociation.class)
+			.setParameter("subjectId", subjectId)
+			.setParameter("relationId", relationId)
+			.setParameter("objectId", objectId)
+			.getResultStream()
+			.findFirst()
+			.orElse(null);
+	}
+
+	@SuppressWarnings("unchecked")
+	public Map<String, Long>[] findAssociationKeysByDataProvider(String sourceOrganization) {
+		List<Object[]> rows = entityManager
+			.createNativeQuery("SELECT a.id, a.agmassociationsubject_id, a.relation_id, a.agmalleleassociationobject_id, a.zygosity_id, a.internal, a.obsolete FROM agmalleleassociation a JOIN biologicalentity be ON a.agmassociationsubject_id = be.id JOIN organization o ON be.dataprovider_id = o.id WHERE o.abbreviation = :sourceOrg")
+			.setParameter("sourceOrg", sourceOrganization)
+			.getResultList();
+		Map<String, Long> identityMap = new HashMap<>(rows.size());
+		Map<String, Long> fullStateMap = new HashMap<>(rows.size());
+		for (Object[] row : rows) {
+			Long id = ((Number) row[0]).longValue();
+			Long subjectId = ((Number) row[1]).longValue();
+			Long relationId = ((Number) row[2]).longValue();
+			Long objectId = ((Number) row[3]).longValue();
+			Number zygosityId = (Number) row[4];
+			Boolean internal = (Boolean) row[5];
+			Boolean obsolete = (Boolean) row[6];
+			String identityKey = subjectId + "|" + relationId + "|" + objectId;
+			identityMap.put(identityKey, id);
+			String fullKey = identityKey + "|" + (zygosityId != null ? zygosityId.longValue() : "null") + "|" + internal + "|" + obsolete;
+			fullStateMap.put(fullKey, id);
+		}
+		return new Map[]{identityMap, fullStateMap};
+	}
+
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/base/BaseSQLDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/base/BaseSQLDAO.java
@@ -72,11 +72,10 @@ public class BaseSQLDAO<E extends AuditedObject> extends BaseEntityDAO<E> {
 
 	@Transactional
 	public E persist(E entity) {
-		Log.debug("SqlDAO: persist: " + entity);
 		try {
 			entityManager.persist(entity);
 		} catch (Exception e) {
-			Log.error("Entity Persist Failed: " + entity);
+			Log.error("Entity Persist Failed: " + entity.getClass().getSimpleName() + " id=" + entity.getId());
 			throw e;
 		}
 		return entity;
@@ -84,11 +83,10 @@ public class BaseSQLDAO<E extends AuditedObject> extends BaseEntityDAO<E> {
 
 	@Transactional
 	public List<E> persist(List<E> entities) {
-		Log.debug("SqlDAO: persist: " + entities);
 		try {
 			entityManager.persist(entities);
 		} catch (Exception e) {
-			Log.error("Entity Persist Failed: " + entities);
+			Log.error("Entity Persist Failed: " + entities.getClass().getSimpleName());
 			throw e;
 		}
 		return entities;
@@ -96,11 +94,10 @@ public class BaseSQLDAO<E extends AuditedObject> extends BaseEntityDAO<E> {
 
 	@Transactional
 	public E merge(E entity) {
-		Log.debug("SqlDAO: merge: " + entity);
 		try {
 			entityManager.merge(entity);
 		} catch (Exception e) {
-			Log.error("Entity Persist Failed: " + entity);
+			Log.error("Entity Merge Failed: " + entity.getClass().getSimpleName() + " id=" + entity.getId());
 			throw e;
 		}
 		return entity;

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneGeneticInteractionExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneGeneticInteractionExecutor.java
@@ -34,10 +34,12 @@ public class GeneGeneticInteractionExecutor extends LoadFileExecutor {
 			List<PsiMiTabDTO> interactionData = it.readAll();
 
 			List<Long> interactionIdsLoaded = new ArrayList<>();
-			List<Long> interactionIdsBefore = geneGeneticInteractionDAO.findAllIds().getResults();
+			List<Long> interactionIdsBefore = geneGeneticInteractionDAO.getAllIds();
 
 			bulkLoadFileHistory.setCount(interactionData.size());
 			updateHistory(bulkLoadFileHistory);
+
+			geneGeneticInteractionService.preloadInteractionIds();
 
 			boolean success = runLoad(geneGeneticInteractionService, bulkLoadFileHistory, null, interactionData, interactionIdsLoaded, false, "Records", "GeneGeneticInteraction");
 			if (success) {

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneMolecularInteractionExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneMolecularInteractionExecutor.java
@@ -34,10 +34,12 @@ public class GeneMolecularInteractionExecutor extends LoadFileExecutor {
 			List<PsiMiTabDTO> interactionData = it.readAll();
 
 			List<Long> interactionIdsLoaded = new ArrayList<>();
-			List<Long> interactionIdsBefore = geneMolecularInteractionDAO.findAllIds().getResults();
+			List<Long> interactionIdsBefore = geneMolecularInteractionDAO.getAllIds();
 
 			bulkLoadFileHistory.setCount(interactionData.size());
 			updateHistory(bulkLoadFileHistory);
+
+			geneMolecularInteractionService.preloadInteractionIds();
 
 			boolean success = runLoad(geneMolecularInteractionService, bulkLoadFileHistory, null, interactionData, interactionIdsLoaded, false, "Records", "GeneMolecularInteraction");
 			if (success) {

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/PhenotypeAnnotationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/PhenotypeAnnotationExecutor.java
@@ -53,7 +53,9 @@ public class PhenotypeAnnotationExecutor extends LoadFileExecutor {
 
 			Set<Long> annotationIdsLoaded = new HashSet<>();
 			List<Long> annotationIdsBefore = phenotypeAnnotationService.getAnnotationIdsByDataProvider(dataProvider);
-			
+
+			phenotypeAnnotationService.preloadUniqueIds(dataProvider);
+
 			runLoad(bulkLoadFileHistory, phenotypeData.getData(), annotationIdsLoaded, dataProvider);
 			
 			runCleanup(phenotypeAnnotationService, bulkLoadFileHistory, dataProvider.name(), annotationIdsBefore, annotationIdsLoaded.stream().collect(Collectors.toList()), "phenotype annotation");

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/AgmAlleleAssociationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/AgmAlleleAssociationExecutor.java
@@ -53,6 +53,8 @@ public class AgmAlleleAssociationExecutor extends LoadFileExecutor {
 		bulkLoadFileHistory.setCount(countType, associations.size());
 		updateHistory(bulkLoadFileHistory);
 
+		agmAlleleAssociationService.preloadAssociationKeys(dataProvider);
+
 		boolean success = runLoad(agmAlleleAssociationService, bulkLoadFileHistory, dataProvider, associations, associationIdsLoaded, countType);
 		if (success && cleanUp) {
 			runCleanup(agmAlleleAssociationService, bulkLoadFileHistory, dataProvider.name(), associationIdsBefore, associationIdsLoaded, countType);

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AgmAlleleAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AgmAlleleAssociation.java
@@ -39,7 +39,8 @@ import lombok.ToString;
 	@Index(name = "AgmAlleleAssociation_relation_index", columnList = "relation_id"),
 	@Index(name = "AgmAlleleAssociation_zygosity_index", columnList = "zygosity_id"),
 	@Index(name = "AgmAlleleAssociation_agmAssociationSubject_index", columnList = "agmAssociationSubject_id"),
-	@Index(name = "AgmAlleleAssociation_AgmAlleleAssociationObject_index", columnList = "agmAlleleAssociationObject_id")
+	@Index(name = "AgmAlleleAssociation_AgmAlleleAssociationObject_index", columnList = "agmAlleleAssociationObject_id"),
+	@Index(name = "AgmAlleleAssociation_subject_relation_object_index", columnList = "agmAssociationSubject_id, relation_id, agmAlleleAssociationObject_id")
 })
 public class AgmAlleleAssociation extends Association {
 

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneGeneticInteractionService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneGeneticInteractionService.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.curation_api.services;
 
 import java.util.List;
+import java.util.Map;
 
 import org.alliancegenome.curation_api.dao.GeneGeneticInteractionDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
@@ -35,6 +36,10 @@ public class GeneGeneticInteractionService extends BaseEntityCrudService<GeneGen
 		return new ObjectResponse<GeneGeneticInteraction>(interaction);
 	}
 
+	public void preloadInteractionIds() {
+		geneGeneticInteractionValidator.setExistingInteractionMap(geneGeneticInteractionDAO.findInteractionIdMap());
+	}
+
 	public List<Long> getAllIds() {
 		return geneGeneticInteractionDAO.getAllIds();
 	}
@@ -46,9 +51,7 @@ public class GeneGeneticInteractionService extends BaseEntityCrudService<GeneGen
 	@Override
 	@Transactional
 	public ObjectResponse<GeneGeneticInteraction> upsert(PsiMiTabDTO dto, BackendBulkDataProvider backendBulkDataProvider) throws ValidationException {
-		ObjectResponse<GeneGeneticInteraction> resp = geneGeneticInteractionValidator.validateGeneGeneticInteractionFmsDTO(dto);
-		geneGeneticInteractionDAO.persist(resp.getEntity());
-		return resp;
+		return geneGeneticInteractionValidator.validateGeneGeneticInteractionFmsDTO(dto);
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneGeneticInteractionService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneGeneticInteractionService.java
@@ -1,7 +1,6 @@
 package org.alliancegenome.curation_api.services;
 
 import java.util.List;
-import java.util.Map;
 
 import org.alliancegenome.curation_api.dao.GeneGeneticInteractionDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneMolecularInteractionService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneMolecularInteractionService.java
@@ -1,7 +1,6 @@
 package org.alliancegenome.curation_api.services;
 
 import java.util.List;
-import java.util.Map;
 
 import org.alliancegenome.curation_api.dao.GeneMolecularInteractionDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneMolecularInteractionService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneMolecularInteractionService.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.curation_api.services;
 
 import java.util.List;
+import java.util.Map;
 
 import org.alliancegenome.curation_api.dao.GeneMolecularInteractionDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
@@ -32,6 +33,10 @@ public class GeneMolecularInteractionService extends BaseEntityCrudService<GeneM
 	@Override
 	public ObjectResponse<GeneMolecularInteraction> getByIdentifier(String identifier) {
 		return new ObjectResponse<>(findByAlternativeFields(List.of("interactionId", "uniqueId"), identifier));
+	}
+
+	public void preloadInteractionIds() {
+		geneMolInteractionValidator.setExistingInteractionMap(geneMolecularInteractionDAO.findInteractionIdMap());
 	}
 
 	public List<Long> getAllIds() {

--- a/src/main/java/org/alliancegenome/curation_api/services/NoteService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/NoteService.java
@@ -34,7 +34,11 @@ public class NoteService extends BaseEntityCrudService<Note, NoteDAO> {
 		if (dbEntity == null) {
 			return null;
 		}
-		return new ObjectResponse<Note>(noteDAO.persist(dbEntity));
+		dbEntity = noteDAO.persist(dbEntity);
+		if (dbEntity.getNoteType() != null && dbEntity.getNoteType().getSynonyms() != null) {
+			dbEntity.getNoteType().getSynonyms().size();
+		}
+		return new ObjectResponse<Note>(dbEntity);
 	}
 
 	public ObjectResponse<Note> validate(Note uiEntity) {

--- a/src/main/java/org/alliancegenome/curation_api/services/PhenotypeAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/PhenotypeAnnotationService.java
@@ -24,10 +24,15 @@ import org.alliancegenome.curation_api.model.entities.AllelePhenotypeAnnotation;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.GenePhenotypeAnnotation;
 import org.alliancegenome.curation_api.model.entities.GenomicEntity;
+import org.alliancegenome.curation_api.model.entities.InformationContentEntity;
 import org.alliancegenome.curation_api.model.entities.PhenotypeAnnotation;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.PhenotypeFmsDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.services.base.BaseAnnotationCrudService;
+import org.alliancegenome.curation_api.services.helpers.annotations.AnnotationUniqueIdHelper;
+import org.alliancegenome.curation_api.services.validation.dto.fms.AGMPhenotypeAnnotationFmsDTOValidator;
+import org.alliancegenome.curation_api.services.validation.dto.fms.AllelePhenotypeAnnotationFmsDTOValidator;
+import org.alliancegenome.curation_api.services.validation.dto.fms.GenePhenotypeAnnotationFmsDTOValidator;
 import org.apache.commons.lang3.StringUtils;
 
 import jakarta.annotation.PostConstruct;
@@ -46,11 +51,17 @@ public class PhenotypeAnnotationService extends BaseAnnotationCrudService<Phenot
 	@Inject PersonDAO personDAO;
 	@Inject GenomicEntityService genomicEntityService;
 	@Inject ReferenceService referenceService;
+	@Inject InformationContentEntityService iceService;
 	@Inject AGMPhenotypeAnnotationService agmPhenotypeAnnotationService;
 	@Inject GenePhenotypeAnnotationService genePhenotypeAnnotationService;
 	@Inject AllelePhenotypeAnnotationService allelePhenotypeAnnotationService;
+	@Inject GenePhenotypeAnnotationFmsDTOValidator genePhenotypeAnnotationFmsDtoValidator;
+	@Inject AllelePhenotypeAnnotationFmsDTOValidator allelePhenotypeAnnotationFmsDtoValidator;
+	@Inject AGMPhenotypeAnnotationFmsDTOValidator agmPhenotypeAnnotationFmsDtoValidator;
 
 	HashMap<String, List<PhenotypeFmsDTO>> unprocessedAnnotationsMap = new HashMap<>();
+	private HashMap<String, String> genomicEntityIdentifierCache = new HashMap<>();
+	private Map<String, Long> existingUniqueIds;
 
 	@Override
 	@PostConstruct
@@ -90,15 +101,52 @@ public class PhenotypeAnnotationService extends BaseAnnotationCrudService<Phenot
 		return annotationIds;
 	}
 
+	public void preloadUniqueIds(BackendBulkDataProvider dataProvider) {
+		existingUniqueIds = phenotypeAnnotationDAO.findUniqueIdsByDataProvider(dataProvider.sourceOrganization);
+		Map<String, Long> inferredGeneIds = phenotypeAnnotationDAO.findInferredGeneIdsByDataProvider(dataProvider.sourceOrganization);
+		Map<String, Long> inferredAlleleIds = phenotypeAnnotationDAO.findInferredAlleleIdsByDataProvider(dataProvider.sourceOrganization);
+		genePhenotypeAnnotationFmsDtoValidator.setExistingUniqueIds(existingUniqueIds);
+		allelePhenotypeAnnotationFmsDtoValidator.setExistingUniqueIds(existingUniqueIds);
+		allelePhenotypeAnnotationFmsDtoValidator.setInferredGeneIds(inferredGeneIds);
+		agmPhenotypeAnnotationFmsDtoValidator.setExistingUniqueIds(existingUniqueIds);
+		agmPhenotypeAnnotationFmsDtoValidator.setInferredGeneIds(inferredGeneIds);
+		agmPhenotypeAnnotationFmsDtoValidator.setInferredAlleleIds(inferredAlleleIds);
+	}
+
+	private String resolveIdentifier(String objectId) {
+		return genomicEntityIdentifierCache.computeIfAbsent(objectId, id -> {
+			GenomicEntity entity = genomicEntityService.findByIdentifierString(id);
+			return entity != null ? entity.getIdentifier() : null;
+		});
+	}
+
 	@Transactional
 	public Long upsertPrimaryAnnotation(PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
 		if (StringUtils.isBlank(dto.getObjectId())) {
 			throw new ObjectValidationException(dto, "objectId - " + ValidationConstants.REQUIRED_MESSAGE);
 		}
-		GenomicEntity phenotypeAnnotationSubject = genomicEntityService.findByIdentifierString(dto.getObjectId());
-		if (phenotypeAnnotationSubject == null) {
+
+		String subjectIdentifier = resolveIdentifier(dto.getObjectId());
+		if (subjectIdentifier == null) {
 			throw new ObjectValidationException(dto, "objectId - " + ValidationConstants.INVALID_MESSAGE + " (" + dto.getObjectId() + ")");
 		}
+
+		// Skip unchanged records by checking pre-loaded uniqueId map
+		if (existingUniqueIds != null && dto.getEvidence() != null && StringUtils.isNotBlank(dto.getEvidence().getPublicationId())) {
+			String refCurie = dto.getEvidence().getPublicationId();
+			if (refCurie.startsWith("OMIM:")) {
+				refCurie = refCurie.substring(1);
+			}
+			InformationContentEntity refEntity = iceService.retrieveFromDbOrLiteratureService(refCurie);
+			String refString = refEntity != null ? refEntity.getCurie() : null;
+			String uniqueId = AnnotationUniqueIdHelper.getPhenotypeAnnotationUniqueId(dto, subjectIdentifier, refString);
+			if (existingUniqueIds.containsKey(uniqueId)) {
+				return existingUniqueIds.get(uniqueId);
+			}
+		}
+
+		// Not skipped -- do a fresh entity lookup within this transaction
+		GenomicEntity phenotypeAnnotationSubject = genomicEntityService.findByIdentifierString(dto.getObjectId());
 
 		if (phenotypeAnnotationSubject instanceof AffectedGenomicModel) {
 			AGMPhenotypeAnnotation annotation = agmPhenotypeAnnotationService.upsertPrimaryAnnotation((AffectedGenomicModel) phenotypeAnnotationSubject, dto, dataProvider);

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/AgmAlleleAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/AgmAlleleAssociationService.java
@@ -50,6 +50,11 @@ public class AgmAlleleAssociationService extends BaseAssociationDTOCrudService<A
 		return agmAlleleAssociationDtoValidator.validateAgmAlleleAssociationDTO(dto, dataProvider);
 	}
 
+	public void preloadAssociationKeys(BackendBulkDataProvider dataProvider) {
+		Map<String, Long>[] keys = agmAlleleAssociationDAO.findAssociationKeysByDataProvider(dataProvider.sourceOrganization);
+		agmAlleleAssociationDtoValidator.preloadAssociationKeys(keys[0], keys[1]);
+	}
+
 	public List<Long> getAssociationsByDataProvider(BackendBulkDataProvider dataProvider) {
 		Map<String, Object> params = new HashMap<>();
 		params.put(EntityFieldConstants.AGM_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/AgmAlleleAssociationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/AgmAlleleAssociationDTOValidator.java
@@ -2,8 +2,8 @@ package org.alliancegenome.curation_api.services.validation.dto.associations;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.associations.AgmAlleleAssociationDAO;
@@ -17,7 +17,6 @@ import org.alliancegenome.curation_api.model.entities.associations.AgmAlleleAsso
 import org.alliancegenome.curation_api.model.entities.ontology.GENOTerm;
 import org.alliancegenome.curation_api.model.ingest.dto.associations.AgmAlleleAssociationDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
-import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.AffectedGenomicModelService;
 import org.alliancegenome.curation_api.services.AlleleService;
 import org.alliancegenome.curation_api.services.VocabularyTermService;
@@ -41,6 +40,18 @@ public class AgmAlleleAssociationDTOValidator extends AuditedObjectDTOValidator<
 	@Inject
 	GenoTermService genoTermService;
 
+	private HashMap<String, List<Long>> agmIdCache = new HashMap<>();
+	private HashMap<String, List<Long>> alleleIdCache = new HashMap<>();
+	private HashMap<String, AffectedGenomicModel> agmCache = new HashMap<>();
+	private HashMap<String, Allele> alleleCache = new HashMap<>();
+	private Map<String, Long> existingIdentityKeys;
+	private Map<String, Long> existingFullStateKeys;
+
+	public void preloadAssociationKeys(Map<String, Long> identityKeys, Map<String, Long> fullStateKeys) {
+		this.existingIdentityKeys = identityKeys;
+		this.existingFullStateKeys = fullStateKeys;
+	}
+
 	public ObjectResponse<AgmAlleleAssociation> validateAgmAlleleAssociationDTO(AgmAlleleAssociationDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
 		response = new ObjectResponse<AgmAlleleAssociation>();
 
@@ -48,7 +59,7 @@ public class AgmAlleleAssociationDTOValidator extends AuditedObjectDTOValidator<
 		if (StringUtils.isBlank(dto.getAgmSubjectIdentifier())) {
 			response.addErrorMessage("agm_identifier", ValidationConstants.REQUIRED_MESSAGE);
 		} else {
-			subjectIds = agmService.findIdsByIdentifierString(dto.getAgmSubjectIdentifier());
+			subjectIds = agmIdCache.computeIfAbsent(dto.getAgmSubjectIdentifier(), agmService::findIdsByIdentifierString);
 			if (subjectIds == null || subjectIds.size() != 1) {
 				response.addErrorMessage("agm_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAgmSubjectIdentifier() + ")");
 			}
@@ -58,7 +69,7 @@ public class AgmAlleleAssociationDTOValidator extends AuditedObjectDTOValidator<
 		if (StringUtils.isBlank(dto.getAlleleIdentifier())) {
 			response.addErrorMessage("allele_identifier", ValidationConstants.REQUIRED_MESSAGE);
 		} else {
-			objectIds = alleleService.findIdsByIdentifierString(dto.getAlleleIdentifier());
+			objectIds = alleleIdCache.computeIfAbsent(dto.getAlleleIdentifier(), alleleService::findIdsByIdentifierString);
 			if (objectIds == null || objectIds.size() != 1) {
 				response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAlleleIdentifier() + ")");
 			}
@@ -71,27 +82,42 @@ public class AgmAlleleAssociationDTOValidator extends AuditedObjectDTOValidator<
 			validateTermInVocabulary("zygosity_curie", dto.getZygosityCurie(), VocabularyConstants.AGM_ALLELE_GENOTYPE_TERMS_VOCABULARY);
 		}
 
+		if (response.hasErrors()) {
+			throw new ObjectValidationException(dto, response.errorMessagesString());
+		}
+
 		AgmAlleleAssociation association = null;
 		if (subjectIds != null && subjectIds.size() == 1 && objectIds != null && objectIds.size() == 1 && relation != null) {
-			HashMap<String, Object> params = new HashMap<>();
+			String identityKey = subjectIds.get(0) + "|" + relation.getId() + "|" + objectIds.get(0);
 
-			params.put(EntityFieldConstants.AGM_ASSOCIATION_SUBJECT + ".id", subjectIds.get(0));
-			params.put(EntityFieldConstants.RELATION + ".id", relation.getId());
-			params.put(EntityFieldConstants.AGM_ALLELE_ASSOCIATION_OBJECT + ".id", objectIds.get(0));
+			Boolean internal = dto.getInternal() != null ? dto.getInternal() : false;
+			Boolean obsolete = dto.getObsolete() != null ? dto.getObsolete() : false;
+			String fullKey = identityKey + "|" + (zygosity != null ? zygosity.getId() : "null") + "|" + internal + "|" + obsolete;
 
-			SearchResponse<AgmAlleleAssociation> searchResponse = agmAlleleAssociationDAO.findByParams(params);
-			if (searchResponse != null && searchResponse.getResults().size() == 1) {
-				association = searchResponse.getSingleResult();
+			// Check if record is completely unchanged -- skip all DB work
+			if (existingFullStateKeys != null && existingFullStateKeys.containsKey(fullKey)) {
+				Long existingId = existingFullStateKeys.get(fullKey);
+				association = new AgmAlleleAssociation();
+				association.setId(existingId);
+				response.setEntity(association);
+				return response;
+			}
+
+			// Record exists but changed -- find and update
+			if (existingIdentityKeys != null && existingIdentityKeys.containsKey(identityKey)) {
+				association = agmAlleleAssociationDAO.find(existingIdentityKeys.get(identityKey));
 			} else {
-				if (association == null) {
-					association = new AgmAlleleAssociation();
-				}
+				association = agmAlleleAssociationDAO.findBySubjectAndRelationAndObject(subjectIds.get(0), relation.getId(), objectIds.get(0));
+			}
+
+			if (association == null) {
+				association = new AgmAlleleAssociation();
 
 				association.setRelation(relation);
 
 				if (association.getAgmAssociationSubject() == null && !StringUtils.isBlank(dto.getAgmSubjectIdentifier())) {
 
-					AffectedGenomicModel subject = agmService.findByIdentifierString(dto.getAgmSubjectIdentifier());
+					AffectedGenomicModel subject = agmCache.computeIfAbsent(dto.getAgmSubjectIdentifier(), agmService::findByIdentifierString);
 					if (subject == null) {
 						response.addErrorMessage("agm_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAgmSubjectIdentifier() + ")");
 					} else if (dataProvider != null && !subject.getDataProvider().getAbbreviation().equals(dataProvider.sourceOrganization)) {
@@ -103,7 +129,7 @@ public class AgmAlleleAssociationDTOValidator extends AuditedObjectDTOValidator<
 
 				if (association.getAgmAlleleAssociationObject() == null && !StringUtils.isBlank(dto.getAlleleIdentifier())) {
 
-					Allele object = alleleService.findByIdentifierString(dto.getAlleleIdentifier());
+					Allele object = alleleCache.computeIfAbsent(dto.getAlleleIdentifier(), alleleService::findByIdentifierString);
 					if (object == null) {
 						response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAlleleIdentifier() + ")");
 					} else if (dataProvider != null && !object.getDataProvider().getAbbreviation().equals(dataProvider.sourceOrganization)) {

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/AGMPhenotypeAnnotationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/AGMPhenotypeAnnotationFmsDTOValidator.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.curation_api.services.validation.dto.fms;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -36,6 +37,8 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 	@Inject GenomicEntityService genomicEntityService;
 	@Inject PhenotypeAnnotationService phenotypeAnnotationService;
 	@Inject GenePhenotypeAnnotationXrefHelper xrefHelper;
+
+	private HashMap<String, Long> genomicEntityIdCache = new HashMap<>();
 
 	public AGMPhenotypeAnnotation validatePrimaryAnnotation(AffectedGenomicModel subject, PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider) throws ObjectValidationException {
 
@@ -77,6 +80,35 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 	}
 
 	public List<AGMPhenotypeAnnotation> validateInferredOrAssertedEntities(AffectedGenomicModel primaryAnnotationSubject, PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider, Set<Long> idsAdded) throws ValidationException {
+		// Fast skip: check if the inferred gene/allele is already set using pre-loaded maps only
+		if (existingUniqueIds != null && StringUtils.isNotBlank(dto.getObjectId())) {
+			ObjectResponse<InformationContentEntity> quickRefResponse = validateReference(dto);
+			if (!quickRefResponse.hasErrors()) {
+				String quickRefString = quickRefResponse.getEntity() != null ? quickRefResponse.getEntity().getCurie() : null;
+				String uniqueId = AnnotationUniqueIdHelper.getPhenotypeAnnotationUniqueId(dto, primaryAnnotationSubject.getIdentifier(), quickRefString);
+				if (existingUniqueIds.containsKey(uniqueId)) {
+					Long objectEntityId = genomicEntityIdCache.computeIfAbsent(dto.getObjectId(), id -> {
+						GenomicEntity entity = genomicEntityService.findByIdentifierString(id);
+						return entity != null ? entity.getId() : null;
+					});
+					if (objectEntityId != null) {
+						boolean alreadySet = false;
+						if (dataProvider.hasInferredGenePhenotypeAnnotations && inferredGeneIds != null) {
+							Long existingId = inferredGeneIds.get(uniqueId);
+							alreadySet = existingId != null && existingId.equals(objectEntityId);
+						} else if (dataProvider.hasInferredAllelePhenotypeAnnotations && inferredAlleleIds != null) {
+							Long existingId = inferredAlleleIds.get(uniqueId);
+							alreadySet = existingId != null && existingId.equals(objectEntityId);
+						}
+						if (alreadySet) {
+							idsAdded.add(existingUniqueIds.get(uniqueId));
+							return new ArrayList<>();
+						}
+					}
+				}
+			}
+		}
+
 		ObjectResponse<AGMPhenotypeAnnotation> apaResponse = new ObjectResponse<AGMPhenotypeAnnotation>();
 
 		ObjectResponse<InformationContentEntity> refResponse = validateReference(dto);
@@ -84,8 +116,8 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 
 		InformationContentEntity reference = refResponse.getEntity();
 		String refString = reference == null ? null : reference.getCurie();
-		
-		List<AGMPhenotypeAnnotation> primaryAnnotations = findPrimaryAnnotations(agmPhenotypeAnnotationDAO, dto, primaryAnnotationSubject.getPrimaryExternalId(), refString);
+
+		List<AGMPhenotypeAnnotation> primaryAnnotations = findPrimaryAnnotations(agmPhenotypeAnnotationDAO, dto, primaryAnnotationSubject.getIdentifier(), refString);
 		
 		if (CollectionUtils.isEmpty(primaryAnnotations)) {
 			PhenotypeFmsDTO inferredPrimaryDTO = createPrimaryAnnotationDTO(dto, primaryAnnotationSubject.getIdentifier());
@@ -108,6 +140,23 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 			if (inferredOrAssertedEntity == null) {
 				apaResponse.addErrorMessage("objectId", ValidationConstants.INVALID_MESSAGE + " (" + dto.getObjectId() + ")");
 			} else if (inferredOrAssertedEntity instanceof Gene) {
+				boolean alreadySet = true;
+				for (AGMPhenotypeAnnotation primaryAnnotation : primaryAnnotations) {
+					if (dataProvider.hasInferredGenePhenotypeAnnotations) {
+						if (primaryAnnotation.getInferredGene() == null || !primaryAnnotation.getInferredGene().getId().equals(inferredOrAssertedEntity.getId())) {
+							alreadySet = false;
+							break;
+						}
+					} else if (dataProvider.hasAssertedGenePhenotypeAnnotations) {
+						if (primaryAnnotation.getAssertedGenes() == null || primaryAnnotation.getAssertedGenes().stream().noneMatch(g -> g.getId().equals(inferredOrAssertedEntity.getId()))) {
+							alreadySet = false;
+							break;
+						}
+					}
+				}
+				if (alreadySet) {
+					return new ArrayList<>();
+				}
 				Gene inferredOrAssertedGene = xrefHelper.addGenePhenotypeCrossReference(dataProvider, (Gene) inferredOrAssertedEntity);
 				for (AGMPhenotypeAnnotation primaryAnnotation : primaryAnnotations) {
 					if (dataProvider.hasInferredGenePhenotypeAnnotations) {
@@ -124,6 +173,23 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 					}
 				}
 			} else if (inferredOrAssertedEntity instanceof Allele) {
+				boolean alreadySet = true;
+				for (AGMPhenotypeAnnotation primaryAnnotation : primaryAnnotations) {
+					if (dataProvider.hasInferredAllelePhenotypeAnnotations) {
+						if (primaryAnnotation.getInferredAllele() == null || !primaryAnnotation.getInferredAllele().getId().equals(inferredOrAssertedEntity.getId())) {
+							alreadySet = false;
+							break;
+						}
+					} else if (dataProvider.hasAssertedAllelePhenotypeAnnotations) {
+						if (primaryAnnotation.getAssertedAlleles() == null || primaryAnnotation.getAssertedAlleles().stream().noneMatch(a -> a.getId().equals(inferredOrAssertedEntity.getId()))) {
+							alreadySet = false;
+							break;
+						}
+					}
+				}
+				if (alreadySet) {
+					return new ArrayList<>();
+				}
 				for (AGMPhenotypeAnnotation primaryAnnotation : primaryAnnotations) {
 					Allele inferredOrInsertedAllele = (Allele) inferredOrAssertedEntity;
 					if (dataProvider.hasInferredAllelePhenotypeAnnotations) {
@@ -147,7 +213,7 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 		if (apaResponse.hasErrors()) {
 			throw new ObjectValidationException(dto, apaResponse.errorMessagesString());
 		}
-		
+
 		return primaryAnnotations;
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/AllelePhenotypeAnnotationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/AllelePhenotypeAnnotationFmsDTOValidator.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.curation_api.services.validation.dto.fms;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -35,6 +36,8 @@ public class AllelePhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotatio
 	@Inject GenomicEntityService genomicEntityService;
 	@Inject PhenotypeAnnotationService phenotypeAnnotationService;
 	@Inject GenePhenotypeAnnotationXrefHelper xrefHelper;
+
+	private HashMap<String, Long> genomicEntityIdCache = new HashMap<>();
 
 	public AllelePhenotypeAnnotation validatePrimaryAnnotation(Allele subject, PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider) throws ObjectValidationException {
 
@@ -74,6 +77,26 @@ public class AllelePhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotatio
 	}
 
 	public List<AllelePhenotypeAnnotation> validateInferredOrAssertedEntities(Allele primaryAnnotationSubject, PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider, Set<Long> idsAdded) throws ValidationException {
+		// Fast skip: check if the inferred gene is already set using pre-loaded maps only
+		if (existingUniqueIds != null && inferredGeneIds != null && dataProvider.hasInferredGenePhenotypeAnnotations && StringUtils.isNotBlank(dto.getObjectId())) {
+			ObjectResponse<InformationContentEntity> quickRefResponse = validateReference(dto);
+			if (!quickRefResponse.hasErrors()) {
+				String quickRefString = quickRefResponse.getEntity() != null ? quickRefResponse.getEntity().getCurie() : null;
+				String uniqueId = AnnotationUniqueIdHelper.getPhenotypeAnnotationUniqueId(dto, primaryAnnotationSubject.getIdentifier(), quickRefString);
+				if (existingUniqueIds.containsKey(uniqueId)) {
+					Long existingInferredGeneId = inferredGeneIds.get(uniqueId);
+					Long objectEntityId = genomicEntityIdCache.computeIfAbsent(dto.getObjectId(), id -> {
+						GenomicEntity entity = genomicEntityService.findByIdentifierString(id);
+						return entity != null ? entity.getId() : null;
+					});
+					if (existingInferredGeneId != null && objectEntityId != null && existingInferredGeneId.equals(objectEntityId)) {
+						idsAdded.add(existingUniqueIds.get(uniqueId));
+						return new ArrayList<>();
+					}
+				}
+			}
+		}
+
 		ObjectResponse<AllelePhenotypeAnnotation> apaResponse = new ObjectResponse<AllelePhenotypeAnnotation>();
 
 		ObjectResponse<InformationContentEntity> refResponse = validateReference(dto);
@@ -81,8 +104,8 @@ public class AllelePhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotatio
 
 		InformationContentEntity reference = refResponse.getEntity();
 		String refString = reference == null ? null : reference.getCurie();
-		
-		List<AllelePhenotypeAnnotation> primaryAnnotations = findPrimaryAnnotations(allelePhenotypeAnnotationDAO, dto, primaryAnnotationSubject.getPrimaryExternalId(), refString);
+
+		List<AllelePhenotypeAnnotation> primaryAnnotations = findPrimaryAnnotations(allelePhenotypeAnnotationDAO, dto, primaryAnnotationSubject.getIdentifier(), refString);
 		
 		if (CollectionUtils.isEmpty(primaryAnnotations)) {
 
@@ -106,6 +129,23 @@ public class AllelePhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotatio
 			if (inferredOrAssertedEntity == null) {
 				apaResponse.addErrorMessage("objectId", ValidationConstants.INVALID_MESSAGE + " (" + dto.getObjectId() + ")");
 			} else if (inferredOrAssertedEntity instanceof Gene) {
+				boolean alreadySet = true;
+				for (AllelePhenotypeAnnotation primaryAnnotation : primaryAnnotations) {
+					if (dataProvider.hasInferredGenePhenotypeAnnotations) {
+						if (primaryAnnotation.getInferredGene() == null || !primaryAnnotation.getInferredGene().getId().equals(inferredOrAssertedEntity.getId())) {
+							alreadySet = false;
+							break;
+						}
+					} else if (dataProvider.hasAssertedGenePhenotypeAnnotations) {
+						if (primaryAnnotation.getAssertedGenes() == null || primaryAnnotation.getAssertedGenes().stream().noneMatch(g -> g.getId().equals(inferredOrAssertedEntity.getId()))) {
+							alreadySet = false;
+							break;
+						}
+					}
+				}
+				if (alreadySet) {
+					return new ArrayList<>();
+				}
 				Gene inferredOrAssertedGene = xrefHelper.addGenePhenotypeCrossReference(dataProvider, (Gene) inferredOrAssertedEntity);
 				for (AllelePhenotypeAnnotation primaryAnnotation : primaryAnnotations) {
 					if (dataProvider.hasInferredGenePhenotypeAnnotations) {
@@ -129,7 +169,7 @@ public class AllelePhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotatio
 		if (apaResponse.hasErrors()) {
 			throw new ObjectValidationException(dto, apaResponse.errorMessagesString());
 		}
-		
+
 		return primaryAnnotations;
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GeneGeneticInteractionFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GeneGeneticInteractionFmsDTOValidator.java
@@ -1,12 +1,14 @@
 package org.alliancegenome.curation_api.services.validation.dto.fms;
 
 import java.util.List;
+import java.util.Map;
 
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.enums.PsiMiTabPrefixEnum;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
+import org.alliancegenome.curation_api.dao.GeneGeneticInteractionDAO;
 import org.alliancegenome.curation_api.model.entities.Allele;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.GeneGeneticInteraction;
@@ -28,11 +30,17 @@ import jakarta.inject.Inject;
 public class GeneGeneticInteractionFmsDTOValidator extends GeneInteractionFmsDTOValidator {
 
 	@Inject GeneGeneticInteractionService geneGeneticInteractionService;
+	@Inject GeneGeneticInteractionDAO geneGeneticInteractionDAO;
 	@Inject AlleleService alleleService;
 	@Inject VocabularyTermService vocabularyTermService;
 	@Inject InteractionAnnotationsHelper interactionAnnotationsHelper;
 
+	private Map<String, long[]> existingInteractionMap;
 	private ObjectResponse<GeneGeneticInteraction> ggiResponse;
+
+	public void setExistingInteractionMap(Map<String, long[]> map) {
+		this.existingInteractionMap = map;
+	}
 
 	public ObjectResponse<GeneGeneticInteraction> validateGeneGeneticInteractionFmsDTO(PsiMiTabDTO dto) throws ValidationException {
 
@@ -75,10 +83,27 @@ public class GeneGeneticInteractionFmsDTOValidator extends GeneInteractionFmsDTO
 
 		String uniqueId = InteractionStringHelper.getGeneGeneticInteractionUniqueId(dto, interactorA, interactorB, interactionId, references, phenotypesOrTraits);
 
-		String searchValue = interactionId == null ? uniqueId : interactionId;
-		ObjectResponse<GeneGeneticInteraction> interactionResponse = geneGeneticInteractionService.getByIdentifier(searchValue);
-		if (interactionResponse != null) {
-			interaction = interactionResponse.getEntity();
+		// Fast path: use pre-loaded map to skip unchanged records or find existing by PK
+		if (existingInteractionMap != null && interactionId != null) {
+			long[] existing = existingInteractionMap.get(interactionId);
+			if (existing != null) {
+				long existingId = existing[0];
+				long existingUniqueIdHash = existing[1];
+				if (uniqueId != null && uniqueId.hashCode() == existingUniqueIdHash) {
+					interaction = new GeneGeneticInteraction();
+					interaction.setId(existingId);
+					ggiResponse.setEntity(interaction);
+					return ggiResponse;
+				}
+				interaction = geneGeneticInteractionDAO.find(existingId);
+			}
+		}
+		if (interaction == null) {
+			String searchValue = interactionId == null ? uniqueId : interactionId;
+			ObjectResponse<GeneGeneticInteraction> interactionResponse = geneGeneticInteractionService.getByIdentifier(searchValue);
+			if (interactionResponse != null) {
+				interaction = interactionResponse.getEntity();
+			}
 		}
 		if (interaction == null) {
 			interaction = new GeneGeneticInteraction();
@@ -106,7 +131,7 @@ public class GeneGeneticInteractionFmsDTOValidator extends GeneInteractionFmsDTO
 			throw new ObjectValidationException(dto, ggiResponse.getErrorMessages().values());
 		}
 		
-		ggiResponse.setEntity(interaction);
+		ggiResponse.setEntity(geneGeneticInteractionDAO.persist(interaction));
 
 		return ggiResponse;
 

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GeneInteractionFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GeneInteractionFmsDTOValidator.java
@@ -187,36 +187,43 @@ public class GeneInteractionFmsDTOValidator extends BaseDTOValidator {
 		if (prefix.isModPrefix) {
 			allianceGene = getGeneFromCache(convertedCurie);
 		} else {
-			String taxonCurie = InteractionStringHelper.getAllianceTaxonCurie(psiMiTabTaxonCurie);
-			if (taxonCurie == null) {
-				response.addErrorMessage("taxon", ValidationConstants.INVALID_MESSAGE + " (expecting string starting taxid:<suffix>, got " + psiMiTabTaxonCurie + ")");
-				return response;
-			}
-			NCBITaxonTerm taxon = ncbiTaxonTermService.getByCurie(taxonCurie).getEntity();
-			if (taxon == null) {
-				response.addErrorMessage("taxon", ValidationConstants.INVALID_MESSAGE + " (" + taxonCurie + " not found)");
-				return response;
-			}
+			String cacheKey = convertedCurie + "|" + psiMiTabTaxonCurie;
+			if (geneCache.containsKey(cacheKey)) {
+				allianceGene = geneCache.get(cacheKey);
+			} else {
+				String taxonCurie = InteractionStringHelper.getAllianceTaxonCurie(psiMiTabTaxonCurie);
+				if (taxonCurie == null) {
+					response.addErrorMessage("taxon", ValidationConstants.INVALID_MESSAGE + " (expecting string starting taxid:<suffix>, got " + psiMiTabTaxonCurie + ")");
+					return response;
+				}
+				NCBITaxonTerm taxon = ncbiTaxonTermService.getByCurie(taxonCurie).getEntity();
+				if (taxon == null) {
+					response.addErrorMessage("taxon", ValidationConstants.INVALID_MESSAGE + " (" + taxonCurie + " not found)");
+					return response;
+				}
 
-			SearchResponse<Gene> searchResponse = geneService.findByField("crossReferences.referencedCurie", convertedCurie);
-			if (searchResponse != null) {
-				// Need to check that returned gene is non-obsolete and belongs to MOD corresponding to taxon
-				for (Gene searchResult : searchResponse.getResults()) {
-					if (!searchResult.getObsolete()) {
-						String resultDataProviderCoreGenus = BackendBulkDataProvider.getCoreGenus(searchResult.getDataProvider().getAbbreviation());
-						if (taxon.getName().startsWith(resultDataProviderCoreGenus + " ")) {
-							allianceGene = searchResult;
-							break;
-						}
-						if (StringUtils.equals(taxonCurie, "NCBITaxon:9606") && StringUtils.equals(searchResult.getDataProvider().getAbbreviation(), "RGD")) {
-							allianceGene = searchResult;
-							break;
-						}
-						if (StringUtils.equals(taxonCurie, "NCBITaxon:2697049") && StringUtils.equals(searchResult.getDataProvider().getAbbreviation(), "Alliance")) {
-							allianceGene = searchResult;
-							break;
+				SearchResponse<Gene> searchResponse = geneService.findByField("crossReferences.referencedCurie", convertedCurie);
+				if (searchResponse != null) {
+					for (Gene searchResult : searchResponse.getResults()) {
+						if (!searchResult.getObsolete()) {
+							String resultDataProviderCoreGenus = BackendBulkDataProvider.getCoreGenus(searchResult.getDataProvider().getAbbreviation());
+							if (taxon.getName().startsWith(resultDataProviderCoreGenus + " ")) {
+								allianceGene = searchResult;
+								break;
+							}
+							if (StringUtils.equals(taxonCurie, "NCBITaxon:9606") && StringUtils.equals(searchResult.getDataProvider().getAbbreviation(), "RGD")) {
+								allianceGene = searchResult;
+								break;
+							}
+							if (StringUtils.equals(taxonCurie, "NCBITaxon:2697049") && StringUtils.equals(searchResult.getDataProvider().getAbbreviation(), "Alliance")) {
+								allianceGene = searchResult;
+								break;
+							}
 						}
 					}
+				}
+				if (allianceGene != null) {
+					geneCache.put(cacheKey, allianceGene);
 				}
 			}
 		}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GeneMolecularInteractionFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GeneMolecularInteractionFmsDTOValidator.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.curation_api.services.validation.dto.fms;
 
 import java.util.List;
+import java.util.Map;
 
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
@@ -30,7 +31,12 @@ public class GeneMolecularInteractionFmsDTOValidator extends GeneInteractionFmsD
 	@Inject VocabularyTermService vocabularyTermService;
 	@Inject GeneMolecularInteractionDAO geneMolecularInteractionDAO;
 
+	private Map<String, long[]> existingInteractionMap;
 	private ObjectResponse<GeneMolecularInteraction> gmiResponse;
+
+	public void setExistingInteractionMap(Map<String, long[]> map) {
+		this.existingInteractionMap = map;
+	}
 
 	public ObjectResponse<GeneMolecularInteraction> validateGeneMolecularInteractionFmsDTO(PsiMiTabDTO dto) throws ValidationException {
 
@@ -71,10 +77,29 @@ public class GeneMolecularInteractionFmsDTOValidator extends GeneInteractionFmsD
 
 		String uniqueId = InteractionStringHelper.getGeneMolecularInteractionUniqueId(dto, interactorA, interactorB, interactionId, references);
 
-		String searchValue = interactionId == null ? uniqueId : interactionId;
-		ObjectResponse<GeneMolecularInteraction> interactionResponse = geneMolecularInteractionService.getByIdentifier(searchValue);
-		if (interactionResponse != null) {
-			interaction = interactionResponse.getEntity();
+		// Fast path: use pre-loaded map to skip unchanged records or find existing by PK
+		if (existingInteractionMap != null && interactionId != null) {
+			long[] existing = existingInteractionMap.get(interactionId);
+			if (existing != null) {
+				long existingId = existing[0];
+				long existingUniqueIdHash = existing[1];
+				// Skip entirely if uniqueId hasn't changed
+				if (uniqueId != null && uniqueId.hashCode() == existingUniqueIdHash) {
+					interaction = new GeneMolecularInteraction();
+					interaction.setId(existingId);
+					gmiResponse.setEntity(interaction);
+					return gmiResponse;
+				}
+				// Changed -- load by PK instead of findByParams
+				interaction = geneMolecularInteractionDAO.find(existingId);
+			}
+		}
+		if (interaction == null) {
+			String searchValue = interactionId == null ? uniqueId : interactionId;
+			ObjectResponse<GeneMolecularInteraction> interactionResponse = geneMolecularInteractionService.getByIdentifier(searchValue);
+			if (interactionResponse != null) {
+				interaction = interactionResponse.getEntity();
+			}
 		}
 		if (interaction == null) {
 			interaction = new GeneMolecularInteraction();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/PhenotypeAnnotationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/PhenotypeAnnotationFmsDTOValidator.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.constants.ValidationConstants;
@@ -19,6 +20,7 @@ import org.alliancegenome.curation_api.model.entities.ExternalDatabaseReference;
 import org.alliancegenome.curation_api.model.entities.InformationContentEntity;
 import org.alliancegenome.curation_api.model.entities.PhenotypeAnnotation;
 import org.alliancegenome.curation_api.model.entities.ontology.PhenotypeTerm;
+import org.alliancegenome.curation_api.services.helpers.annotations.AnnotationUniqueIdHelper;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.ConditionRelationFmsDTO;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.PhenotypeFmsDTO;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.PhenotypeTermIdentifierFmsDTO;
@@ -47,6 +49,22 @@ public class PhenotypeAnnotationFmsDTOValidator {
 	@Inject VocabularyTermService vocabularyTermService;
 	@Inject ResourceDescriptorPageService resourceDescriptorPageService;
 	@Inject ExternalDatabaseReferenceDAO externalDatabaseReferenceDAO;
+
+	protected Map<String, Long> existingUniqueIds;
+	protected Map<String, Long> inferredGeneIds;
+	protected Map<String, Long> inferredAlleleIds;
+
+	public void setExistingUniqueIds(Map<String, Long> existingUniqueIds) {
+		this.existingUniqueIds = existingUniqueIds;
+	}
+
+	public void setInferredGeneIds(Map<String, Long> inferredGeneIds) {
+		this.inferredGeneIds = inferredGeneIds;
+	}
+
+	public void setInferredAlleleIds(Map<String, Long> inferredAlleleIds) {
+		this.inferredAlleleIds = inferredAlleleIds;
+	}
 
 	public <E extends PhenotypeAnnotation> ObjectResponse<E> validatePhenotypeAnnotation(E annotation, PhenotypeFmsDTO dto, BackendBulkDataProvider beDataProvider) {
 
@@ -144,9 +162,23 @@ public class PhenotypeAnnotationFmsDTOValidator {
 		return refResponse;
 	}
 
-	protected <D extends BaseSQLDAO<E>, E extends PhenotypeAnnotation> List<E> findPrimaryAnnotations(D dao, PhenotypeFmsDTO dto, String primaryAnnotationSubjectprimaryExternalId, String refString) {
+	protected <D extends BaseSQLDAO<E>, E extends PhenotypeAnnotation> List<E> findPrimaryAnnotations(D dao, PhenotypeFmsDTO dto, String primaryAnnotationSubjectIdentifier, String refString) {
+		// Fast path: compute uniqueId and look up in pre-loaded map
+		if (existingUniqueIds != null) {
+			String uniqueId = AnnotationUniqueIdHelper.getPhenotypeAnnotationUniqueId(dto, primaryAnnotationSubjectIdentifier, refString);
+			Long existingId = existingUniqueIds.get(uniqueId);
+			if (existingId != null) {
+				E annotation = dao.find(existingId);
+				if (annotation != null) {
+					return List.of(annotation);
+				}
+			}
+			return null;
+		}
+
+		// Fallback: original findByParams path
 		HashMap<String, Object> params = new HashMap<>();
-		params.put("phenotypeAnnotationSubject.primaryExternalId", primaryAnnotationSubjectprimaryExternalId);
+		params.put("phenotypeAnnotationSubject.primaryExternalId", primaryAnnotationSubjectIdentifier);
 		if (StringUtils.isNotBlank(dto.getPhenotypeStatement())) {
 			params.put("phenotypeAnnotationObject", dto.getPhenotypeStatement());
 		} else {
@@ -157,12 +189,12 @@ public class PhenotypeAnnotationFmsDTOValidator {
 		} else {
 			return null;
 		}
-		
+
 		SearchResponse<E> searchResponse = dao.findByParams(params);
 		if (searchResponse == null || CollectionUtils.isEmpty(searchResponse.getResults())) {
 			return null;
 		}
-		
+
 		String secondaryPhenotypeTermIdString = "";
 		if (CollectionUtils.isNotEmpty(dto.getPhenotypeTermIdentifiers())) {
 			List<String> validPhenotypeTermCuries = new ArrayList<>();
@@ -178,7 +210,7 @@ public class PhenotypeAnnotationFmsDTOValidator {
 				secondaryPhenotypeTermIdString = getPhenotypeTermIdString(validPhenotypeTermCuries);
 			}
 		}
-		
+
 		List<E> primaryAnnotations = new ArrayList<>();
 		for (E possiblePrimaryAnnotation : searchResponse.getResults()) {
 			String primaryPhenotypeTermIdString = "";
@@ -192,7 +224,7 @@ public class PhenotypeAnnotationFmsDTOValidator {
 		if (CollectionUtils.isEmpty(primaryAnnotations)) {
 			return null;
 		}
-		
+
 		return primaryAnnotations;
 	}
 	

--- a/src/main/resources/db/migration/v0.46.0.3__agr_curation_api.sql
+++ b/src/main/resources/db/migration/v0.46.0.3__agr_curation_api.sql
@@ -1,0 +1,2 @@
+CREATE INDEX AgmAlleleAssociation_subject_relation_object_index
+	ON agmalleleassociation (agmassociationsubject_id, relation_id, agmalleleassociationobject_id);


### PR DESCRIPTION
## Summary

### AgmAlleleAssociation bulk load optimization
- Add request-scoped caches for AGM and Allele ID/entity lookups to eliminate redundant DB queries
- Pre-load all existing association state via native SQL, skip unchanged records entirely
- Replace generic findByParams with direct JPQL query for association existence check
- Add composite index on (subject_id, relation_id, object_id)

### PhenotypeAnnotation bulk load optimization
- Pre-load all existing annotation uniqueIds via native SQL, skip unchanged primary annotations
- Cache genomic entity identifier resolution to avoid repeated DB lookups
- Optimize secondary annotation pass: pre-load inferred gene/allele IDs, skip persist when already set
- Replace findByParams with uniqueId-based HashMap lookup for secondary annotation processing

### Gene Interaction bulk load optimization (Molecular + Genetic)
- Pre-load interactionId -> (id, uniqueIdHash) maps via native SQL, skip unchanged records
- Fix OOM: replace findAllIds() (loads full entities) with getAllIds() (native SQL, IDs only)
- Cache non-MOD gene lookups (UniProtKB, ENSEMBL, RefSeq) in shared geneCache

### General fixes
- Remove eager toString() calls in BaseSQLDAO that triggered LazyInitializationException

All pre-loaded maps are request-scoped and only populated during bulk loads -- single-record API operations are unaffected.

## Measured Results

| Load | Records | Before | After | Speedup |
|---|---|---|---|---|
| AgmAllele FB | 1,110,262 | 4.5h (68 r/s) | 13min (1,410 r/s) | 21x |
| AgmAllele WB | 750,186 | ~3h+ (68 r/s) | 69s (10,813 r/s) | 159x |
| Phenotype FB | 302,112 | 9:52 (8 r/s) | 28min (177 r/s) | 21x |
| Phenotype HUMAN | 447,428 | 6:29 (19 r/s) | 23min (317 r/s) | 17x |
| Molecular Interaction | 1,989,327 | 18h (30 r/s) | 50min (657 r/s) | 21x |
| Genetic Interaction | 637,172 | 6:18 (28 r/s) | 67min (158 r/s) | 5.6x |

## Test plan

- [x] Tested AgmAllele FB (1.1M) -- 13 minutes
- [x] Tested AgmAllele WB (750K) -- 69 seconds
- [x] Tested Phenotype FB (302K) -- 28 minutes
- [x] Tested Phenotype HUMAN (447K) -- 23 minutes
- [x] Tested Molecular Interaction (2M) -- 50 minutes
- [x] Tested Genetic Interaction (637K) -- 67 minutes
- [ ] Verify single-record API create/update still works
- [ ] Verify cleanup phase correctly removes obsolete records