### PR TITLE
SCRUM-5858: Produce warnings instead of errors for unrecognized refer…

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AffectedGenomicModelDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AffectedGenomicModelDTOValidator.java
@@ -82,6 +82,7 @@ public class AffectedGenomicModelDTOValidator extends GenomicEntityDTOValidator<
 		VocabularyTerm subtype = validateRequiredTermInVocabulary("subtype_name", dto.getSubtypeName(), VocabularyConstants.AGM_SUBTYPE_VOCABULARY);
 		agm.setSubtype(subtype);
 
+		response.convertWarningMessagesToMap();
 		response.convertErrorMessagesToMap();
 
 		if (response.hasErrors()) {
@@ -104,6 +105,10 @@ public class AffectedGenomicModelDTOValidator extends GenomicEntityDTOValidator<
 			response.addErrorMessage(field, nameResponse.errorMessagesString());
 			response.addErrorMessages(field, nameResponse.getErrorMessages());
 			return null;
+		}
+
+		if (nameResponse.hasWarnings()) {
+			response.addWarningMessages(nameResponse.getWarningMessages());
 		}
 
 		AgmFullNameSlotAnnotation fullName = nameResponse.getEntity();
@@ -137,6 +142,9 @@ public class AffectedGenomicModelDTOValidator extends GenomicEntityDTOValidator<
 					syn.setSingleAgm(agm);
 					validatedSynonyms.add(syn);
 				}
+				if (synResponse.hasWarnings()) {
+					response.addWarningMessages(field, ix, synResponse.getWarningMessages());
+				}
 			}
 		}
 
@@ -144,6 +152,8 @@ public class AffectedGenomicModelDTOValidator extends GenomicEntityDTOValidator<
 			response.convertMapToErrorMessages(field);
 			return null;
 		}
+
+		response.convertMapToWarningMessages(field);
 
 		if (CollectionUtils.isEmpty(validatedSynonyms)) {
 			return null;
@@ -177,6 +187,9 @@ public class AffectedGenomicModelDTOValidator extends GenomicEntityDTOValidator<
 					sid.setSingleAgm(model);
 					validatedSecondaryIds.add(sid);
 				}
+				if (sidResponse.hasWarnings()) {
+					response.addWarningMessages(field, ix, sidResponse.getWarningMessages());
+				}
 			}
 		}
 
@@ -184,6 +197,8 @@ public class AffectedGenomicModelDTOValidator extends GenomicEntityDTOValidator<
 			response.convertMapToErrorMessages(field);
 			return null;
 		}
+
+		response.convertMapToWarningMessages(field);
 
 		if (CollectionUtils.isEmpty(validatedSecondaryIds)) {
 			return null;

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AffectedGenomicModelDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AffectedGenomicModelDTOValidator.java
@@ -108,7 +108,8 @@ public class AffectedGenomicModelDTOValidator extends GenomicEntityDTOValidator<
 		}
 
 		if (nameResponse.hasWarnings()) {
-			response.addWarningMessages(nameResponse.getWarningMessages());
+			response.addWarningMessage(field, nameResponse.warningMessagesString());
+			response.addWarningMessages(field, nameResponse.getWarningMessages());
 		}
 
 		AgmFullNameSlotAnnotation fullName = nameResponse.getEntity();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AlleleDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AlleleDTOValidator.java
@@ -96,7 +96,7 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 
 		allele.setIsExtinct(dto.getIsExtinct());
 
-		List<Reference> refs = validateReferences("reference_curies", dto.getReferenceCuries(), false);
+		List<Reference> refs = validateOptionalEntities("reference_curies", dto.getReferenceCuries(), referenceService::retrieveFromDbOrLiteratureService);
 		allele.setReferences(refs);
 
 		List<AlleleMutationTypeSlotAnnotation> mutationTypes = validateAlleleMutationTypes(allele, dto);
@@ -183,7 +183,7 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 		if (response.hasErrors()) {
 			throw new ObjectValidationException(dto, response.errorMessagesString());
 		}
-		
+
 		try {
 			response.setEntity(alleleDAO.persist(allele));
 			return response;
@@ -219,6 +219,9 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 					mt.setSingleAllele(allele);
 					validatedMutationTypes.add(mt);
 				}
+				if (mtResponse.hasWarnings()) {
+					response.addWarningMessages(field, ix, mtResponse.getWarningMessages());
+				}
 			}
 		}
 
@@ -226,6 +229,8 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			response.convertMapToErrorMessages(field);
 			return null;
 		}
+
+		response.convertMapToWarningMessages(field);
 
 		if (CollectionUtils.isEmpty(validatedMutationTypes)) {
 			return null;
@@ -259,6 +264,9 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 					im.setSingleAllele(allele);
 					validatedInheritanceModes.add(im);
 				}
+				if (imResponse.hasWarnings()) {
+					response.addWarningMessages(field, ix, imResponse.getWarningMessages());
+				}
 			}
 		}
 
@@ -266,6 +274,8 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			response.convertMapToErrorMessages(field);
 			return null;
 		}
+
+		response.convertMapToWarningMessages(field);
 
 		if (CollectionUtils.isEmpty(validatedInheritanceModes)) {
 			return null;
@@ -287,6 +297,9 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			response.addErrorMessages(field, agtsResponse.getErrorMessages());
 			return null;
 		}
+		if (agtsResponse.hasWarnings()) {
+			response.addWarningMessages(agtsResponse.getWarningMessages());
+		}
 
 		AlleleGermlineTransmissionStatusSlotAnnotation agts = agtsResponse.getEntity();
 		agts.setSingleAllele(allele);
@@ -306,6 +319,9 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			response.addErrorMessage(field, adsResponse.errorMessagesString());
 			response.addErrorMessages(field, adsResponse.getErrorMessages());
 			return null;
+		}
+		if (adsResponse.hasWarnings()) {
+			response.addWarningMessages(adsResponse.getWarningMessages());
 		}
 
 		AlleleDatabaseStatusSlotAnnotation ads = adsResponse.getEntity();
@@ -339,6 +355,9 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 					ne.setSingleAllele(allele);
 					validatedNomenclatureEvents.add(ne);
 				}
+				if (neResponse.hasWarnings()) {
+					response.addWarningMessages(field, ix, neResponse.getWarningMessages());
+				}
 			}
 		}
 
