### PR TITLE
SCRUM-5825: Fix stopped load Slack notifications and sort dependencies alphabetically

### DIFF
--- a/src/main/cliapp/src/containers/dataLoadsPage/NewBulkLoadForm.js
+++ b/src/main/cliapp/src/containers/dataLoadsPage/NewBulkLoadForm.js
@@ -215,9 +215,11 @@ export const NewBulkLoadForm = ({
 							<label>Dependencies</label>
 							{Array.isArray(newBulkLoad.dependencies) && newBulkLoad.dependencies.length > 0 ? (
 								<ul style={{ margin: 0, paddingLeft: '1.5rem' }}>
-									{newBulkLoad.dependencies.map((dep) => (
-										<li key={dep.id}>{dep.name}</li>
-									))}
+									{[...newBulkLoad.dependencies]
+										.sort((a, b) => a.name.localeCompare(b.name))
+										.map((dep) => (
+											<li key={dep.id}>{dep.name}</li>
+										))}
 								</ul>
 							) : (
 								<p style={{ margin: 0, fontStyle: 'italic', color: '#999' }}>None</p>

--- a/src/main/java/org/alliancegenome/curation_api/exceptions/ApiErrorException.java
+++ b/src/main/java/org/alliancegenome/curation_api/exceptions/ApiErrorException.java
@@ -9,6 +9,8 @@ import lombok.Setter;
 @Getter
 public class ApiErrorException extends RuntimeException {
 
+	public static final String INTERRUPTED_MESSAGE = "Thread isInterrupted";
+	
 	private ObjectResponse<?> objectResponse;
 
 	public ApiErrorException(String message) {

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/BiogridOrcExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/BiogridOrcExecutor.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
@@ -121,8 +122,8 @@ public class BiogridOrcExecutor extends LoadFileExecutor {
 				}
 				ph.progressProcess();
 				if (Thread.currentThread().isInterrupted()) {
-					history.setErrorMessage("Thread isInterrupted");
-					throw new RuntimeException("Thread isInterrupted");
+					history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+					throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 				}
 			}
 			

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/ExpressionAtlasExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/ExpressionAtlasExecutor.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
@@ -54,8 +55,8 @@ public class ExpressionAtlasExecutor extends LoadFileExecutor {
 		
 	private void runLoad(BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<String> identifiers) {
 		if (Thread.currentThread().isInterrupted()) {
-			history.setErrorMessage("Thread isInterrupted");
-			throw new RuntimeException("Thread isInterrupted");
+			history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+			throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 		}
 		
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
@@ -94,8 +95,8 @@ public class ExpressionAtlasExecutor extends LoadFileExecutor {
 				}
 				ph.progressProcess();
 				if (Thread.currentThread().isInterrupted()) {
-					history.setErrorMessage("Thread isInterrupted");
-					throw new RuntimeException("Thread isInterrupted");
+					history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+					throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 				}
 			}
 			updateHistory(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneExpressionExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneExpressionExecutor.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
 import org.alliancegenome.curation_api.model.entities.GeneExpressionAnnotation;
@@ -118,8 +119,8 @@ public class GeneExpressionExecutor extends LoadFileExecutor {
 			}
 			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
-				history.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 		updateHistory(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneOntologyAnnotationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneOntologyAnnotationExecutor.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
 import org.alliancegenome.curation_api.model.entities.GeneOntologyAnnotation;
@@ -119,8 +120,8 @@ public class GeneOntologyAnnotationExecutor extends LoadFileExecutor {
 			ph.progressProcess();
 
 			if (Thread.currentThread().isInterrupted()) {
-				bulkLoadFileHistory.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				bulkLoadFileHistory.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 		ph.finishProcess();

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeoXrefExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeoXrefExecutor.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
@@ -54,8 +55,8 @@ public class GeoXrefExecutor extends LoadFileExecutor {
 
 	private void runLoad(BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<String> entrezIds) {
 		if (Thread.currentThread().isInterrupted()) {
-			history.setErrorMessage("Thread isInterrupted");
-			throw new RuntimeException("Thread isInterrupted");
+			history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+			throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 		}
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.addDisplayHandler(loadProcessDisplayService);
@@ -93,8 +94,8 @@ public class GeoXrefExecutor extends LoadFileExecutor {
 				}
 				ph.progressProcess();
 				if (Thread.currentThread().isInterrupted()) {
-					history.setErrorMessage("Thread isInterrupted");
-					throw new RuntimeException("Thread isInterrupted");
+					history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+					throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 				}
 			}
 			updateHistory(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/HTPExpressionDatasetAnnotationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/HTPExpressionDatasetAnnotationExecutor.java
@@ -8,6 +8,7 @@ import java.util.zip.GZIPInputStream;
 import org.alliancegenome.curation_api.dao.ExternalDataBaseEntityDAO;
 import org.alliancegenome.curation_api.dao.HTPExpressionDatasetAnnotationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
@@ -104,8 +105,8 @@ public class HTPExpressionDatasetAnnotationExecutor extends LoadFileExecutor {
 			}
 			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
-				history.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 		updateHistory(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/LoadFileExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/LoadFileExecutor.java
@@ -16,6 +16,7 @@ import org.alliancegenome.curation_api.dao.loads.BulkLoadFileExceptionDAO;
 import org.alliancegenome.curation_api.dao.loads.BulkLoadFileHistoryDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.enums.JobStatus;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
@@ -230,8 +231,8 @@ public class LoadFileExecutor {
 
 	protected <E extends AuditedObject, T extends BaseDTO> boolean runLoad(BaseUpsertServiceInterface<E, T> service, BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<T> objectList, List<Long> idsAdded, Boolean terminateFailing, String countType, String dataType) {
 		if (Thread.currentThread().isInterrupted()) {
-			history.setErrorMessage("Thread isInterrupted");
-			throw new RuntimeException("Thread isInterrupted");
+			history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+			throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 		}
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.addDisplayHandler(loadProcessDisplayService);
@@ -277,8 +278,8 @@ public class LoadFileExecutor {
 				}
 				ph.progressProcess();
 				if (Thread.currentThread().isInterrupted()) {
-					history.setErrorMessage("Thread isInterrupted");
-					throw new RuntimeException("Thread isInterrupted");
+					history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+					throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 				}
 			}
 			updateHistory(history);
@@ -295,8 +296,8 @@ public class LoadFileExecutor {
 	// The following methods are for bulk validation
 	protected <S extends BaseEntityCrudService<?, ?>> void runCleanup(S service, BulkLoadFileHistory history, String dataProviderName, List<Long> annotationIdsBefore, List<Long> annotationIdsAfter, String loadTypeString, Boolean deprecate) {
 		if (Thread.currentThread().isInterrupted()) {
-			history.setErrorMessage("Thread isInterrupted");
-			throw new RuntimeException("Thread isInterrupted");
+			history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+			throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 		}
 		Log.debug("runLoad: After: " + dataProviderName + " " + annotationIdsAfter.size());
 
@@ -332,8 +333,8 @@ public class LoadFileExecutor {
 			}
 			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
-				history.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 		updateHistory(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/OntologyExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/OntologyExecutor.java
@@ -12,6 +12,7 @@ import org.alliancegenome.curation_api.dao.loads.BulkLoadFileDAO;
 import org.alliancegenome.curation_api.dao.loads.BulkLoadFileExceptionDAO;
 import org.alliancegenome.curation_api.dao.loads.BulkLoadFileHistoryDAO;
 import org.alliancegenome.curation_api.enums.OntologyBulkLoadType;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.ontology.OntologyTerm;
@@ -337,8 +338,8 @@ public class OntologyExecutor extends LoadFileExecutor {
 			bulkLoadFileHistory.incrementCompleted(countType);
 			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
-				bulkLoadFileHistory.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				bulkLoadFileHistory.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 		ph.finishProcess();
@@ -361,8 +362,8 @@ public class OntologyExecutor extends LoadFileExecutor {
 				}
 				ph1.progressProcess();
 				if (Thread.currentThread().isInterrupted()) {
-					bulkLoadFileHistory.setErrorMessage("Thread isInterrupted");
-					throw new RuntimeException("Thread isInterrupted");
+					bulkLoadFileHistory.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+					throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 				}
 			}
 			ph1.finishProcess();
@@ -376,8 +377,8 @@ public class OntologyExecutor extends LoadFileExecutor {
 				bulkLoadFileHistory.incrementCompleted(countType);
 				ph2.progressProcess();
 				if (Thread.currentThread().isInterrupted()) {
-					bulkLoadFileHistory.setErrorMessage("Thread isInterrupted");
-					throw new RuntimeException("Thread isInterrupted");
+					bulkLoadFileHistory.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+					throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 				}
 			}
 			ph2.finishProcess();
@@ -421,8 +422,8 @@ public class OntologyExecutor extends LoadFileExecutor {
 			}
 			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
-				history.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 		bulkLoadFileHistoryDAO.merge(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/PhenotypeAnnotationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/PhenotypeAnnotationExecutor.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
@@ -113,8 +114,8 @@ public class PhenotypeAnnotationExecutor extends LoadFileExecutor {
 			
 			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
-				history.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 		updateHistory(history);
@@ -145,8 +146,8 @@ public class PhenotypeAnnotationExecutor extends LoadFileExecutor {
 			
 			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
-				history.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 		updateHistory(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/SequenceTargetingReagentExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/SequenceTargetingReagentExecutor.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
@@ -132,8 +133,8 @@ public class SequenceTargetingReagentExecutor extends LoadFileExecutor {
 			updateHistory(history);
 			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
-				history.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 	}
@@ -159,8 +160,8 @@ public class SequenceTargetingReagentExecutor extends LoadFileExecutor {
 			updateHistory(history);
 			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
-				history.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 	}

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/VariantFmsExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/VariantFmsExecutor.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
@@ -125,8 +126,8 @@ public class VariantFmsExecutor extends LoadFileExecutor {
 			}
 			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
-				history.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 		

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/VepGeneExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/VepGeneExecutor.java
@@ -8,6 +8,7 @@ import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.dao.PredictedVariantConsequenceDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
@@ -71,8 +72,8 @@ public class VepGeneExecutor extends LoadFileExecutor {
 	
 	protected boolean runLoad(BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<VepTxtDTO> objectList, List<Long> idsUpdated) {
 		if (Thread.currentThread().isInterrupted()) {
-			history.setErrorMessage("Thread isInterrupted");
-			throw new RuntimeException("Thread isInterrupted");
+			history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+			throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 		}
 		
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
@@ -112,8 +113,8 @@ public class VepGeneExecutor extends LoadFileExecutor {
 				}
 				ph.progressProcess();
 				if (Thread.currentThread().isInterrupted()) {
-					history.setErrorMessage("Thread isInterrupted");
-					throw new RuntimeException("Thread isInterrupted");
+					history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+					throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 				}
 			}
 			updateHistory(history);
@@ -157,8 +158,8 @@ public class VepGeneExecutor extends LoadFileExecutor {
 			}
 			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
-				history.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 		updateHistory(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/AlleleGeneAssociationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/AlleleGeneAssociationExecutor.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
@@ -73,8 +74,8 @@ public class AlleleGeneAssociationExecutor extends LoadFileExecutor {
 	
 	protected boolean runLoad(BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<AlleleGeneAssociationDTO> associationDtos, List<Long> idsAdded, String countType, boolean isFullLoad) {
 		if (Thread.currentThread().isInterrupted()) {
-			history.setErrorMessage("Thread isInterrupted");
-			throw new RuntimeException("Thread isInterrupted");
+			history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+			throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 		}
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.addDisplayHandler(loadProcessDisplayService);
@@ -117,8 +118,8 @@ public class AlleleGeneAssociationExecutor extends LoadFileExecutor {
 				}
 				ph.progressProcess();
 				if (Thread.currentThread().isInterrupted()) {
-					history.setErrorMessage("Thread isInterrupted");
-					throw new RuntimeException("Thread isInterrupted");
+					history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+					throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 				}
 			}
 			updateHistory(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3CDSExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3CDSExecutor.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
@@ -152,8 +153,8 @@ public class Gff3CDSExecutor extends Gff3Executor {
 			}
 			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
-				history.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 		updateHistory(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3ExonExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3ExonExecutor.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
@@ -156,8 +157,8 @@ public class Gff3ExonExecutor extends Gff3Executor {
 
 			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
-				history.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 		updateHistory(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3TranscriptExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3TranscriptExecutor.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
@@ -153,8 +154,8 @@ public class Gff3TranscriptExecutor extends Gff3Executor {
 			}
 			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
-				history.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
+				throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
 			}
 		}
 		updateHistory(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/processors/BulkLoadProcessor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/processors/BulkLoadProcessor.java
@@ -215,7 +215,6 @@ public class BulkLoadProcessor {
 		bulkLoadFileHistory.setErrorMessage(message);
 		bulkLoadFileHistory.setBulkloadStatus(status);
 		bulkLoadFileHistory.setLoadFinished(LocalDateTime.now());
-		Thread.interrupted();
 		slackNotifier.slackalert(bulkLoadFileHistory);
 		
 		bulkLoadFileHistory.setRunningThreadName(null); // Clears the name once finished

--- a/src/main/java/org/alliancegenome/curation_api/jobs/processors/BulkLoadProcessor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/processors/BulkLoadProcessor.java
@@ -215,6 +215,7 @@ public class BulkLoadProcessor {
 		bulkLoadFileHistory.setErrorMessage(message);
 		bulkLoadFileHistory.setBulkloadStatus(status);
 		bulkLoadFileHistory.setLoadFinished(LocalDateTime.now());
+		Thread.interrupted();
 		slackNotifier.slackalert(bulkLoadFileHistory);
 		
 		bulkLoadFileHistory.setRunningThreadName(null); // Clears the name once finished

--- a/src/main/java/org/alliancegenome/curation_api/jobs/processors/StartLoadProcessor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/processors/StartLoadProcessor.java
@@ -6,6 +6,7 @@ import java.io.StringWriter;
 import org.alliancegenome.curation_api.dao.loads.BulkLoadFileHistoryDAO;
 import org.alliancegenome.curation_api.enums.BulkLoadCleanUp;
 import org.alliancegenome.curation_api.enums.JobStatus;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.jobs.events.StartedLoadJobEvent;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 
@@ -42,11 +43,13 @@ public class StartLoadProcessor extends BulkLoadProcessor {
 			// This gets run when quarkus is in Dev Mode
 			bulkLoadFileHistory.setErrorMessage(formatStackTrace(e));
 
-			endLoad(bulkLoadFileHistory, "Failed loading: " + bulkLoadFileHistory.getBulkLoad().getName() + " please check the logs for more info. " + bulkLoadFileHistory.getErrorMessage(), JobStatus.FAILED);
-			Log.error("Load File: " + bulkLoadFileHistory.getBulkLoad().getName() + " is failed");
-			if (!bulkLoadFileHistory.getErrorMessage().equals("Thread isInterrupted")) {
+			if (!bulkLoadFileHistory.getErrorMessage().equals(ApiErrorException.INTERRUPTED_MESSAGE)) {
+				Thread.interrupted();
 				e.printStackTrace();
 			}
+			
+			endLoad(bulkLoadFileHistory, "Failed loading: " + bulkLoadFileHistory.getBulkLoad().getName() + " please check the logs for more info. " + bulkLoadFileHistory.getErrorMessage(), JobStatus.FAILED);
+			Log.error("Load File: " + bulkLoadFileHistory.getBulkLoad().getName() + " is failed");
 		}
 
 	}


### PR DESCRIPTION
## Summary
- Clear thread interrupt flag before sending Slack notification in `endLoad`, fixing `InterruptedIOException` that prevented stopped load notifications from being sent
- Sort dependent files alphabetically in the bulk load edit dialog

## Test plan
- [ ] Start a bulk load (e.g. SGD Gene), stop it, and verify Slack notification is sent
- [ ] Open the bulk load edit dialog and verify dependencies are listed in alphabetical order

🤖 Generated with [Claude Code](https://claude.com/claude-code)