### PR TITLE
SCRUM-5857 Unify warning exception JSON to use singular message field

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/LoadFileExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/LoadFileExecutor.java
@@ -251,7 +251,7 @@ public class LoadFileExecutor {
 						for (Entry<String, String> entry : dbObject.getWarningMessages().entrySet()) {
 							history.incrementWarnings(countType);
 						}
-						addException(history, new ObjectUpdateExceptionData(dtoObject, dbObject.warningMessagesList(), null));
+						addException(history, new ObjectUpdateExceptionData(dtoObject, dbObject.warningMessagesString(), null));
 					}
 					history.incrementCompleted(countType);
 					if (idsAdded != null) {

--- a/src/main/resources/db/migration/v0.46.0.5__unify_exception_message_field.sql
+++ b/src/main/resources/db/migration/v0.46.0.5__unify_exception_message_field.sql
@@ -1,0 +1,10 @@
+UPDATE bulkloadfileexception
+SET exception = jsonb_set(
+    exception::jsonb - 'messages',
+    '{message}',
+    to_jsonb(array_to_string(
+        ARRAY(SELECT jsonb_array_elements_text(exception::jsonb -> 'messages')),
+        ' | '
+    ))
+)
+WHERE jsonb_typeof(exception::jsonb -> 'messages') = 'array';


### PR DESCRIPTION
Warning exceptions now use warningMessagesString() (pipe-delimited String) instead of warningMessagesList() (Collection<String>), so they populate the same singular "message" field that failure exceptions already use. Includes a Flyway migration to convert existing messages arrays in the DB.