@@ -346,6 +365,8 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			response.convertMapToErrorMessages(field);
 			return null;
 		}
+
+		response.convertMapToWarningMessages(field);
 
 		if (CollectionUtils.isEmpty(validatedNomenclatureEvents)) {
 			return null;
@@ -368,6 +389,9 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			response.addErrorMessages(field, symbolResponse.getErrorMessages());
 			return null;
 		}
+		if (symbolResponse.hasWarnings()) {
+			response.addWarningMessages(symbolResponse.getWarningMessages());
+		}
 
 		AlleleSymbolSlotAnnotation symbol = symbolResponse.getEntity();
 		symbol.setSingleAllele(allele);
@@ -387,6 +411,9 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			response.addErrorMessage(field, nameResponse.errorMessagesString());
 			response.addErrorMessages(field, nameResponse.getErrorMessages());
 			return null;
+		}
+		if (nameResponse.hasWarnings()) {
+			response.addWarningMessages(nameResponse.getWarningMessages());
 		}
 
 		AlleleFullNameSlotAnnotation fullName = nameResponse.getEntity();
@@ -420,6 +447,9 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 					syn.setSingleAllele(allele);
 					validatedSynonyms.add(syn);
 				}
+				if (synResponse.hasWarnings()) {
+					response.addWarningMessages(field, ix, synResponse.getWarningMessages());
+				}
 			}
 		}
 
@@ -427,6 +457,8 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			response.convertMapToErrorMessages(field);
 			return null;
 		}
+
+		response.convertMapToWarningMessages(field);
 
 		if (CollectionUtils.isEmpty(validatedSynonyms)) {
 			return null;
@@ -460,6 +492,9 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 					sid.setSingleAllele(allele);
 					validatedSecondaryIds.add(sid);
 				}
+				if (sidResponse.hasWarnings()) {
+					response.addWarningMessages(field, ix, sidResponse.getWarningMessages());
+				}
 			}
 		}
 
@@ -467,6 +502,8 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			response.convertMapToErrorMessages(field);
 			return null;
 		}
+
+		response.convertMapToWarningMessages(field);
 
 		if (CollectionUtils.isEmpty(validatedSecondaryIds)) {
 			return null;
@@ -500,6 +537,9 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 					fi.setSingleAllele(allele);
 					validatedFunctionalImpacts.add(fi);
 				}
+				if (fiResponse.hasWarnings()) {
+					response.addWarningMessages(field, ix, fiResponse.getWarningMessages());
+				}
 			}
 		}
 
@@ -507,6 +547,8 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			response.convertMapToErrorMessages(field);
 			return null;
 		}
+
+		response.convertMapToWarningMessages(field);
 
 		if (CollectionUtils.isEmpty(validatedFunctionalImpacts)) {
 			return null;

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AlleleDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AlleleDTOValidator.java
@@ -301,7 +301,8 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			return null;
 		}
 		if (agtsResponse.hasWarnings()) {
-			response.addWarningMessages(agtsResponse.getWarningMessages());
+			response.addWarningMessage(field, agtsResponse.warningMessagesString());
+			response.addWarningMessages(field, agtsResponse.getWarningMessages());
 		}
 
 		AlleleGermlineTransmissionStatusSlotAnnotation agts = agtsResponse.getEntity();
@@ -324,7 +325,8 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			return null;
 		}
 		if (adsResponse.hasWarnings()) {
-			response.addWarningMessages(adsResponse.getWarningMessages());
+			response.addWarningMessage(field, adsResponse.warningMessagesString());
+			response.addWarningMessages(field, adsResponse.getWarningMessages());
 		}
 
 		AlleleDatabaseStatusSlotAnnotation ads = adsResponse.getEntity();
@@ -393,7 +395,8 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			return null;
 		}
 		if (symbolResponse.hasWarnings()) {
-			response.addWarningMessages(symbolResponse.getWarningMessages());
+			response.addWarningMessage(field, symbolResponse.warningMessagesString());
+			response.addWarningMessages(field, symbolResponse.getWarningMessages());
 		}
 
 		AlleleSymbolSlotAnnotation symbol = symbolResponse.getEntity();
@@ -416,7 +419,8 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			return null;
 		}
 		if (nameResponse.hasWarnings()) {
-			response.addWarningMessages(nameResponse.getWarningMessages());
+			response.addWarningMessage(field, nameResponse.warningMessagesString());
+			response.addWarningMessages(field, nameResponse.getWarningMessages());
 		}
 
 		AlleleFullNameSlotAnnotation fullName = nameResponse.getEntity();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AlleleDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AlleleDTOValidator.java
@@ -32,6 +32,7 @@ import org.alliancegenome.curation_api.model.ingest.dto.slotAnnotions.AlleleNome
 import org.alliancegenome.curation_api.model.ingest.dto.slotAnnotions.NameSlotAnnotationDTO;
 import org.alliancegenome.curation_api.model.ingest.dto.slotAnnotions.SecondaryIdSlotAnnotationDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
+import org.alliancegenome.curation_api.services.ReferenceService;
 import org.alliancegenome.curation_api.services.helpers.SlotAnnotationIdentityHelper;
 import org.alliancegenome.curation_api.services.validation.dto.base.GenomicEntityDTOValidator;
 import org.alliancegenome.curation_api.services.validation.dto.slotAnnotations.AlleleDatabaseStatusSlotAnnotationDTOValidator;
@@ -79,6 +80,8 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 	AlleleFunctionalImpactSlotAnnotationDTOValidator alleleFunctionalImpactDtoValidator;
 	@Inject
 	NoteDTOValidator noteDtoValidator;
