### PR TITLE
feat: add diseasesWithParents to allele summary documents (SCRUM-5829)

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
@@ -751,6 +751,46 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 			alleleDiseaseAgrSlimMap.computeIfAbsent(alleleId, k -> new java.util.HashSet<>()).add(slimName);
 		}
 
+		// Disease names with all parent terms per allele
+		String diseaseWithParentsQueryString = """
+			SELECT allele_id, doterm.name AS direct_name, ancestor.name AS ancestor_name
+			FROM (
+				SELECT DISTINCT ada.diseaseannotationsubject_id AS allele_id, da.diseaseannotationobject_id AS doterm_id
+				FROM allelediseaseannotation ada
+				JOIN diseaseannotation da ON da.id = ada.id
+				WHERE ada.diseaseannotationsubject_id IN :alleleIds
+				UNION
+				SELECT DISTINCT agm.inferredallele_id AS allele_id, da.diseaseannotationobject_id AS doterm_id
+				FROM agmdiseaseannotation agm
+				JOIN diseaseannotation da ON da.id = agm.id
+				WHERE agm.inferredallele_id IN :alleleIds
+				UNION
+				SELECT DISTINCT agma.assertedalleles_id AS allele_id, da.diseaseannotationobject_id AS doterm_id
+				FROM agmdiseaseannotation_allele agma
+				JOIN agmdiseaseannotation agm ON agm.id = agma.agmdiseaseannotation_id
+				JOIN diseaseannotation da ON da.id = agm.id
+				WHERE agma.assertedalleles_id IN :alleleIds
+			) allele_diseases
+			JOIN ontologyterm doterm ON doterm.id = allele_diseases.doterm_id
+			LEFT JOIN ontologytermclosure otc ON otc.closuresubject_id = allele_diseases.doterm_id
+			LEFT JOIN ontologyterm ancestor ON ancestor.id = otc.closureobject_id
+				AND ancestor.ontologytermtype = 'DOTerm'
+			""";
+		Query diseaseWithParentsQuery = entityManager.createNativeQuery(diseaseWithParentsQueryString);
+		diseaseWithParentsQuery.setParameter("alleleIds", alleleIds);
+		List<Object[]> diseaseWithParentsResults = diseaseWithParentsQuery.getResultList();
+
+		Map<Long, Set<String>> alleleDiseaseWithParentsMap = new HashMap<>();
+		for (Object[] row : diseaseWithParentsResults) {
+			Long alleleId = (Long) row[0];
+			String directName = (String) row[1];
+			String ancestorName = (String) row[2];
+			alleleDiseaseWithParentsMap.computeIfAbsent(alleleId, k -> new java.util.HashSet<>()).add(directName);
+			if (ancestorName != null) {
+				alleleDiseaseWithParentsMap.computeIfAbsent(alleleId, k -> new java.util.HashSet<>()).add(ancestorName);
+			}
+		}
+
 		// Disease names per allele
 		String diseaseNamesQueryString = """
 			SELECT DISTINCT allele_id, doterm.name
@@ -821,6 +861,7 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 			doc.setHasPhenotype(allelesWithPhenotype.contains(allele.getId()));
 			doc.setHasDisease(allelesWithDisease.contains(allele.getId()));
 			doc.setDiseases(alleleDiseaseNamesMap.get(allele.getId()));
+			doc.setDiseasesWithParents(alleleDiseaseWithParentsMap.get(allele.getId()));
 			doc.setDiseasesAgrSlim(alleleDiseaseAgrSlimMap.get(allele.getId()));
 			doc.setConstructExpressedComponents(alleleConstructExpressedComponentsMap.get(allele.getId()));
 			doc.setConstructRegulatoryRegions(alleleConstructRegulatoryRegionsMap.get(allele.getId()));

--- a/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -748,7 +749,7 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 		for (Object[] row : diseaseAgrSlimResults) {
 			Long alleleId = (Long) row[0];
 			String slimName = (String) row[1];
-			alleleDiseaseAgrSlimMap.computeIfAbsent(alleleId, k -> new java.util.HashSet<>()).add(slimName);
+			alleleDiseaseAgrSlimMap.computeIfAbsent(alleleId, k -> new HashSet<>()).add(slimName);
 		}
 
 		// Disease names with all parent terms per allele
@@ -785,9 +786,9 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 			Long alleleId = (Long) row[0];
 			String directName = (String) row[1];
 			String ancestorName = (String) row[2];
-			alleleDiseaseWithParentsMap.computeIfAbsent(alleleId, k -> new java.util.HashSet<>()).add(directName);
+			alleleDiseaseWithParentsMap.computeIfAbsent(alleleId, k -> new HashSet<>()).add(directName);
 			if (ancestorName != null) {
-				alleleDiseaseWithParentsMap.computeIfAbsent(alleleId, k -> new java.util.HashSet<>()).add(ancestorName);
+				alleleDiseaseWithParentsMap.computeIfAbsent(alleleId, k -> new HashSet<>()).add(ancestorName);
 			}
 		}
 
@@ -821,7 +822,7 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 		for (Object[] row : diseaseNamesResults) {
 			Long alleleId = (Long) row[0];
 			String diseaseName = (String) row[1];
-			alleleDiseaseNamesMap.computeIfAbsent(alleleId, k -> new java.util.HashSet<>()).add(diseaseName);
+			alleleDiseaseNamesMap.computeIfAbsent(alleleId, k -> new HashSet<>()).add(diseaseName);
 		}
 
 		// Construct components per allele (expressed, regulatory, knockdown)
@@ -846,9 +847,9 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 			String componentSymbol = (String) row[1];
 			String relationName = (String) row[2];
 			switch (relationName) {
-				case "expresses" -> alleleConstructExpressedComponentsMap.computeIfAbsent(alleleId, k -> new java.util.HashSet<>()).add(componentSymbol);
-				case "is_regulated_by" -> alleleConstructRegulatoryRegionsMap.computeIfAbsent(alleleId, k -> new java.util.HashSet<>()).add(componentSymbol);
-				case "targets" -> alleleConstructKnockdownComponentsMap.computeIfAbsent(alleleId, k -> new java.util.HashSet<>()).add(componentSymbol);
+				case "expresses" -> alleleConstructExpressedComponentsMap.computeIfAbsent(alleleId, k -> new HashSet<>()).add(componentSymbol);
+				case "is_regulated_by" -> alleleConstructRegulatoryRegionsMap.computeIfAbsent(alleleId, k -> new HashSet<>()).add(componentSymbol);
+				case "targets" -> alleleConstructKnockdownComponentsMap.computeIfAbsent(alleleId, k -> new HashSet<>()).add(componentSymbol);
 			}
 		}
 

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/AlleleSummaryDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/AlleleSummaryDocument.java
@@ -28,6 +28,7 @@ public class AlleleSummaryDocument extends AVSParentDocument {
 	private CrossReference crossReference;
 	private List<Variant> variants;
 	private Set<String> diseases;
+	private Set<String> diseasesWithParents;
 	private Set<String> diseasesAgrSlim;
 	private Set<String> constructExpressedComponents;
 	private Set<String> constructRegulatoryRegions;
@@ -39,6 +40,15 @@ public class AlleleSummaryDocument extends AVSParentDocument {
 			geneIds = new HashSet<>();
 		}
 		geneIds.add(alleleOfGene.getPrimaryExternalId());
+	}
+
+	public void removeTransportFields() {
+		diseases = null;
+		diseasesWithParents = null;
+		diseasesAgrSlim = null;
+		constructExpressedComponents = null;
+		constructRegulatoryRegions = null;
+		constructKnockdownComponents = null;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `diseasesWithParents` field to `AlleleSummaryDocument` populated via ontology closure from allele disease annotations (direct, AGM inferred, AGM asserted)
- Add `removeTransportFields()` to null out fields only needed by derived ES documents before indexing `allele_summary` to ES: `diseases`, `diseasesWithParents`, `diseasesAgrSlim`, `constructExpressedComponents`, `constructRegulatoryRegions`, `constructKnockdownComponents`

## Context
Disease search results show Gene and Model related data but not Allele because the `diseasesWithParents` field was missing from allele documents. The `SearchService.addRelatedDataLinks` queries alleles by `diseasesWithParents` to compute cross-links.

## Test plan
- [ ] Deploy to production, rebuild indexer
- [ ] Verify allele documents in ES contain `diseasesWithParents`
- [ ] Verify disease search results show Allele related data count
- [ ] Verify `allele_summary` ES documents do NOT contain transport-only fields