### PR TITLE
SCRUM-5901: Rename genomic_entity_relation_name to relation_name in C…

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/ingest/dto/associations/ConstructGenomicEntityAssociationDTO.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/ingest/dto/associations/ConstructGenomicEntityAssociationDTO.java
@@ -23,8 +23,8 @@ public class ConstructGenomicEntityAssociationDTO extends EvidenceAssociationDTO
 	private String constructIdentifier;
 	
 	@JsonView({ CurationView.FieldsOnly.class })
-	@JsonProperty("genomic_entity_relation_name")
-	private String genomicEntityRelationName;
+	@JsonProperty("relation_name")
+	private String relationName;
 	
 	@JsonView({ CurationView.FieldsOnly.class })
 	@JsonProperty("genomic_entity_identifier")

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/ConstructGenomicEntityAssociationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/ConstructGenomicEntityAssociationDTOValidator.java
@@ -59,7 +59,7 @@ public class ConstructGenomicEntityAssociationDTOValidator extends EvidenceAssoc
 			}
 		}
 
-		VocabularyTerm relation = validateRequiredTermInVocabularyTermSet("genomic_entity_relation_name", dto.getGenomicEntityRelationName(), VocabularyConstants.CONSTRUCT_GENOMIC_ENTITY_RELATION_VOCABULARY_TERM_SET);
+		VocabularyTerm relation = validateRequiredTermInVocabularyTermSet("relation_name", dto.getRelationName(), VocabularyConstants.CONSTRUCT_GENOMIC_ENTITY_RELATION_VOCABULARY_TERM_SET);
 
 		ConstructGenomicEntityAssociation association = null;
 		if (subjectIds != null && subjectIds.size() == 1 && objectIds != null && objectIds.size() == 1 && relation != null) {

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/AF_01_all_fields.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/AF_01_all_fields.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:25920550"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/ER_01_empty_subject.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/ER_01_empty_subject.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:25920550"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/ER_02_empty_relation.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/ER_02_empty_relation.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "",
+    "relation_name": "",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:25920550"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/ER_03_empty_object.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/ER_03_empty_object.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "",
      "evidence_curies": [
       "PMID:25920550"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/ER_04_empty_related_note_note_type.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/ER_04_empty_related_note_note_type.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:25920550"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/ER_05_empty_related_note_free_text.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/ER_05_empty_related_note_free_text.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:25920550"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/IV_01_invalid_subject.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/IV_01_invalid_subject.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "CONSTRUCTTEST:IV01",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:25920550"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/IV_02_invalid_relation.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/IV_02_invalid_relation.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "invalid",
+    "relation_name": "invalid",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:25920550"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/IV_03_invalid_object.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/IV_03_invalid_object.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Invalid",
      "evidence_curies": [
       "PMID:25920550"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/IV_04_invalid_date_created.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/IV_04_invalid_date_created.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:25920550"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/IV_05_invalid_date_updated.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/IV_05_invalid_date_updated.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:25920550"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/IV_06_invalid_evidence.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/IV_06_invalid_evidence.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:Invalid"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/IV_07_invalid_related_note_note_type.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/IV_07_invalid_related_note_note_type.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:25920550"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/MR_03_no_object.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/MR_03_no_object.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
      "evidence_curies": [
       "PMID:25920550"
     ],

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/MR_04_no_related_note_note_type.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/MR_04_no_related_note_note_type.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:25920550"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/MR_05_no_related_note_free_text.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/MR_05_no_related_note_free_text.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:25920550"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/UD_01_update_all_except_default_fields.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/UD_01_update_all_except_default_fields.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:25920551"

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/UE_01_update_empty_non_required_fields.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/UE_01_update_empty_non_required_fields.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [],
     "created_by_curie": "",

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/UM_01_update_no_non_required_fields_level_1.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/UM_01_update_no_non_required_fields_level_1.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001"
   }
 ]

--- a/src/test/resources/bulk/CA01_construct_genomic_entity_association/UM_02_update_no_non_required_fields_level_2.json
+++ b/src/test/resources/bulk/CA01_construct_genomic_entity_association/UM_02_update_no_non_required_fields_level_2.json
@@ -1,7 +1,7 @@
 [
   {
     "construct_identifier": "WB:Construct0001",
-    "genomic_entity_relation_name": "is_regulated_by",
+    "relation_name": "is_regulated_by",
     "genomic_entity_identifier": "GENETEST:Gene0001",
      "evidence_curies": [
       "PMID:25920550"


### PR DESCRIPTION
…onstructGenomicEntityAssociation

The DTO was still using the old field name genomic_entity_relation_name while LinkML v2.14.0+ renamed it to relation_name, causing Jackson to silently drop the field during deserialization and the validator to report it as missing.