+	@Inject
+	ReferenceService referenceService;
 
 	@Transactional
 	public ObjectResponse<Allele> validateAlleleDTO(AlleleDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/ConstructDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/ConstructDTOValidator.java
@@ -22,6 +22,7 @@ import org.alliancegenome.curation_api.model.ingest.dto.slotAnnotions.ConstructC
 import org.alliancegenome.curation_api.model.ingest.dto.slotAnnotions.NameSlotAnnotationDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
+import org.alliancegenome.curation_api.services.ReferenceService;
 import org.alliancegenome.curation_api.services.helpers.ConstructUniqueIdHelper;
 import org.alliancegenome.curation_api.services.helpers.SlotAnnotationIdentityHelper;
 import org.alliancegenome.curation_api.services.helpers.UniqueIdentifierHelper;
@@ -50,6 +51,8 @@ public class ConstructDTOValidator extends ReagentDTOValidator<Construct, Constr
 	ConstructComponentSlotAnnotationDTOValidator constructComponentDtoValidator;
 	@Inject
 	SlotAnnotationIdentityHelper identityHelper;
+	@Inject
+	ReferenceService referenceService;
 
 	@Transactional
 	public ObjectResponse<Construct> validateConstructDTO(ConstructDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/ConstructDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/ConstructDTOValidator.java
@@ -78,7 +78,7 @@ public class ConstructDTOValidator extends ReagentDTOValidator<Construct, Constr
 
 		construct = validateReagentDTO(construct, dto, VocabularyConstants.CONSTRUCT_NOTE_TYPES_VOCABULARY_TERM_SET);
 
-		List<Reference> refs = validateReferences("reference_curies", dto.getReferenceCuries(), true);
+		List<Reference> refs = validateOptionalEntities("reference_curies", dto.getReferenceCuries(), referenceService::retrieveFromDbOrLiteratureService);
 
 		construct.setReferences(refs);
 
@@ -110,6 +110,7 @@ public class ConstructDTOValidator extends ReagentDTOValidator<Construct, Constr
 			construct.getConstructComponents().addAll(components);
 		}
 
+		response.convertWarningMessagesToMap();
 		response.convertErrorMessagesToMap();
 
 		if (response.hasErrors()) {
@@ -140,6 +141,10 @@ public class ConstructDTOValidator extends ReagentDTOValidator<Construct, Constr
 			return null;
 		}
 
+		if (symbolResponse.hasWarnings()) {
+			response.addWarningMessages(symbolResponse.getWarningMessages());
+		}
+
 		ConstructSymbolSlotAnnotation symbol = symbolResponse.getEntity();
 		symbol.setSingleConstruct(construct);
 
@@ -158,6 +163,10 @@ public class ConstructDTOValidator extends ReagentDTOValidator<Construct, Constr
 			response.addErrorMessage(field, nameResponse.errorMessagesString());
 			response.addErrorMessages(field, nameResponse.getErrorMessages());
 			return null;
+		}
+
+		if (nameResponse.hasWarnings()) {
+			response.addWarningMessages(nameResponse.getWarningMessages());
 		}
 
 		ConstructFullNameSlotAnnotation fullName = nameResponse.getEntity();
@@ -191,6 +200,9 @@ public class ConstructDTOValidator extends ReagentDTOValidator<Construct, Constr
 					syn.setSingleConstruct(construct);
 					validatedSynonyms.add(syn);
 				}
+				if (synResponse.hasWarnings()) {
+					response.addWarningMessages(field, ix, synResponse.getWarningMessages());
+				}
 			}
 		}
 
@@ -198,6 +210,8 @@ public class ConstructDTOValidator extends ReagentDTOValidator<Construct, Constr
 			response.convertMapToErrorMessages(field);
 			return null;
 		}
+
+		response.convertMapToWarningMessages(field);
 
 		if (CollectionUtils.isEmpty(validatedSynonyms)) {
 			return null;
@@ -231,6 +245,9 @@ public class ConstructDTOValidator extends ReagentDTOValidator<Construct, Constr
 					comp.setSingleConstruct(construct);
 					validatedComponents.add(comp);
 				}
+				if (compResponse.hasWarnings()) {
+					response.addWarningMessages(field, ix, compResponse.getWarningMessages());
+				}
 			}
 		}
 
@@ -238,6 +255,8 @@ public class ConstructDTOValidator extends ReagentDTOValidator<Construct, Constr
 			response.convertMapToErrorMessages(field);
 			return null;
 		}
+
+		response.convertMapToWarningMessages(field);
 
 		if (CollectionUtils.isEmpty(validatedComponents)) {
 			return null;

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/ConstructDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/ConstructDTOValidator.java
@@ -145,7 +145,8 @@ public class ConstructDTOValidator extends ReagentDTOValidator<Construct, Constr
 		}
 
 		if (symbolResponse.hasWarnings()) {
-			response.addWarningMessages(symbolResponse.getWarningMessages());
+			response.addWarningMessage(field, symbolResponse.warningMessagesString());
+			response.addWarningMessages(field, symbolResponse.getWarningMessages());
 		}
 
 		ConstructSymbolSlotAnnotation symbol = symbolResponse.getEntity();
@@ -169,7 +170,8 @@ public class ConstructDTOValidator extends ReagentDTOValidator<Construct, Constr
 		}
 
 		if (nameResponse.hasWarnings()) {
-			response.addWarningMessages(nameResponse.getWarningMessages());
+			response.addWarningMessage(field, nameResponse.warningMessagesString());
+			response.addWarningMessages(field, nameResponse.getWarningMessages());
 		}
 
 		ConstructFullNameSlotAnnotation fullName = nameResponse.getEntity();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDTOValidator.java
@@ -134,7 +134,8 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 		}
 
 		if (symbolResponse.hasWarnings()) {
-			response.addWarningMessages(symbolResponse.getWarningMessages());
+			response.addWarningMessage(field, symbolResponse.warningMessagesString());
+			response.addWarningMessages(field, symbolResponse.getWarningMessages());
 		}
 
 		GeneSymbolSlotAnnotation symbol = symbolResponse.getEntity();
@@ -158,7 +159,8 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 		}
 
 		if (nameResponse.hasWarnings()) {
-			response.addWarningMessages(nameResponse.getWarningMessages());
+			response.addWarningMessage(field, nameResponse.warningMessagesString());
+			response.addWarningMessages(field, nameResponse.getWarningMessages());
 		}
 
 		GeneFullNameSlotAnnotation fullName = nameResponse.getEntity();
@@ -182,7 +184,8 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 		}
 
 		if (nameResponse.hasWarnings()) {
-			response.addWarningMessages(nameResponse.getWarningMessages());
+			response.addWarningMessage(field, nameResponse.warningMessagesString());
+			response.addWarningMessages(field, nameResponse.getWarningMessages());
 		}
 
 		GeneSystematicNameSlotAnnotation systematicName = nameResponse.getEntity();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDTOValidator.java
