### PR TITLE
SCRUM-5456: Fix GEA table filters and add dashboard link

### DIFF
--- a/src/main/cliapp/src/constants/Classes.js
+++ b/src/main/cliapp/src/constants/Classes.js
@@ -125,6 +125,7 @@ export const CLASSES = Object.freeze({
 	},
 	GeneExpressionAnnotation: {
 		name: 'Gene Expression Annotations',
+		link: '/#/geneExpressionAnnotations',
 		type: 'entity',
 		hasTable: true,
 		isIndexed: true,

--- a/src/main/cliapp/src/constants/FilterFields.js
+++ b/src/main/cliapp/src/constants/FilterFields.js
@@ -768,11 +768,13 @@ export const FIELD_SETS = Object.freeze({
 			'expressionAnnotationSubject.geneSymbol.displayText',
 			'expressionAnnotationSubject.geneSymbol.formatText',
 			'expressionAnnotationSubject.curie',
+			'expressionAnnotationSubject.primaryExternalId',
+			'expressionAnnotationSubject.modInternalId',
 		],
 	},
 	geaAssayUsedFieldSet: {
 		filterName: 'geaAssayUsedFilter',
-		fields: ['expressionAssayUsed.name'],
+		fields: ['expressionAssayUsed.name', 'expressionAssayUsed.curie'],
 	},
 	geaRelationFieldSet: {
 		filterName: 'geaRelationFilter',

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GeneExpressionAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GeneExpressionAnnotation.java
@@ -55,13 +55,13 @@ import lombok.EqualsAndHashCode;
 
 public class GeneExpressionAnnotation extends ExpressionAnnotation {
 
-	@IndexedEmbedded(includePaths = {"geneSymbol.displayText", "geneSymbol.formatText", "geneSymbol.displayText_keyword", "geneSymbol.formatText_keyword", "curie", "curie_keyword", "taxon.curie", "taxon.name", "taxon.curie_keyword", "taxon.name_keyword"})
+	@IndexedEmbedded(includePaths = {"geneSymbol.displayText", "geneSymbol.formatText", "geneSymbol.displayText_keyword", "geneSymbol.formatText_keyword", "curie", "curie_keyword", "primaryExternalId", "primaryExternalId_keyword", "modInternalId", "modInternalId_keyword", "taxon.curie", "taxon.name", "taxon.curie_keyword", "taxon.name_keyword"})
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
 	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class})
 	private Gene expressionAnnotationSubject;
 
-	@IndexedEmbedded(includePaths = {"name", "name_keyword"})
+	@IndexedEmbedded(includePaths = {"name", "name_keyword", "curie", "curie_keyword"})
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
 	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class})
@@ -81,6 +81,8 @@ public class GeneExpressionAnnotation extends ExpressionAnnotation {
 		"uniqueId", "uniqueId_keyword",
 		"primaryExternalId", "primaryExternalId_keyword",
 		"modInternalId", "modInternalId_keyword",
+		"internal", "internal_keyword",
+		"obsolete", "obsolete_keyword",
 		"singleReference.curie", "singleReference.primaryCrossReferenceCurie",
 		"singleReference.crossReferences.referencedCurie",
 		"singleReference.curie_keyword", "singleReference.primaryCrossReferenceCurie_keyword",


### PR DESCRIPTION
## Summary
- Fix **Experiment Internal** and **Experiment Obsolete** boolean dropdown filters (were returning 0 rows for "false") by adding `internal`/`obsolete` to the `expressionExperiment` `@IndexedEmbedded` includePaths and wiring up filter configs
- Enable **Subject** filter to search by gene ID (`primaryExternalId`, `modInternalId`) in addition to symbol/curie
- Enable **Assay Used** filter to search by MMO term ID (`curie`) in addition to name
- Add missing dashboard hyperlink for the Gene Expression Annotations table

## Test plan
- [ ] Verify Experiment Internal filter returns results when set to "false"
- [ ] Verify Experiment Obsolete filter returns results when set to "false"
- [ ] Verify Subject filter returns results when searching by gene ID (e.g. HGNC:1234)
- [ ] Verify Assay Used filter returns results when searching by MMO term ID (e.g. MMO:0000658)
- [ ] Verify Gene Expression Annotations link on dashboard navigates to the table
- [ ] Note: Hibernate Search reindex required for new indexed paths to take effect on existing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)