### PR TITLE
Release v0.47.10

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
@@ -79,7 +79,7 @@ public class DoTermDAO extends BaseSQLDAO<DOTerm> {
 	public List<Object[]> findAllGeneSymbols() {
 		String sql = """
 			SELECT sa.singlegene_id, sa.displaytext, sp.abbreviation,
-				split_part(taxon.name, ' ', 1) || ' ' || split_part(taxon.name, ' ', 2) AS genus_species
+				sp.fullname AS genus_species
 			FROM slotannotation sa
 			JOIN biologicalentity be ON be.id = sa.singlegene_id
 			JOIN ontologyterm taxon ON taxon.id = be.taxon_id


### PR DESCRIPTION
## Summary
- Use `species.fullName` instead of `split_part(taxon.name)` for `associatedSpecies` on disease search result documents

## Test plan
- [ ] Deploy to production
- [ ] Trigger disease search result reindex
- [ ] Verify disease search results show correct species names