@@ -106,12 +106,13 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 		}
 		gene.setGcrpCrossReference(gcrpCrossReference);
 		
+		response.convertWarningMessagesToMap();
 		response.convertErrorMessagesToMap();
 
 		if (response.hasErrors()) {
 			throw new ObjectValidationException(dto, response.errorMessagesString());
 		}
-		
+
 		response.setEntity(geneDAO.persist(gene));
 
 		return response;
@@ -130,6 +131,10 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 			response.addErrorMessage(field, symbolResponse.errorMessagesString());
 			response.addErrorMessages(field, symbolResponse.getErrorMessages());
 			return null;
+		}
+
+		if (symbolResponse.hasWarnings()) {
+			response.addWarningMessages(symbolResponse.getWarningMessages());
 		}
 
 		GeneSymbolSlotAnnotation symbol = symbolResponse.getEntity();
@@ -152,6 +157,10 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 			return null;
 		}
 
+		if (nameResponse.hasWarnings()) {
+			response.addWarningMessages(nameResponse.getWarningMessages());
+		}
+
 		GeneFullNameSlotAnnotation fullName = nameResponse.getEntity();
 		fullName.setSingleGene(gene);
 
@@ -170,6 +179,10 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 			response.addErrorMessage(field, nameResponse.errorMessagesString());
 			response.addErrorMessages(field, nameResponse.getErrorMessages());
 			return null;
+		}
+
+		if (nameResponse.hasWarnings()) {
+			response.addWarningMessages(nameResponse.getWarningMessages());
 		}
 
 		GeneSystematicNameSlotAnnotation systematicName = nameResponse.getEntity();
@@ -203,6 +216,9 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 					syn.setSingleGene(gene);
 					validatedSynonyms.add(syn);
 				}
+				if (synResponse.hasWarnings()) {
+					response.addWarningMessages(field, ix, synResponse.getWarningMessages());
+				}
 			}
 		}
 
@@ -210,6 +226,8 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 			response.convertMapToErrorMessages(field);
 			return null;
 		}
+
+		response.convertMapToWarningMessages(field);
 
 		if (CollectionUtils.isEmpty(validatedSynonyms)) {
 			return null;
@@ -243,6 +261,9 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 					sid.setSingleGene(gene);
 					validatedSecondaryIds.add(sid);
 				}
+				if (sidResponse.hasWarnings()) {
+					response.addWarningMessages(field, ix, sidResponse.getWarningMessages());
+				}
 			}
 		}
 
@@ -250,6 +271,8 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 			response.convertMapToErrorMessages(field);
 			return null;
 		}
