### PR TITLE
SCRUM-5894: Add Where/When Expressed pop-up dialogs

### DIFF
--- a/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/GeneExpressionAnnotationsTable.js
+++ b/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/GeneExpressionAnnotationsTable.js
@@ -6,6 +6,7 @@ import { GenomicEntityTemplate } from '../../components/Templates/genomicEntity/
 import { BooleanTemplate } from '../../components/Templates/BooleanTemplate';
 import { OntologyTermTemplate } from '../../components/Templates/OntologyTermTemplate';
 import { StringTemplate } from '../../components/Templates/StringTemplate';
+import { TextDialogTemplate } from '../../components/Templates/dialog/TextDialogTemplate';
 import { SingleReferenceTemplate } from '../../components/Templates/reference/SingleReferenceTemplate';
 import { CrossReferencesTemplate } from '../../components/Templates/CrossReferencesTemplate';
 import { getDefaultTableState } from '../../service/TableStateService';
@@ -13,6 +14,8 @@ import { FILTER_CONFIGS } from '../../constants/FilterFields';
 import { useGetTableData } from '../../service/useGetTableData';
 import { useGetUserSettings } from '../../service/useGetUserSettings';
 import { SearchService } from '../../service/SearchService';
+import { WhereExpressedDialog } from './WhereExpressedDialog';
+import { WhenExpressedDialog } from './WhenExpressedDialog';
 
 export const GeneExpressionAnnotationsTable = () => {
 	const [isInEditMode, setIsInEditMode] = useState(false);
@@ -30,6 +33,17 @@ export const GeneExpressionAnnotationsTable = () => {
 
 	const toast_topleft = useRef(null);
 	const toast_topright = useRef(null);
+
+	const [whereExpressedData, setWhereExpressedData] = useState({ data: null, dialog: false });
+	const [whenExpressedData, setWhenExpressedData] = useState({ data: null, dialog: false });
+
+	const handleWhereExpressedOpen = (anatomicalSite) => {
+		setWhereExpressedData({ data: anatomicalSite, dialog: true });
+	};
+
+	const handleWhenExpressedOpen = (temporalContext) => {
+		setWhenExpressedData({ data: temporalContext, dialog: true });
+	};
 
 	const sortMapping = {};
 
@@ -153,14 +167,26 @@ export const GeneExpressionAnnotationsTable = () => {
 			{
 				field: 'whereExpressedStatement',
 				header: 'Where Expressed',
-				body: (rowData) => <StringTemplate string={rowData.whereExpressedStatement} />,
+				body: (rowData) => (
+					<TextDialogTemplate
+						entity={rowData.expressionPattern?.whereExpressed}
+						handleOpen={handleWhereExpressedOpen}
+						text={rowData.whereExpressedStatement}
+					/>
+				),
 				sortable: true,
 				filterConfig: FILTER_CONFIGS.geaWhereExpressedFilterConfig,
 			},
 			{
 				field: 'whenExpressedStageName',
 				header: 'When Expressed',
-				body: (rowData) => <StringTemplate string={rowData.whenExpressedStageName} />,
+				body: (rowData) => (
+					<TextDialogTemplate
+						entity={rowData.expressionPattern?.whenExpressed}
+						handleOpen={handleWhenExpressedOpen}
+						text={rowData.whenExpressedStageName}
+					/>
+				),
 				sortable: true,
 				filterConfig: FILTER_CONFIGS.geaWhenExpressedFilterConfig,
 			},
@@ -320,6 +346,8 @@ export const GeneExpressionAnnotationsTable = () => {
 					defaultFilters={defaultFilters}
 				/>
 			</div>
+			<WhereExpressedDialog whereExpressedData={whereExpressedData} setWhereExpressedData={setWhereExpressedData} />
+			<WhenExpressedDialog whenExpressedData={whenExpressedData} setWhenExpressedData={setWhenExpressedData} />
 		</>
 	);
 };

--- a/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/WhenExpressedDialog.js
+++ b/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/WhenExpressedDialog.js
@@ -46,35 +46,23 @@ export const WhenExpressedDialog = ({ whenExpressedData, setWhenExpressedData })
 				<Column
 					field="developmentalStageStart.name"
 					header="Developmental Stage Start"
-					body={(rowData) => (
-						<EllipsisTableCell>{termTemplate(rowData.developmentalStageStart)}</EllipsisTableCell>
-					)}
+					body={(rowData) => <EllipsisTableCell>{termTemplate(rowData.developmentalStageStart)}</EllipsisTableCell>}
 				/>
 				<Column
 					field="developmentalStageStop.name"
 					header="Developmental Stage Stop"
-					body={(rowData) => (
-						<EllipsisTableCell>{termTemplate(rowData.developmentalStageStop)}</EllipsisTableCell>
-					)}
+					body={(rowData) => <EllipsisTableCell>{termTemplate(rowData.developmentalStageStop)}</EllipsisTableCell>}
 				/>
-				<Column
-					field="age"
-					header="Age"
-					body={(rowData) => <EllipsisTableCell>{rowData.age}</EllipsisTableCell>}
-				/>
+				<Column field="age" header="Age" body={(rowData) => <EllipsisTableCell>{rowData.age}</EllipsisTableCell>} />
 				<Column
 					field="temporalQualifiers"
 					header="Temporal Qualifiers"
-					body={(rowData) => (
-						<EllipsisTableCell>{listTemplate(rowData.temporalQualifiers)}</EllipsisTableCell>
-					)}
+					body={(rowData) => <EllipsisTableCell>{listTemplate(rowData.temporalQualifiers)}</EllipsisTableCell>}
 				/>
 				<Column
 					field="stageUberonSlimTerms"
 					header="Stage Uberon Terms"
-					body={(rowData) => (
-						<EllipsisTableCell>{listTemplate(rowData.stageUberonSlimTerms)}</EllipsisTableCell>
-					)}
+					body={(rowData) => <EllipsisTableCell>{listTemplate(rowData.stageUberonSlimTerms)}</EllipsisTableCell>}
 				/>
 			</DataTable>
 		</Dialog>

--- a/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/WhenExpressedDialog.js
+++ b/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/WhenExpressedDialog.js
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { Dialog } from 'primereact/dialog';
+import { DataTable } from 'primereact/datatable';
+import { Column } from 'primereact/column';
+import { EllipsisTableCell } from '../../components/EllipsisTableCell';
+
+const termTemplate = (term) => {
+	if (!term) return null;
+	if (!term.name) return term.curie || '';
+	if (term.curie) return `${term.name} (${term.curie})`;
+	if (term.definition) return `${term.name} (${term.definition})`;
+	return term.name;
+};
+
+const listTemplate = (terms) => {
+	if (!terms || terms.length === 0) return null;
+	return terms.map((t) => termTemplate(t)).join(', ');
+};
+
+export const WhenExpressedDialog = ({ whenExpressedData, setWhenExpressedData }) => {
+	const { data, dialog } = whenExpressedData;
+	const [localData, setLocalData] = useState(null);
+
+	const showDialogHandler = () => {
+		if (data) {
+			const _localData = global.structuredClone(data);
+			_localData.dataKey = 0;
+			setLocalData([_localData]);
+		} else {
+			setLocalData([]);
+		}
+	};
+
+	const hideDialog = () => {
+		setWhenExpressedData((prev) => ({
+			...prev,
+			dialog: false,
+		}));
+		setLocalData(null);
+	};
+
+	return (
+		<Dialog visible={dialog} className="w-10" modal onHide={hideDialog} closable onShow={showDialogHandler}>
+			<h3>When Expressed [Temporal Context]</h3>
+			<DataTable value={localData} dataKey="dataKey" showGridlines>
+				<Column
+					field="developmentalStageStart.name"
+					header="Developmental Stage Start"
+					body={(rowData) => (
+						<EllipsisTableCell>{termTemplate(rowData.developmentalStageStart)}</EllipsisTableCell>
+					)}
+				/>
+				<Column
+					field="developmentalStageStop.name"
+					header="Developmental Stage Stop"
+					body={(rowData) => (
+						<EllipsisTableCell>{termTemplate(rowData.developmentalStageStop)}</EllipsisTableCell>
+					)}
+				/>
+				<Column
+					field="age"
+					header="Age"
+					body={(rowData) => <EllipsisTableCell>{rowData.age}</EllipsisTableCell>}
+				/>
+				<Column
+					field="temporalQualifiers"
+					header="Temporal Qualifiers"
+					body={(rowData) => (
+						<EllipsisTableCell>{listTemplate(rowData.temporalQualifiers)}</EllipsisTableCell>
+					)}
+				/>
+				<Column
+					field="stageUberonSlimTerms"
+					header="Stage Uberon Terms"
+					body={(rowData) => (
+						<EllipsisTableCell>{listTemplate(rowData.stageUberonSlimTerms)}</EllipsisTableCell>
+					)}
+				/>
+			</DataTable>
+		</Dialog>
+	);
+};

--- a/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/WhereExpressedDialog.js
+++ b/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/WhereExpressedDialog.js
@@ -1,0 +1,134 @@
+import { useState } from 'react';
+import { Dialog } from 'primereact/dialog';
+import { DataTable } from 'primereact/datatable';
+import { Column } from 'primereact/column';
+import { EllipsisTableCell } from '../../components/EllipsisTableCell';
+
+const termTemplate = (term) => {
+	if (!term) return null;
+	if (!term.name) return term.curie || '';
+	if (!term.curie) return term.name;
+	return `${term.name} (${term.curie})`;
+};
+
+const listTemplate = (terms) => {
+	if (!terms || terms.length === 0) return null;
+	return terms.map((t) => termTemplate(t)).join(', ');
+};
+
+export const WhereExpressedDialog = ({ whereExpressedData, setWhereExpressedData }) => {
+	const { data, dialog } = whereExpressedData;
+	const [localData, setLocalData] = useState(null);
+
+	const showDialogHandler = () => {
+		if (data) {
+			const _localData = global.structuredClone(data);
+			_localData.dataKey = 0;
+			setLocalData([_localData]);
+		} else {
+			setLocalData([]);
+		}
+	};
+
+	const hideDialog = () => {
+		setWhereExpressedData((prev) => ({
+			...prev,
+			dialog: false,
+		}));
+		setLocalData(null);
+	};
+
+	return (
+		<Dialog visible={dialog} className="w-10" modal onHide={hideDialog} closable onShow={showDialogHandler}>
+			<h3>Where Expressed [Anatomical Site]</h3>
+			<DataTable value={localData} dataKey="dataKey" showGridlines>
+				<Column
+					field="anatomicalStructure.name"
+					header="Anatomical Structure"
+					body={(rowData) => (
+						<EllipsisTableCell>{termTemplate(rowData.anatomicalStructure)}</EllipsisTableCell>
+					)}
+				/>
+				<Column
+					field="anatomicalStructureQualifiers"
+					header="Structure Qualifiers"
+					body={(rowData) => (
+						<EllipsisTableCell>{listTemplate(rowData.anatomicalStructureQualifiers)}</EllipsisTableCell>
+					)}
+				/>
+				<Column
+					field="anatomicalStructureUberonTerms"
+					header="Structure Uberon Terms"
+					body={(rowData) => (
+						<EllipsisTableCell>{listTemplate(rowData.anatomicalStructureUberonTerms)}</EllipsisTableCell>
+					)}
+				/>
+				<Column
+					field="anatomicalSubstructure.name"
+					header="Anatomical Substructure"
+					body={(rowData) => (
+						<EllipsisTableCell>{termTemplate(rowData.anatomicalSubstructure)}</EllipsisTableCell>
+					)}
+				/>
+				<Column
+					field="anatomicalSubstructureQualifiers"
+					header="Substructure Qualifiers"
+					body={(rowData) => (
+						<EllipsisTableCell>{listTemplate(rowData.anatomicalSubstructureQualifiers)}</EllipsisTableCell>
+					)}
+				/>
+				<Column
+					field="anatomicalSubstructureUberonTerms"
+					header="Substructure Uberon Terms"
+					body={(rowData) => (
+						<EllipsisTableCell>
+							{listTemplate(rowData.anatomicalSubstructureUberonTerms)}
+						</EllipsisTableCell>
+					)}
+				/>
+				<Column
+					field="cellularComponentTerm.name"
+					header="Cellular Component"
+					body={(rowData) => (
+						<EllipsisTableCell>{termTemplate(rowData.cellularComponentTerm)}</EllipsisTableCell>
+					)}
+				/>
+				<Column
+					field="cellularComponentQualifiers"
+					header="Cellular Component Qualifiers"
+					body={(rowData) => (
+						<EllipsisTableCell>{listTemplate(rowData.cellularComponentQualifiers)}</EllipsisTableCell>
+					)}
+				/>
+				<Column
+					field="cellularComponentRibbonTerms"
+					header="CC Ribbon Terms"
+					body={(rowData) => (
+						<EllipsisTableCell>{listTemplate(rowData.cellularComponentRibbonTerms)}</EllipsisTableCell>
+					)}
+				/>
+				<Column
+					field="cellularComponentOther"
+					header="CC Other"
+					body={(rowData) => (
+						<EllipsisTableCell>{rowData.cellularComponentOther != null ? String(rowData.cellularComponentOther) : ''}</EllipsisTableCell>
+					)}
+				/>
+				<Column
+					field="anatomicalStructureUberonTermOther"
+					header="Structure Uberon Other"
+					body={(rowData) => (
+						<EllipsisTableCell>{rowData.anatomicalStructureUberonTermOther != null ? String(rowData.anatomicalStructureUberonTermOther) : ''}</EllipsisTableCell>
+					)}
+				/>
+				<Column
+					field="anatomicalSubStructureUberonTermOther"
+					header="Substructure Uberon Other"
+					body={(rowData) => (
+						<EllipsisTableCell>{rowData.anatomicalSubStructureUberonTermOther != null ? String(rowData.anatomicalSubStructureUberonTermOther) : ''}</EllipsisTableCell>
+					)}
+				/>
+			</DataTable>
+		</Dialog>
+	);
+};

--- a/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/WhereExpressedDialog.js
+++ b/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/WhereExpressedDialog.js
@@ -45,9 +45,7 @@ export const WhereExpressedDialog = ({ whereExpressedData, setWhereExpressedData
 				<Column
 					field="anatomicalStructure.name"
 					header="Anatomical Structure"
-					body={(rowData) => (
-						<EllipsisTableCell>{termTemplate(rowData.anatomicalStructure)}</EllipsisTableCell>
-					)}
+					body={(rowData) => <EllipsisTableCell>{termTemplate(rowData.anatomicalStructure)}</EllipsisTableCell>}
 				/>
 				<Column
 					field="anatomicalStructureQualifiers"
@@ -66,9 +64,7 @@ export const WhereExpressedDialog = ({ whereExpressedData, setWhereExpressedData
 				<Column
 					field="anatomicalSubstructure.name"
 					header="Anatomical Substructure"
-					body={(rowData) => (
-						<EllipsisTableCell>{termTemplate(rowData.anatomicalSubstructure)}</EllipsisTableCell>
-					)}
+					body={(rowData) => <EllipsisTableCell>{termTemplate(rowData.anatomicalSubstructure)}</EllipsisTableCell>}
 				/>
 				<Column
 					field="anatomicalSubstructureQualifiers"
@@ -81,24 +77,18 @@ export const WhereExpressedDialog = ({ whereExpressedData, setWhereExpressedData
 					field="anatomicalSubstructureUberonTerms"
 					header="Substructure Uberon Terms"
 					body={(rowData) => (
-						<EllipsisTableCell>
-							{listTemplate(rowData.anatomicalSubstructureUberonTerms)}
-						</EllipsisTableCell>
+						<EllipsisTableCell>{listTemplate(rowData.anatomicalSubstructureUberonTerms)}</EllipsisTableCell>
 					)}
 				/>
 				<Column
 					field="cellularComponentTerm.name"
 					header="Cellular Component"
-					body={(rowData) => (
-						<EllipsisTableCell>{termTemplate(rowData.cellularComponentTerm)}</EllipsisTableCell>
-					)}
+					body={(rowData) => <EllipsisTableCell>{termTemplate(rowData.cellularComponentTerm)}</EllipsisTableCell>}
 				/>
 				<Column
 					field="cellularComponentQualifiers"
 					header="Cellular Component Qualifiers"
-					body={(rowData) => (
-						<EllipsisTableCell>{listTemplate(rowData.cellularComponentQualifiers)}</EllipsisTableCell>
-					)}
+					body={(rowData) => <EllipsisTableCell>{listTemplate(rowData.cellularComponentQualifiers)}</EllipsisTableCell>}
 				/>
 				<Column
 					field="cellularComponentRibbonTerms"
@@ -111,21 +101,31 @@ export const WhereExpressedDialog = ({ whereExpressedData, setWhereExpressedData
 					field="cellularComponentOther"
 					header="CC Other"
 					body={(rowData) => (
-						<EllipsisTableCell>{rowData.cellularComponentOther != null ? String(rowData.cellularComponentOther) : ''}</EllipsisTableCell>
+						<EllipsisTableCell>
+							{rowData.cellularComponentOther != null ? String(rowData.cellularComponentOther) : ''}
+						</EllipsisTableCell>
 					)}
 				/>
 				<Column
 					field="anatomicalStructureUberonTermOther"
 					header="Structure Uberon Other"
 					body={(rowData) => (
-						<EllipsisTableCell>{rowData.anatomicalStructureUberonTermOther != null ? String(rowData.anatomicalStructureUberonTermOther) : ''}</EllipsisTableCell>
+						<EllipsisTableCell>
+							{rowData.anatomicalStructureUberonTermOther != null
+								? String(rowData.anatomicalStructureUberonTermOther)
+								: ''}
+						</EllipsisTableCell>
 					)}
 				/>
 				<Column
 					field="anatomicalSubStructureUberonTermOther"
 					header="Substructure Uberon Other"
 					body={(rowData) => (
-						<EllipsisTableCell>{rowData.anatomicalSubStructureUberonTermOther != null ? String(rowData.anatomicalSubStructureUberonTermOther) : ''}</EllipsisTableCell>
+						<EllipsisTableCell>
+							{rowData.anatomicalSubStructureUberonTermOther != null
+								? String(rowData.anatomicalSubStructureUberonTermOther)
+								: ''}
+						</EllipsisTableCell>
 					)}
 				/>
 			</DataTable>


### PR DESCRIPTION
## Summary
- Make "Where Expressed" and "When Expressed" columns clickable (blue, underlined) to open read-only pop-up dialogs
- **WhereExpressedDialog**: displays all AnatomicalSite fields — anatomical structure/substructure, qualifiers, uberon terms, cellular component, CC ribbon terms, and boolean "other" flags (12 columns)
- **WhenExpressedDialog**: displays all TemporalContext fields — developmental stage start/stop, age, temporal qualifiers, stage uberon slim terms with definition in parentheses when available (5 columns)
- No backend changes needed — `expressionPattern.whereExpressed` and `expressionPattern.whenExpressed` already returned via `CurationView.FieldsOnly`

## Test plan
- [ ] Load Gene Expression Annotations table at `/#/geneExpressionAnnotations`
- [ ] Verify "Where Expressed" text is blue and underlined
- [ ] Click "Where Expressed" — popup shows anatomical site data in a table with all 12 columns
- [ ] Verify "When Expressed" text is blue and underlined
- [ ] Click "When Expressed" — popup shows temporal context data in a table with all 5 columns
- [ ] Verify dialogs close via X button or clicking outside
- [ ] Verify rows with no expressionPattern data still render without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)