### PR TITLE
SCRUM-5901: Update schema version and min compatible versions for Lin…

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/constants/LinkMLSchemaConstants.java
+++ b/src/main/java/org/alliancegenome/curation_api/constants/LinkMLSchemaConstants.java
@@ -5,7 +5,7 @@ public class LinkMLSchemaConstants {
 	private LinkMLSchemaConstants() {
 		// Hidden from view, as it is a utility class
 	}
-	public static final String LATEST_RELEASE = "2.15.0";
+	public static final String LATEST_RELEASE = "2.16.0";
 	public static final String MIN_ONTOLOGY_RELEASE = "1.2.4";
 	public static final String MAX_ONTOLOGY_RELEASE = LATEST_RELEASE;
 

--- a/src/main/java/org/alliancegenome/curation_api/model/ingest/dto/associations/AgmSequenceTargetingReagentAssociationDTO.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/ingest/dto/associations/AgmSequenceTargetingReagentAssociationDTO.java
@@ -13,7 +13,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@AGRCurationSchemaVersion(min = "2.8.1", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObjectDTO.class }, submitted = true)
+@AGRCurationSchemaVersion(min = "2.14.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { AuditedObjectDTO.class }, submitted = true)
 public class AgmSequenceTargetingReagentAssociationDTO extends AuditedObjectDTO {
 
 	@JsonView({ CurationView.FieldsOnly.class })

--- a/src/main/java/org/alliancegenome/curation_api/model/ingest/dto/associations/ConstructGenomicEntityAssociationDTO.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/ingest/dto/associations/ConstructGenomicEntityAssociationDTO.java
@@ -15,7 +15,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@AGRCurationSchemaVersion(min = "2.0.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { EvidenceAssociationDTO.class, NoteDTO.class }, submitted = true)
+@AGRCurationSchemaVersion(min = "2.14.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = { EvidenceAssociationDTO.class, NoteDTO.class }, submitted = true)
 public class ConstructGenomicEntityAssociationDTO extends EvidenceAssociationDTO {
 
 	@JsonView({ CurationView.FieldsOnly.class })


### PR DESCRIPTION
…kML v2.16.0

Bump LATEST_RELEASE to 2.16.0 and set minimum compatible schema version to 2.14.0 for ConstructGenomicEntityAssociationDTO and AgmSequenceTargetingReagentAssociationDTO to align with the latest LinkML model.