+
+		response.convertMapToWarningMessages(field);
 
 		if (CollectionUtils.isEmpty(validatedSecondaryIds)) {
 			return null;

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/NoteDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/NoteDTOValidator.java
@@ -18,7 +18,7 @@ public class NoteDTOValidator extends AuditedObjectDTOValidator<Note, NoteDTO> {
 
 	public ObjectResponse<Note> validateNoteDTO(NoteDTO dto, String noteTypeVocabularyTermSet) {
 		response = new ObjectResponse<Note>();
-		
+
 		Note note = new Note();
 		note = validateAuditedObjectDTO(note, dto);
 
@@ -30,9 +30,9 @@ public class NoteDTOValidator extends AuditedObjectDTOValidator<Note, NoteDTO> {
 		VocabularyTerm noteType = validateRequiredTermInVocabularyTermSet("note_type_name", dto.getNoteTypeName(), noteTypeVocabularyTermSet);
 		note.setNoteType(noteType);
 
-		List<Reference> references = validateReferences("evidence_curies", dto.getEvidenceCuries(), true);
+		List<Reference> references = validateOptionalEntities("evidence_curies", dto.getEvidenceCuries(), referenceService::retrieveFromDbOrLiteratureService);
 		note.setReferences(references);
-		
+
 		response.setEntity(note);
 
 		return response;

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/NoteDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/NoteDTOValidator.java
@@ -8,13 +8,17 @@ import org.alliancegenome.curation_api.model.entities.Reference;
 import org.alliancegenome.curation_api.model.entities.VocabularyTerm;
 import org.alliancegenome.curation_api.model.ingest.dto.NoteDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
+import org.alliancegenome.curation_api.services.ReferenceService;
 import org.alliancegenome.curation_api.services.validation.dto.base.AuditedObjectDTOValidator;
 import org.apache.commons.lang3.StringUtils;
 
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
 
 @RequestScoped
 public class NoteDTOValidator extends AuditedObjectDTOValidator<Note, NoteDTO> {
+
+	@Inject ReferenceService referenceService;
 
 	public ObjectResponse<Note> validateNoteDTO(NoteDTO dto, String noteTypeVocabularyTermSet) {
 		response = new ObjectResponse<Note>();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/VariantDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/VariantDTOValidator.java
@@ -57,6 +57,7 @@ public class VariantDTOValidator extends GenomicEntityDTOValidator<Variant, Vari
 		SOTerm sourceGeneralConsequence = validateOntologyTerm(soTermService, "source_general_consequence_curie", dto.getSourceGeneralConsequenceCurie());
 		variant.setSourceGeneralConsequence(sourceGeneralConsequence);
 		
+		response.convertWarningMessagesToMap();
 		response.convertErrorMessagesToMap();
 
 		if (response.hasErrors()) {

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/base/BaseDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/base/BaseDTOValidator.java
@@ -447,7 +447,8 @@ public class BaseDTOValidator<E extends Object> {
 			return null;
 		}
 		if (noteResponse.hasWarnings()) {
-			response.addWarningMessages(noteResponse.getWarningMessages());
+			response.addWarningMessage("note_dto", noteResponse.warningMessagesString());
+			response.addWarningMessages("note_dto", noteResponse.getWarningMessages());
 		}
 
 		return noteDAO.persist(noteResponse.getEntity());

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/base/BaseDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/base/BaseDTOValidator.java
@@ -51,7 +51,7 @@ public class BaseDTOValidator<E extends Object> {
 	@Inject
 	MiTermService miTermService;
 	@Inject
-	protected ReferenceService referenceService;
+	ReferenceService referenceService;
 	@Inject
 	VocabularyTermService vocabularyTermService;
 	@Inject

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/base/BaseDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/base/BaseDTOValidator.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.dao.NoteDAO;
@@ -50,7 +51,7 @@ public class BaseDTOValidator<E extends Object> {
 	@Inject
 	MiTermService miTermService;
 	@Inject
-	ReferenceService referenceService;
+	protected ReferenceService referenceService;
 	@Inject
 	VocabularyTermService vocabularyTermService;
 	@Inject
@@ -236,27 +237,23 @@ public class BaseDTOValidator<E extends Object> {
 		return reference;
 	}
 
-	protected List<Reference> validateReferences(String field, List<String> referenceCuries, boolean failOnMissingReferences) {
-		if (CollectionUtils.isEmpty(referenceCuries)) {
+	protected <T> List<T> validateOptionalEntities(String field, List<String> curies, Function<String, T> lookupFn) {
+		if (CollectionUtils.isEmpty(curies)) {
 			return null;
 		}
 
-		List<Reference> references = new ArrayList<>();
-		for (String referenceCurie : referenceCuries) {
-			Reference reference = referenceService.retrieveFromDbOrLiteratureService(referenceCurie);
-			if (reference == null) {
-				if (failOnMissingReferences) {
-					response.addErrorMessage(field, ValidationConstants.INVALID_MESSAGE + " (" + referenceCurie + ")");
-					return null;
-				} else {
-					response.addWarningMessage(field, ValidationConstants.WARNING_MISSING_MESSAGE + " (" + referenceCurie + ")");
-				}
+		List<T> entities = new ArrayList<>();
+		for (String curie : curies) {
+			T entity = lookupFn.apply(curie);
+			if (entity == null) {
+				response.addWarningMessage(field, ValidationConstants.WARNING_MISSING_MESSAGE + " (" + curie + ")");
+				continue;
 			}
-			if (!references.contains(reference)) {
-				references.add(reference);
+			if (!entities.contains(entity)) {
+				entities.add(entity);
 			}
 		}
-		return references;
+		return entities;
 	}
 
 	protected <N extends OntologyTerm, D extends BaseSQLDAO<N>, S extends BaseOntologyTermService<N, D>> N validateOntologyTerm(S service, String field, String curie) {
@@ -449,6 +446,9 @@ public class BaseDTOValidator<E extends Object> {
 			response.addErrorMessage("note_dto", noteResponse.errorMessagesString());
 			return null;
 		}
+		if (noteResponse.hasWarnings()) {
+			response.addWarningMessages(noteResponse.getWarningMessages());
+		}
 
 		return noteDAO.persist(noteResponse.getEntity());
 	}
@@ -472,6 +472,9 @@ public class BaseDTOValidator<E extends Object> {
 				allNotesValid = false;
 				response.addErrorMessages("note_dtos", ix, noteResponse.getErrorMessages());
 			} else {
+				if (noteResponse.hasWarnings()) {
+					response.addWarningMessages("note_dtos", ix, noteResponse.getWarningMessages());
+				}
 				if (StringUtils.isNotBlank(expectedReference)) {
 					if (CollectionUtils.isNotEmpty(dtos.get(ix).getEvidenceCuries())) {
 						for (String noteRef : dtos.get(ix).getEvidenceCuries()) {
@@ -496,6 +499,8 @@ public class BaseDTOValidator<E extends Object> {
 			response.convertMapToErrorMessages("note_dtos");
 			return null;
 		}
+
+		response.convertMapToWarningMessages("note_dtos");
 
 		return validatedNotes;
 	}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/base/SubmittedObjectDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/base/SubmittedObjectDTOValidator.java
@@ -25,9 +25,9 @@ public class SubmittedObjectDTOValidator<E extends SubmittedObject, D extends Su
 	public E validateSubmittedObjectDTO(E entity, D dto, String noteTypeVocabularyTermSet) {
 
 		entity = validateAuditedObjectDTO(entity, dto);
-		
+
 		UniqueIdentifierHelper.setSubmittedObjectIdentifiers(dto, entity, null);
-		
+
 		if (dto.getDataProviderDto() == null) {
 			response.addErrorMessage("data_provider_dto", ValidationConstants.REQUIRED_MESSAGE);
 		} else {
@@ -43,11 +43,11 @@ public class SubmittedObjectDTOValidator<E extends SubmittedObject, D extends Su
 				}
 			}
 		}
-		
+
 		if (entity.getRelatedNotes() != null) {
 			entity.getRelatedNotes().clear();
 		}
-		
+
 		List<Note> relatedNotes = validateRelatedNotes(entity, dto, noteTypeVocabularyTermSet);
 		if (relatedNotes != null) {
 			if (entity.getRelatedNotes() == null) {
@@ -58,8 +58,6 @@ public class SubmittedObjectDTOValidator<E extends SubmittedObject, D extends Su
 
 		return entity;
 	}
-	
-
 
 	private List<Note> validateRelatedNotes(E entity, D dto, String noteTypeVocabularyTermSet) {
 		String field = "relatedNotes";
@@ -84,12 +82,19 @@ public class SubmittedObjectDTOValidator<E extends SubmittedObject, D extends Su
 						validatedNotes.add(noteResponse.getEntity());
 					}
 				}
+				if (noteResponse.hasWarnings()) {
+					response.addWarningMessages(field, ix, noteResponse.getWarningMessages());
+				}
 			}
 		}
 
 		if (!allValid) {
 			response.convertMapToErrorMessages(field);
 			return null;
+		}
+
+		if (CollectionUtils.isNotEmpty(dto.getNoteDtos())) {
+			response.convertMapToWarningMessages(field);
 		}
 
 		if (CollectionUtils.isEmpty(validatedNotes)) {

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/slotAnnotations/SlotAnnotationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/slotAnnotations/SlotAnnotationDTOValidator.java
@@ -1,15 +1,12 @@
 package org.alliancegenome.curation_api.services.validation.dto.slotAnnotations;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.model.entities.InformationContentEntity;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.SlotAnnotation;
 import org.alliancegenome.curation_api.model.ingest.dto.slotAnnotions.SlotAnnotationDTO;
 import org.alliancegenome.curation_api.services.InformationContentEntityService;
 import org.alliancegenome.curation_api.services.validation.dto.base.AuditedObjectDTOValidator;
-import org.apache.commons.collections.CollectionUtils;
 
 import jakarta.inject.Inject;
 
@@ -19,21 +16,10 @@ public class SlotAnnotationDTOValidator<E extends SlotAnnotation, D extends Slot
 
 	public E validateSlotAnnotationDTO(E annotation, D dto) {
 		annotation = validateAuditedObjectDTO(annotation, dto);
-		
-		List<InformationContentEntity> evidence = new ArrayList<>();
-		if (CollectionUtils.isNotEmpty(dto.getEvidenceCuries())) {
-			for (String evidenceCurie : dto.getEvidenceCuries()) {
-				InformationContentEntity evidenceEntity = informationContentEntityService.retrieveFromDbOrLiteratureService(evidenceCurie);
-				if (evidenceEntity == null) {
-					response.addErrorMessage("evidence_curies", ValidationConstants.INVALID_MESSAGE + " (" + evidenceCurie + ")");
-					break;
-				}
-				evidence.add(evidenceEntity);
-			}
-			annotation.setEvidence(evidence);
-		} else {
-			annotation.setEvidence(null);
-		}
+
+		List<InformationContentEntity> evidence = validateOptionalEntities("evidence_curies", dto.getEvidenceCuries(), informationContentEntityService::retrieveFromDbOrLiteratureService);
+
+		annotation.setEvidence(evidence);
 
 		return annotation;
 	}

--- a/src/test/java/org/alliancegenome/curation_api/IT_0101_GeneBulkUploadITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_0101_GeneBulkUploadITCase.java
@@ -356,17 +356,11 @@ public class IT_0101_GeneBulkUploadITCase extends BaseITCase {
 		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_09_invalid_gene_full_name_synonym_scope.json");
 		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_10_invalid_gene_systematic_name_synonym_scope.json");
 		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_11_invalid_gene_synonym_synonym_scope.json");
-		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_12_invalid_gene_symbol_evidence.json");
-		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_13_invalid_gene_full_name_evidence.json");
-		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_14_invalid_gene_systematic_name_evidence.json");
-		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_15_invalid_gene_synonym_evidence.json");
 		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_16_invalid_data_provider_source_organization_abbreviation.json");
 		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_17_invalid_data_provider_cross_reference_prefix.json");
 		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_18_invalid_data_provider_cross_reference_page_area.json");
-		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_19_invalid_gene_secondary_id_evidence.json");
 		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_20_invalid_gene_type.json");
 		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_21_invalid_note_type_name.json");
-		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_22_invalid_evidence_curies.json");
 		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_23_invalid_gcrp_cross_reference_prefix.json");
 		checkFailedBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_24_invalid_gcrp_cross_reference_page_area.json");
 	}
@@ -564,5 +558,16 @@ public class IT_0101_GeneBulkUploadITCase extends BaseITCase {
 			statusCode(200).
 			body("entity.primaryExternalId", is("GENETEST:DN01")).
 			body("entity.relatedNotes", hasSize(1));
+	}
+
+	@Test
+	@Order(14)
+	public void geneBulkUploadInvalidReferenceWarning() throws Exception {
+		checkWarningBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_12_invalid_gene_symbol_evidence.json");
+		checkWarningBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_13_invalid_gene_full_name_evidence.json");
+		checkWarningBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_14_invalid_gene_systematic_name_evidence.json");
+		checkWarningBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_15_invalid_gene_synonym_evidence.json");
+		checkWarningBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_19_invalid_gene_secondary_id_evidence.json");
+		checkWarningBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_22_invalid_evidence_curies.json");
 	}
 }

--- a/src/test/java/org/alliancegenome/curation_api/IT_0101_GeneBulkUploadITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_0101_GeneBulkUploadITCase.java
@@ -569,5 +569,6 @@ public class IT_0101_GeneBulkUploadITCase extends BaseITCase {
 		checkWarningBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_15_invalid_gene_synonym_evidence.json");
 		checkWarningBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_19_invalid_gene_secondary_id_evidence.json");
 		checkWarningBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_22_invalid_evidence_curies.json");
+		checkWarningBulkLoad(geneBulkPostEndpoint, geneTestFilePath + "IV_25_invalid_multiple_evidence_fields.json", 3);
 	}
 }

--- a/src/test/java/org/alliancegenome/curation_api/IT_0102_AlleleBulkUploadITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_0102_AlleleBulkUploadITCase.java
@@ -409,34 +409,23 @@ public class IT_0102_AlleleBulkUploadITCase extends BaseITCase {
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_03_invalid_taxon.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_04_invalid_in_collection.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_06_invalid_allele_mutation_type_mutation_type.json");
-		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_07_invalid_allele_mutation_type_evidence.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_08_invalid_allele_symbol_name_type.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_09_invalid_allele_full_name_name_type.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_10_invalid_allele_synonym_name_type.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_11_invalid_allele_symbol_synonym_scope.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_12_invalid_allele_full_name_synonym_scope.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_13_invalid_allele_synonym_synonym_scope.json");
-		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_14_invalid_allele_symbol_evidence.json");
-		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_15_invalid_allele_full_name_evidence.json");
-		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_16_invalid_allele_synonym_evidence.json");
-		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_17_invalid_allele_secondary_id_evidence.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_18_invalid_allele_inheritance_mode_inheritance_mode.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_19_invalid_allele_inheritance_mode_phenotype_term.json");
-		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_20_invalid_allele_inheritance_mode_evidence.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_21_invalid_data_provider_source_organization_abbreviation.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_22_invalid_data_provider_cross_reference_prefix.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_23_invalid_data_provider_cross_reference_page_area.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_24_invalid_allele_functional_impacts_functional_impacts.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_25_invalid_allele_functional_impacts_phenotype_term.json");
-		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_26_invalid_allele_functional_impacts_evidence.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_27_invalid_allele_germline_transmission_status_germline_transmission_status.json");
-		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_28_invalid_allele_germline_transmission_status_evidence.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_29_invalid_related_notes_note_type_name.json");
-		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_30_invalid_related_notes_evidence.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_31_invalid_allele_database_status_database_status.json");
-		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_32_invalid_allele_database_status_evidence.json");
 		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_33_invalid_allele_nomenclature_events_nomenclature_event.json");
-		checkFailedBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_34_invalid_allele_nomenclature_events_evidence.json");
 	}
 	
 	@Test
@@ -680,5 +669,16 @@ public class IT_0102_AlleleBulkUploadITCase extends BaseITCase {
 	@Order(14)
 	public void alleleBulkUploadInvalidReferenceWarning() throws Exception {
 		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_05_invalid_reference.json");
+		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_07_invalid_allele_mutation_type_evidence.json");
+		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_14_invalid_allele_symbol_evidence.json");
+		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_15_invalid_allele_full_name_evidence.json");
+		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_16_invalid_allele_synonym_evidence.json");
+		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_17_invalid_allele_secondary_id_evidence.json");
+		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_20_invalid_allele_inheritance_mode_evidence.json");
+		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_26_invalid_allele_functional_impacts_evidence.json");
+		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_28_invalid_allele_germline_transmission_status_evidence.json");
+		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_30_invalid_related_notes_evidence.json");
+		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_32_invalid_allele_database_status_evidence.json");
+		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_34_invalid_allele_nomenclature_events_evidence.json");
 	}
 }

--- a/src/test/java/org/alliancegenome/curation_api/IT_0102_AlleleBulkUploadITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_0102_AlleleBulkUploadITCase.java
@@ -680,5 +680,6 @@ public class IT_0102_AlleleBulkUploadITCase extends BaseITCase {
 		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_30_invalid_related_notes_evidence.json");
 		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_32_invalid_allele_database_status_evidence.json");
 		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_34_invalid_allele_nomenclature_events_evidence.json");
+		checkWarningBulkLoad(alleleBulkPostEndpoint, alleleTestFilePath + "IV_35_invalid_multiple_evidence_fields.json", 4);
 	}
 }

--- a/src/test/java/org/alliancegenome/curation_api/IT_0105_ConstructBulkUploadITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_0105_ConstructBulkUploadITCase.java
@@ -495,5 +495,6 @@ public class IT_0105_ConstructBulkUploadITCase extends BaseITCase {
 		checkWarningBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_16_invalid_construct_symbol_evidence.json");
 		checkWarningBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_17_invalid_construct_full_name_evidence.json");
 		checkWarningBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_18_invalid_construct_synonym_evidence.json");
+		checkWarningBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_20_invalid_multiple_evidence_fields.json", 3);
 	}
 }

--- a/src/test/java/org/alliancegenome/curation_api/IT_0105_ConstructBulkUploadITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_0105_ConstructBulkUploadITCase.java
@@ -293,8 +293,6 @@ public class IT_0105_ConstructBulkUploadITCase extends BaseITCase {
 	public void constructBulkUploadInvalidFields() throws Exception {
 		checkFailedBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_01_invalid_date_created.json");
 		checkFailedBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_02_invalid_date_updated.json");
-		checkFailedBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_03_invalid_reference.json");
-		checkFailedBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_04_invalid_construct_component_evidence.json");
 		checkFailedBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_05_invalid_construct_component_taxon.json");
 		checkFailedBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_06_invalid_construct_component_note_note_type.json");
 		checkFailedBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_07_invalid_data_provider_source_organization_abbreviation.json");
@@ -306,9 +304,6 @@ public class IT_0105_ConstructBulkUploadITCase extends BaseITCase {
 		checkFailedBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_13_invalid_construct_symbol_synonym_scope.json");
 		checkFailedBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_14_invalid_construct_full_name_synonym_scope.json");
 		checkFailedBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_15_invalid_construct_synonym_synonym_scope.json");
-		checkFailedBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_16_invalid_construct_symbol_evidence.json");
-		checkFailedBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_17_invalid_construct_full_name_evidence.json");
-		checkFailedBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_18_invalid_construct_synonym_evidence.json");
 		checkFailedBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_19_invalid_construct_component_relation.json");
 	}
 	
@@ -491,5 +486,14 @@ public class IT_0105_ConstructBulkUploadITCase extends BaseITCase {
 			statusCode(200).
 			body("entity.primaryExternalId", is("WB:Construct0001"));
 	}
-		
+
+	@Test
+	@Order(14)
+	public void constructBulkUploadInvalidReferenceWarning() throws Exception {
+		checkWarningBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_03_invalid_reference.json");
+		checkWarningBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_04_invalid_construct_component_evidence.json");
+		checkWarningBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_16_invalid_construct_symbol_evidence.json");
+		checkWarningBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_17_invalid_construct_full_name_evidence.json");
+		checkWarningBulkLoad(constructBulkPostEndpoint, constructTestFilePath + "IV_18_invalid_construct_synonym_evidence.json");
+	}
 }

--- a/src/test/java/org/alliancegenome/curation_api/IT_0106_VariantBulkUploadITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_0106_VariantBulkUploadITCase.java
@@ -192,7 +192,6 @@ public class IT_0106_VariantBulkUploadITCase extends BaseITCase {
 		checkFailedBulkLoad(variantBulkPostEndpoint, variantTestFilePath + "IV_08_invalid_data_provider_cross_reference_prefix.json");
 		checkFailedBulkLoad(variantBulkPostEndpoint, variantTestFilePath + "IV_09_invalid_data_provider_cross_reference_page_area.json");
 		checkFailedBulkLoad(variantBulkPostEndpoint, variantTestFilePath + "IV_10_invalid_related_notes_note_type.json");
-		checkFailedBulkLoad(variantBulkPostEndpoint, variantTestFilePath + "IV_11_invalid_related_notes_evidence.json");
 	}
 	
 	@Test
@@ -287,5 +286,10 @@ public class IT_0106_VariantBulkUploadITCase extends BaseITCase {
 			body("entity.primaryExternalId", is("VARIANTTEST:DN01")).
 			body("entity.relatedNotes", hasSize(1));
 	}
-	
+
+	@Test
+	@Order(13)
+	public void variantBulkUploadInvalidReferenceWarning() throws Exception {
+		checkWarningBulkLoad(variantBulkPostEndpoint, variantTestFilePath + "IV_11_invalid_related_notes_evidence.json");
+	}
 }

--- a/src/test/java/org/alliancegenome/curation_api/base/BaseITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/base/BaseITCase.java
@@ -158,6 +158,10 @@ public class BaseITCase {
 		checkBulkLoadRecordCounts(endpoint, filePath, "Records", 1, 0, 1, 0, 1);
 	}
 
+	public void checkWarningBulkLoad(String endpoint, String filePath, int nrWarnings) throws Exception {
+		checkBulkLoadRecordCounts(endpoint, filePath, "Records", 1, 0, 1, 0, nrWarnings);
+	}
+
 	public void checkSkippedBulkLoad(String endpoint, String filePath) throws Exception {
 		checkBulkLoadRecordCounts(endpoint, filePath, "Records", 1, 0, 0, 1, 0);
 	}

--- a/src/test/resources/bulk/01_gene/IV_25_invalid_multiple_evidence_fields.json
+++ b/src/test/resources/bulk/01_gene/IV_25_invalid_multiple_evidence_fields.json
@@ -1,0 +1,50 @@
+[
+  {
+    "primary_external_id": "GENETEST:IV25",
+    "taxon_curie": "NCBITaxon:6239",
+    "internal": false,
+    "obsolete": false,
+    "gene_type_curie": "SO:0001217",
+    "gene_symbol_dto": {
+      "display_text": "iv25",
+      "format_text": "iv25",
+      "name_type_name": "nomenclature_symbol",
+      "evidence_curies": [
+        "PMID:does_not_exist"
+      ],
+      "internal": false,
+      "obsolete": false
+    },
+    "gene_full_name_dto": {
+      "display_text": "Invalid evidence test 25",
+      "format_text": "Invalid evidence test 25",
+      "name_type_name": "full_name",
+      "evidence_curies": [
+        "PMID:does_not_exist"
+      ],
+      "internal": false,
+      "obsolete": false
+    },
+    "gene_systematic_name_dto": {
+      "display_text": "iv25.1",
+      "format_text": "iv25.1",
+      "name_type_name": "systematic_name",
+      "evidence_curies": [
+        "PMID:does_not_exist"
+      ],
+      "internal": false,
+      "obsolete": false
+    },
+    "data_provider_dto": {
+      "internal": false,
+      "obsolete": false,
+      "source_organization_abbreviation": "WB",
+      "cross_reference_dto": {
+        "referenced_curie": "TEST:0001",
+        "page_area": "homepage",
+        "display_name": "TEST:0001",
+        "prefix": "TEST"
+      }
+    }
+  }
+]

--- a/src/test/resources/bulk/02_allele/IV_35_invalid_multiple_evidence_fields.json
+++ b/src/test/resources/bulk/02_allele/IV_35_invalid_multiple_evidence_fields.json
@@ -1,0 +1,55 @@
+[
+  {
+    "primary_external_id": "ALLELETEST:IV35",
+    "taxon_curie": "NCBITaxon:6239",
+    "internal": false,
+    "obsolete": false,
+    "allele_symbol_dto": {
+      "display_text": "iv35",
+      "format_text": "iv35",
+      "name_type_name": "nomenclature_symbol",
+      "evidence_curies": [
+        "PMID:does_not_exist"
+      ],
+      "internal": false,
+      "obsolete": false
+    },
+    "allele_full_name_dto": {
+      "display_text": "Invalid evidence test 35",
+      "format_text": "Invalid evidence test 35",
+      "name_type_name": "full_name",
+      "evidence_curies": [
+        "PMID:does_not_exist"
+      ],
+      "internal": false,
+      "obsolete": false
+    },
+    "allele_germline_transmission_status_dto": {
+      "germline_transmission_status_name": "cell_line",
+      "evidence_curies": [
+        "PMID:does_not_exist"
+      ],
+      "internal": false,
+      "obsolete": false
+    },
+    "allele_database_status_dto": {
+      "database_status_name": "reserved",
+      "evidence_curies": [
+        "PMID:does_not_exist"
+      ],
+      "internal": false,
+      "obsolete": false
+    },
+    "data_provider_dto": {
+      "internal": false,
+      "obsolete": false,
+      "source_organization_abbreviation": "WB",
+      "cross_reference_dto": {
+        "referenced_curie": "TEST:0001",
+        "page_area": "homepage",
+        "display_name": "TEST:0001",
+        "prefix": "TEST"
+      }
+    }
+  }
+]

--- a/src/test/resources/bulk/05_construct/IV_20_invalid_multiple_evidence_fields.json
+++ b/src/test/resources/bulk/05_construct/IV_20_invalid_multiple_evidence_fields.json
@@ -1,0 +1,41 @@
+[
+  {
+    "primary_external_id": "WB:ConstructIV20",
+    "internal": false,
+    "obsolete": false,
+    "construct_symbol_dto": {
+      "display_text": "iv20",
+      "format_text": "iv20",
+      "name_type_name": "nomenclature_symbol",
+      "evidence_curies": [
+        "PMID:does_not_exist"
+      ],
+      "internal": false,
+      "obsolete": false
+    },
+    "construct_full_name_dto": {
+      "display_text": "Invalid evidence test 20",
+      "format_text": "Invalid evidence test 20",
+      "name_type_name": "full_name",
+      "evidence_curies": [
+        "PMID:does_not_exist"
+      ],
+      "internal": false,
+      "obsolete": false
+    },
+    "reference_curies": [
+      "PMID:does_not_exist"
+    ],
+    "data_provider_dto": {
+      "internal": false,
+      "obsolete": false,
+      "source_organization_abbreviation": "WB",
+      "cross_reference_dto": {
+        "referenced_curie": "TEST:0001",
+        "page_area": "homepage",
+        "display_name": "TEST:0001",
+        "prefix": "TEST"
+      }
+    }
+  }
+]


### PR DESCRIPTION
…ences/evidence across all bulk loads

Unrecognized references and evidence curies in bulk loads now produce warnings instead of hard errors, allowing entities to still load. Applies to all entity types: allele, gene, construct, AGM, and variant.

Introduces a generic validateOptionalEntities() helper in BaseDTOValidator that takes a lookup function and always warns on missing entities. This replaces the old validateReferences() method and the inline evidence loop in SlotAnnotationDTOValidator, eliminating duplicated validation logic.

Warning propagation added to all entity DTO validators so sub-validator warnings bubble up to load results.