### PR TITLE
SCRUM-5829 SCRUM-5931: Gene search models, species on allele docs, nameKey consistency, GFF batch performance

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/CodingSequenceDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/CodingSequenceDAO.java
@@ -17,6 +17,18 @@ public class CodingSequenceDAO extends BaseSQLDAO<CodingSequence> {
 		super(CodingSequence.class);
 	}
 
+	public List<Long> findIdsByDataProvider(String dataProvider, String taxonCurie) {
+		String jpql = "SELECT c.id FROM CodingSequence c WHERE c.dataProvider.abbreviation = :dp";
+		if (taxonCurie != null) {
+			jpql += " AND c.taxon.curie = :taxon";
+		}
+		var query = entityManager.createQuery(jpql, Long.class).setParameter("dp", dataProvider);
+		if (taxonCurie != null) {
+			query.setParameter("taxon", taxonCurie);
+		}
+		return query.getResultList();
+	}
+
 	public Map<String, CodingSequence> findByUniqueIds(Collection<String> uniqueIds) {
 		if (uniqueIds == null || uniqueIds.isEmpty()) {
 			return new HashMap<>();

--- a/src/main/java/org/alliancegenome/curation_api/dao/CodingSequenceDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/CodingSequenceDAO.java
@@ -1,5 +1,10 @@
 package org.alliancegenome.curation_api.dao;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.CodingSequence;
 
@@ -10,6 +15,21 @@ public class CodingSequenceDAO extends BaseSQLDAO<CodingSequence> {
 
 	protected CodingSequenceDAO() {
 		super(CodingSequence.class);
+	}
+
+	public Map<String, CodingSequence> findByUniqueIds(Collection<String> uniqueIds) {
+		if (uniqueIds == null || uniqueIds.isEmpty()) {
+			return new HashMap<>();
+		}
+		List<CodingSequence> results = entityManager
+			.createQuery("SELECT c FROM CodingSequence c WHERE c.uniqueId IN :uniqueIds", CodingSequence.class)
+			.setParameter("uniqueIds", uniqueIds)
+			.getResultList();
+		Map<String, CodingSequence> map = new HashMap<>();
+		for (CodingSequence cds : results) {
+			map.put(cds.getUniqueId(), cds);
+		}
+		return map;
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/ExonDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ExonDAO.java
@@ -17,6 +17,18 @@ public class ExonDAO extends BaseSQLDAO<Exon> {
 		super(Exon.class);
 	}
 
+	public List<Long> findIdsByDataProvider(String dataProvider, String taxonCurie) {
+		String jpql = "SELECT e.id FROM Exon e WHERE e.dataProvider.abbreviation = :dp";
+		if (taxonCurie != null) {
+			jpql += " AND e.taxon.curie = :taxon";
+		}
+		var query = entityManager.createQuery(jpql, Long.class).setParameter("dp", dataProvider);
+		if (taxonCurie != null) {
+			query.setParameter("taxon", taxonCurie);
+		}
+		return query.getResultList();
+	}
+
 	public Map<String, Exon> findByUniqueIds(Collection<String> uniqueIds) {
 		if (uniqueIds == null || uniqueIds.isEmpty()) {
 			return new HashMap<>();

--- a/src/main/java/org/alliancegenome/curation_api/dao/ExonDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ExonDAO.java
@@ -1,5 +1,10 @@
 package org.alliancegenome.curation_api.dao;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.Exon;
 
@@ -10,6 +15,21 @@ public class ExonDAO extends BaseSQLDAO<Exon> {
 
 	protected ExonDAO() {
 		super(Exon.class);
+	}
+
+	public Map<String, Exon> findByUniqueIds(Collection<String> uniqueIds) {
+		if (uniqueIds == null || uniqueIds.isEmpty()) {
+			return new HashMap<>();
+		}
+		List<Exon> results = entityManager
+			.createQuery("SELECT e FROM Exon e WHERE e.uniqueId IN :uniqueIds", Exon.class)
+			.setParameter("uniqueIds", uniqueIds)
+			.getResultList();
+		Map<String, Exon> map = new HashMap<>();
+		for (Exon exon : results) {
+			map.put(exon.getUniqueId(), exon);
+		}
+		return map;
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
@@ -487,6 +487,23 @@ public class GeneDAO extends BaseSQLDAO<Gene> {
 			""", geneIds);
 	}
 
+	public Map<Long, Set<String>> getGeneModels(List<Long> geneIds) {
+		if (CollectionUtils.isEmpty(geneIds)) {
+			return new HashMap<>();
+		}
+		return runJdbcSetQuery("""
+			SELECT ag.allelegeneassociationobject_id, slag.formattext
+			FROM allelegeneassociation ag
+			JOIN allele a ON a.id = ag.alleleassociationsubject_id
+			JOIN agmalleleassociation aa ON aa.agmalleleassociationobject_id = a.id
+			JOIN affectedgenomicmodel agm ON agm.id = aa.agmassociationsubject_id
+			JOIN slotannotation slag ON slag.singleagm_id = agm.id AND slag.slotannotationtype = 'AgmFullNameSlotAnnotation'
+			WHERE ag.allelegeneassociationobject_id IN :geneIds
+			AND ag.internal = false AND ag.obsolete = false
+			AND aa.internal = false AND aa.obsolete = false
+			""", geneIds);
+	}
+
 	public List<Object[]> getGeneDescriptions(List<Long> geneIds) {
 		if (CollectionUtils.isEmpty(geneIds)) {
 			return new ArrayList<>();

--- a/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,6 +43,27 @@ public class GeneDAO extends BaseSQLDAO<Gene> {
 
 	protected GeneDAO() {
 		super(Gene.class);
+	}
+
+	public Map<String, Gene> findByIdentifiers(Collection<String> identifiers) {
+		if (identifiers == null || identifiers.isEmpty()) {
+			return new HashMap<>();
+		}
+		List<Gene> results = entityManager.createQuery(
+				"SELECT g FROM Gene g WHERE g.primaryExternalId IN :ids OR g.modInternalId IN :ids",
+				Gene.class)
+			.setParameter("ids", identifiers)
+			.getResultList();
+		Map<String, Gene> map = new HashMap<>();
+		for (Gene g : results) {
+			if (g.getPrimaryExternalId() != null) {
+				map.put(g.getPrimaryExternalId(), g);
+			}
+			if (g.getModInternalId() != null) {
+				map.put(g.getModInternalId(), g);
+			}
+		}
+		return map;
 	}
 
 	public Boolean hasReferencingDiseaseAnnotations(Long geneId) {

--- a/src/main/java/org/alliancegenome/curation_api/dao/TranscriptDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/TranscriptDAO.java
@@ -24,6 +24,18 @@ public class TranscriptDAO extends BaseSQLDAO<Transcript> {
 		super(Transcript.class);
 	}
 
+	public List<Long> findIdsByDataProvider(String dataProvider, String taxonCurie) {
+		String jpql = "SELECT t.id FROM Transcript t WHERE t.dataProvider.abbreviation = :dp";
+		if (taxonCurie != null) {
+			jpql += " AND t.taxon.curie = :taxon";
+		}
+		var query = entityManager.createQuery(jpql, Long.class).setParameter("dp", dataProvider);
+		if (taxonCurie != null) {
+			query.setParameter("taxon", taxonCurie);
+		}
+		return query.getResultList();
+	}
+
 	public Map<String, Transcript> findByModInternalIds(Collection<String> modInternalIds) {
 		if (modInternalIds == null || modInternalIds.isEmpty()) {
 			return new HashMap<>();

--- a/src/main/java/org/alliancegenome/curation_api/dao/TranscriptDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/TranscriptDAO.java
@@ -1,5 +1,10 @@
 package org.alliancegenome.curation_api.dao;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.PredictedVariantConsequence;
@@ -12,11 +17,26 @@ import jakarta.inject.Inject;
 
 @ApplicationScoped
 public class TranscriptDAO extends BaseSQLDAO<Transcript> {
-	
+
 	@Inject PredictedVariantConsequenceDAO pvcDAO;
 
 	protected TranscriptDAO() {
 		super(Transcript.class);
+	}
+
+	public Map<String, Transcript> findByModInternalIds(Collection<String> modInternalIds) {
+		if (modInternalIds == null || modInternalIds.isEmpty()) {
+			return new HashMap<>();
+		}
+		List<Transcript> results = entityManager
+			.createQuery("SELECT t FROM Transcript t WHERE t.modInternalId IN :ids", Transcript.class)
+			.setParameter("ids", modInternalIds)
+			.getResultList();
+		Map<String, Transcript> map = new HashMap<>();
+		for (Transcript t : results) {
+			map.put(t.getModInternalId(), t);
+		}
+		return map;
 	}
 
 	public Boolean hasReferencingPredictedVariantConsequences(Long transcriptId) {

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/CodingSequenceGenomicLocationAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/CodingSequenceGenomicLocationAssociationDAO.java
@@ -22,9 +22,9 @@ public class CodingSequenceGenomicLocationAssociationDAO extends BaseSQLDAO<Codi
 			return new HashMap<>();
 		}
 		List<CodingSequenceGenomicLocationAssociation> results = entityManager.createQuery(
-				"SELECT a FROM CodingSequenceGenomicLocationAssociation a" +
-				" WHERE a.codingSequenceAssociationSubject.id IN :cdsIds" +
-				" AND a.codingSequenceGenomicLocationAssociationObject.genomeAssembly.primaryExternalId = :assemblyId",
+				"SELECT a FROM CodingSequenceGenomicLocationAssociation a"
+				+ " WHERE a.codingSequenceAssociationSubject.id IN :cdsIds"
+				+ " AND a.codingSequenceGenomicLocationAssociationObject.genomeAssembly.primaryExternalId = :assemblyId",
 				CodingSequenceGenomicLocationAssociation.class)
 			.setParameter("cdsIds", cdsIds)
 			.setParameter("assemblyId", assemblyId)

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/CodingSequenceGenomicLocationAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/CodingSequenceGenomicLocationAssociationDAO.java
@@ -1,5 +1,10 @@
 package org.alliancegenome.curation_api.dao.associations;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.associations.CodingSequenceGenomicLocationAssociation;
 
@@ -10,6 +15,25 @@ public class CodingSequenceGenomicLocationAssociationDAO extends BaseSQLDAO<Codi
 
 	protected CodingSequenceGenomicLocationAssociationDAO() {
 		super(CodingSequenceGenomicLocationAssociation.class);
+	}
+
+	public Map<Long, CodingSequenceGenomicLocationAssociation> findByCdsIdsAndAssembly(Collection<Long> cdsIds, String assemblyId) {
+		if (cdsIds == null || cdsIds.isEmpty()) {
+			return new HashMap<>();
+		}
+		List<CodingSequenceGenomicLocationAssociation> results = entityManager.createQuery(
+				"SELECT a FROM CodingSequenceGenomicLocationAssociation a" +
+				" WHERE a.codingSequenceAssociationSubject.id IN :cdsIds" +
+				" AND a.codingSequenceGenomicLocationAssociationObject.genomeAssembly.primaryExternalId = :assemblyId",
+				CodingSequenceGenomicLocationAssociation.class)
+			.setParameter("cdsIds", cdsIds)
+			.setParameter("assemblyId", assemblyId)
+			.getResultList();
+		Map<Long, CodingSequenceGenomicLocationAssociation> map = new HashMap<>();
+		for (CodingSequenceGenomicLocationAssociation a : results) {
+			map.put(a.getCodingSequenceAssociationSubject().getId(), a);
+		}
+		return map;
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/CodingSequenceGenomicLocationAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/CodingSequenceGenomicLocationAssociationDAO.java
@@ -17,6 +17,19 @@ public class CodingSequenceGenomicLocationAssociationDAO extends BaseSQLDAO<Codi
 		super(CodingSequenceGenomicLocationAssociation.class);
 	}
 
+	public List<Long> findIdsByDataProvider(String dataProvider, String taxonCurie) {
+		String jpql = "SELECT a.id FROM CodingSequenceGenomicLocationAssociation a"
+			+ " WHERE a.codingSequenceAssociationSubject.dataProvider.abbreviation = :dp";
+		if (taxonCurie != null) {
+			jpql += " AND a.codingSequenceAssociationSubject.taxon.curie = :taxon";
+		}
+		var query = entityManager.createQuery(jpql, Long.class).setParameter("dp", dataProvider);
+		if (taxonCurie != null) {
+			query.setParameter("taxon", taxonCurie);
+		}
+		return query.getResultList();
+	}
+
 	public Map<Long, CodingSequenceGenomicLocationAssociation> findByCdsIdsAndAssembly(Collection<Long> cdsIds, String assemblyId) {
 		if (cdsIds == null || cdsIds.isEmpty()) {
 			return new HashMap<>();

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/ExonGenomicLocationAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/ExonGenomicLocationAssociationDAO.java
@@ -22,9 +22,9 @@ public class ExonGenomicLocationAssociationDAO extends BaseSQLDAO<ExonGenomicLoc
 			return new HashMap<>();
 		}
 		List<ExonGenomicLocationAssociation> results = entityManager.createQuery(
-				"SELECT a FROM ExonGenomicLocationAssociation a" +
-				" WHERE a.exonAssociationSubject.id IN :exonIds" +
-				" AND a.exonGenomicLocationAssociationObject.genomeAssembly.primaryExternalId = :assemblyId",
+				"SELECT a FROM ExonGenomicLocationAssociation a"
+				+ " WHERE a.exonAssociationSubject.id IN :exonIds"
+				+ " AND a.exonGenomicLocationAssociationObject.genomeAssembly.primaryExternalId = :assemblyId",
 				ExonGenomicLocationAssociation.class)
 			.setParameter("exonIds", exonIds)
 			.setParameter("assemblyId", assemblyId)

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/ExonGenomicLocationAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/ExonGenomicLocationAssociationDAO.java
@@ -17,6 +17,19 @@ public class ExonGenomicLocationAssociationDAO extends BaseSQLDAO<ExonGenomicLoc
 		super(ExonGenomicLocationAssociation.class);
 	}
 
+	public List<Long> findIdsByDataProvider(String dataProvider, String taxonCurie) {
+		String jpql = "SELECT a.id FROM ExonGenomicLocationAssociation a"
+			+ " WHERE a.exonAssociationSubject.dataProvider.abbreviation = :dp";
+		if (taxonCurie != null) {
+			jpql += " AND a.exonAssociationSubject.taxon.curie = :taxon";
+		}
+		var query = entityManager.createQuery(jpql, Long.class).setParameter("dp", dataProvider);
+		if (taxonCurie != null) {
+			query.setParameter("taxon", taxonCurie);
+		}
+		return query.getResultList();
+	}
+
 	public Map<Long, ExonGenomicLocationAssociation> findByExonIdsAndAssembly(Collection<Long> exonIds, String assemblyId) {
 		if (exonIds == null || exonIds.isEmpty()) {
 			return new HashMap<>();

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/ExonGenomicLocationAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/ExonGenomicLocationAssociationDAO.java
@@ -1,5 +1,10 @@
 package org.alliancegenome.curation_api.dao.associations;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.associations.ExonGenomicLocationAssociation;
 
@@ -10,6 +15,25 @@ public class ExonGenomicLocationAssociationDAO extends BaseSQLDAO<ExonGenomicLoc
 
 	protected ExonGenomicLocationAssociationDAO() {
 		super(ExonGenomicLocationAssociation.class);
+	}
+
+	public Map<Long, ExonGenomicLocationAssociation> findByExonIdsAndAssembly(Collection<Long> exonIds, String assemblyId) {
+		if (exonIds == null || exonIds.isEmpty()) {
+			return new HashMap<>();
+		}
+		List<ExonGenomicLocationAssociation> results = entityManager.createQuery(
+				"SELECT a FROM ExonGenomicLocationAssociation a" +
+				" WHERE a.exonAssociationSubject.id IN :exonIds" +
+				" AND a.exonGenomicLocationAssociationObject.genomeAssembly.primaryExternalId = :assemblyId",
+				ExonGenomicLocationAssociation.class)
+			.setParameter("exonIds", exonIds)
+			.setParameter("assemblyId", assemblyId)
+			.getResultList();
+		Map<Long, ExonGenomicLocationAssociation> map = new HashMap<>();
+		for (ExonGenomicLocationAssociation a : results) {
+			map.put(a.getExonAssociationSubject().getId(), a);
+		}
+		return map;
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptCodingSequenceAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptCodingSequenceAssociationDAO.java
@@ -22,8 +22,8 @@ public class TranscriptCodingSequenceAssociationDAO extends BaseSQLDAO<Transcrip
 			return new HashMap<>();
 		}
 		List<TranscriptCodingSequenceAssociation> results = entityManager.createQuery(
-				"SELECT a FROM TranscriptCodingSequenceAssociation a" +
-				" WHERE a.transcriptCodingSequenceAssociationObject.id IN :cdsIds",
+				"SELECT a FROM TranscriptCodingSequenceAssociation a"
+				+ " WHERE a.transcriptCodingSequenceAssociationObject.id IN :cdsIds",
 				TranscriptCodingSequenceAssociation.class)
 			.setParameter("cdsIds", cdsIds)
 			.getResultList();

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptCodingSequenceAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptCodingSequenceAssociationDAO.java
@@ -17,6 +17,19 @@ public class TranscriptCodingSequenceAssociationDAO extends BaseSQLDAO<Transcrip
 		super(TranscriptCodingSequenceAssociation.class);
 	}
 
+	public List<Long> findIdsByDataProvider(String dataProvider, String taxonCurie) {
+		String jpql = "SELECT a.id FROM TranscriptCodingSequenceAssociation a"
+			+ " WHERE a.transcriptAssociationSubject.dataProvider.abbreviation = :dp";
+		if (taxonCurie != null) {
+			jpql += " AND a.transcriptAssociationSubject.taxon.curie = :taxon";
+		}
+		var query = entityManager.createQuery(jpql, Long.class).setParameter("dp", dataProvider);
+		if (taxonCurie != null) {
+			query.setParameter("taxon", taxonCurie);
+		}
+		return query.getResultList();
+	}
+
 	public Map<Long, TranscriptCodingSequenceAssociation> findByCdsIds(Collection<Long> cdsIds) {
 		if (cdsIds == null || cdsIds.isEmpty()) {
 			return new HashMap<>();

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptCodingSequenceAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptCodingSequenceAssociationDAO.java
@@ -1,5 +1,10 @@
 package org.alliancegenome.curation_api.dao.associations;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptCodingSequenceAssociation;
 
@@ -10,6 +15,23 @@ public class TranscriptCodingSequenceAssociationDAO extends BaseSQLDAO<Transcrip
 
 	protected TranscriptCodingSequenceAssociationDAO() {
 		super(TranscriptCodingSequenceAssociation.class);
+	}
+
+	public Map<Long, TranscriptCodingSequenceAssociation> findByCdsIds(Collection<Long> cdsIds) {
+		if (cdsIds == null || cdsIds.isEmpty()) {
+			return new HashMap<>();
+		}
+		List<TranscriptCodingSequenceAssociation> results = entityManager.createQuery(
+				"SELECT a FROM TranscriptCodingSequenceAssociation a" +
+				" WHERE a.transcriptCodingSequenceAssociationObject.id IN :cdsIds",
+				TranscriptCodingSequenceAssociation.class)
+			.setParameter("cdsIds", cdsIds)
+			.getResultList();
+		Map<Long, TranscriptCodingSequenceAssociation> map = new HashMap<>();
+		for (TranscriptCodingSequenceAssociation a : results) {
+			map.put(a.getTranscriptCodingSequenceAssociationObject().getId(), a);
+		}
+		return map;
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptExonAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptExonAssociationDAO.java
@@ -22,8 +22,8 @@ public class TranscriptExonAssociationDAO extends BaseSQLDAO<TranscriptExonAssoc
 			return new HashMap<>();
 		}
 		List<TranscriptExonAssociation> results = entityManager.createQuery(
-				"SELECT a FROM TranscriptExonAssociation a" +
-				" WHERE a.transcriptExonAssociationObject.id IN :exonIds",
+				"SELECT a FROM TranscriptExonAssociation a"
+				+ " WHERE a.transcriptExonAssociationObject.id IN :exonIds",
 				TranscriptExonAssociation.class)
 			.setParameter("exonIds", exonIds)
 			.getResultList();

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptExonAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptExonAssociationDAO.java
@@ -1,5 +1,10 @@
 package org.alliancegenome.curation_api.dao.associations;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptExonAssociation;
 
@@ -10,6 +15,23 @@ public class TranscriptExonAssociationDAO extends BaseSQLDAO<TranscriptExonAssoc
 
 	protected TranscriptExonAssociationDAO() {
 		super(TranscriptExonAssociation.class);
+	}
+
+	public Map<Long, TranscriptExonAssociation> findByExonIds(Collection<Long> exonIds) {
+		if (exonIds == null || exonIds.isEmpty()) {
+			return new HashMap<>();
+		}
+		List<TranscriptExonAssociation> results = entityManager.createQuery(
+				"SELECT a FROM TranscriptExonAssociation a" +
+				" WHERE a.transcriptExonAssociationObject.id IN :exonIds",
+				TranscriptExonAssociation.class)
+			.setParameter("exonIds", exonIds)
+			.getResultList();
+		Map<Long, TranscriptExonAssociation> map = new HashMap<>();
+		for (TranscriptExonAssociation a : results) {
+			map.put(a.getTranscriptExonAssociationObject().getId(), a);
+		}
+		return map;
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptExonAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptExonAssociationDAO.java
@@ -17,6 +17,19 @@ public class TranscriptExonAssociationDAO extends BaseSQLDAO<TranscriptExonAssoc
 		super(TranscriptExonAssociation.class);
 	}
 
+	public List<Long> findIdsByDataProvider(String dataProvider, String taxonCurie) {
+		String jpql = "SELECT a.id FROM TranscriptExonAssociation a"
+			+ " WHERE a.transcriptAssociationSubject.dataProvider.abbreviation = :dp";
+		if (taxonCurie != null) {
+			jpql += " AND a.transcriptAssociationSubject.taxon.curie = :taxon";
+		}
+		var query = entityManager.createQuery(jpql, Long.class).setParameter("dp", dataProvider);
+		if (taxonCurie != null) {
+			query.setParameter("taxon", taxonCurie);
+		}
+		return query.getResultList();
+	}
+
 	public Map<Long, TranscriptExonAssociation> findByExonIds(Collection<Long> exonIds) {
 		if (exonIds == null || exonIds.isEmpty()) {
 			return new HashMap<>();

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptGeneAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptGeneAssociationDAO.java
@@ -1,5 +1,10 @@
 package org.alliancegenome.curation_api.dao.associations;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptGeneAssociation;
 
@@ -10,6 +15,36 @@ public class TranscriptGeneAssociationDAO extends BaseSQLDAO<TranscriptGeneAssoc
 
 	protected TranscriptGeneAssociationDAO() {
 		super(TranscriptGeneAssociation.class);
+	}
+
+	public List<Long> findIdsByDataProvider(String dataProvider, String taxonCurie) {
+		String jpql = "SELECT a.id FROM TranscriptGeneAssociation a"
+			+ " WHERE a.transcriptAssociationSubject.dataProvider.abbreviation = :dp";
+		if (taxonCurie != null) {
+			jpql += " AND a.transcriptAssociationSubject.taxon.curie = :taxon";
+		}
+		var query = entityManager.createQuery(jpql, Long.class).setParameter("dp", dataProvider);
+		if (taxonCurie != null) {
+			query.setParameter("taxon", taxonCurie);
+		}
+		return query.getResultList();
+	}
+
+	public Map<Long, TranscriptGeneAssociation> findByTranscriptIds(Collection<Long> transcriptIds) {
+		if (transcriptIds == null || transcriptIds.isEmpty()) {
+			return new HashMap<>();
+		}
+		List<TranscriptGeneAssociation> results = entityManager.createQuery(
+				"SELECT a FROM TranscriptGeneAssociation a"
+				+ " WHERE a.transcriptAssociationSubject.id IN :transcriptIds",
+				TranscriptGeneAssociation.class)
+			.setParameter("transcriptIds", transcriptIds)
+			.getResultList();
+		Map<Long, TranscriptGeneAssociation> map = new HashMap<>();
+		for (TranscriptGeneAssociation a : results) {
+			map.put(a.getTranscriptAssociationSubject().getId(), a);
+		}
+		return map;
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptGenomicLocationAssociationDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/associations/TranscriptGenomicLocationAssociationDAO.java
@@ -1,5 +1,10 @@
 package org.alliancegenome.curation_api.dao.associations;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptGenomicLocationAssociation;
 
@@ -10,6 +15,38 @@ public class TranscriptGenomicLocationAssociationDAO extends BaseSQLDAO<Transcri
 
 	protected TranscriptGenomicLocationAssociationDAO() {
 		super(TranscriptGenomicLocationAssociation.class);
+	}
+
+	public List<Long> findIdsByDataProvider(String dataProvider, String taxonCurie) {
+		String jpql = "SELECT a.id FROM TranscriptGenomicLocationAssociation a"
+			+ " WHERE a.transcriptAssociationSubject.dataProvider.abbreviation = :dp";
+		if (taxonCurie != null) {
+			jpql += " AND a.transcriptAssociationSubject.taxon.curie = :taxon";
+		}
+		var query = entityManager.createQuery(jpql, Long.class).setParameter("dp", dataProvider);
+		if (taxonCurie != null) {
+			query.setParameter("taxon", taxonCurie);
+		}
+		return query.getResultList();
+	}
+
+	public Map<Long, TranscriptGenomicLocationAssociation> findByTranscriptIdsAndAssembly(Collection<Long> transcriptIds, String assemblyId) {
+		if (transcriptIds == null || transcriptIds.isEmpty()) {
+			return new HashMap<>();
+		}
+		List<TranscriptGenomicLocationAssociation> results = entityManager.createQuery(
+				"SELECT a FROM TranscriptGenomicLocationAssociation a"
+				+ " WHERE a.transcriptAssociationSubject.id IN :transcriptIds"
+				+ " AND a.transcriptGenomicLocationAssociationObject.genomeAssembly.primaryExternalId = :assemblyId",
+				TranscriptGenomicLocationAssociation.class)
+			.setParameter("transcriptIds", transcriptIds)
+			.setParameter("assemblyId", assemblyId)
+			.getResultList();
+		Map<Long, TranscriptGenomicLocationAssociation> map = new HashMap<>();
+		for (TranscriptGenomicLocationAssociation a : results) {
+			map.put(a.getTranscriptAssociationSubject().getId(), a);
+		}
+		return map;
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/base/BaseSQLDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/base/BaseSQLDAO.java
@@ -3,6 +3,7 @@ package org.alliancegenome.curation_api.dao.base;
 import static org.reflections.scanners.Scanners.TypesAnnotated;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -114,6 +115,17 @@ public class BaseSQLDAO<E extends AuditedObject> extends BaseEntityDAO<E> {
 			handlePersistenceException(entity, e);
 		}
 		return entity;
+	}
+
+	@Transactional
+	public int removeByIds(Collection<Long> ids) {
+		if (ids == null || ids.isEmpty()) {
+			return 0;
+		}
+		return entityManager
+			.createQuery("DELETE FROM " + myClass.getSimpleName() + " e WHERE e.id IN :ids")
+			.setParameter("ids", ids)
+			.executeUpdate();
 	}
 
 	public E find(Long id) {

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/LoadFileExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/LoadFileExecutor.java
@@ -298,10 +298,10 @@ public class LoadFileExecutor {
 			history.setErrorMessage("Thread isInterrupted");
 			throw new RuntimeException("Thread isInterrupted");
 		}
-		Log.debug("runLoad: After: " + dataProviderName + " " + annotationIdsAfter.size());
+		Log.debug("runCleanup: After: " + dataProviderName + " " + annotationIdsAfter.size());
 
 		Set<Long> distinctAfter = new LinkedHashSet<>(annotationIdsAfter);
-		Log.debug("runLoad: Distinct: " + dataProviderName + " " + distinctAfter.size());
+		Log.debug("runCleanup: Distinct: " + dataProviderName + " " + distinctAfter.size());
 
 		List<Long> idsToRemove = new ArrayList<>();
 		for (Long id : annotationIdsBefore) {
@@ -309,7 +309,7 @@ public class LoadFileExecutor {
 				idsToRemove.add(id);
 			}
 		}
-		Log.debug("runLoad: Remove: " + dataProviderName + " " + idsToRemove.size());
+		Log.debug("runCleanup: Remove: " + dataProviderName + " " + idsToRemove.size());
 
 		String countType = loadTypeString + " Deleted";
 
@@ -318,13 +318,15 @@ public class LoadFileExecutor {
 
 		String loadDescription = dataProviderName + " " + loadTypeString + " bulk load (" + history.getBulkLoadFile().getMd5Sum() + ")";
 
-		ProcessDisplayHelper ph = new ProcessDisplayHelper(10000);
-		ph.startProcess("Deletion/deprecation of: " + dataProviderName + " " + loadTypeString, idsToRemove.size());
 		updateHistory(history);
-
+		Log.info("Updated history ready to delete");
+		
 		if (!deprecate) {
 			// Batch delete path — bulk JPQL DELETE, fall back to per-row on FK errors
 			int batchSize = 3000;
+			ProcessDisplayHelper ph = new ProcessDisplayHelper(10000);
+			ph.startProcess("Deletion/deprecation in batches: " + dataProviderName + " " + loadTypeString, idsToRemove.size() / batchSize);
+
 			for (int i = 0; i < idsToRemove.size(); i += batchSize) {
 				int end = Math.min(i + batchSize, idsToRemove.size());
 				List<Long> batch = idsToRemove.subList(i, end);
@@ -332,11 +334,10 @@ public class LoadFileExecutor {
 					service.removeByIds(batch);
 					for (int j = 0; j < batch.size(); j++) {
 						history.incrementCompleted(countType);
-						ph.progressProcess();
 					}
 				} catch (Exception batchEx) {
 					// FK constraint or other error — fall back to per-row for this batch
-					Log.debug("Batch delete failed, falling back to per-row: " + batchEx.getMessage());
+					Log.warn("Batch delete failed, falling back to per-row: " + batchEx.getMessage());
 					for (Long id : batch) {
 						try {
 							service.deprecateOrDelete(id, false, loadDescription, false);
@@ -346,7 +347,6 @@ public class LoadFileExecutor {
 							history.incrementFailed(countType);
 							addException(history, new ObjectUpdateExceptionData(new IdObject(id), e.getMessage(), e.getStackTrace()));
 						}
-						ph.progressProcess();
 					}
 				}
 				if (history.getErrorRate(countType) > 0.25) {
@@ -358,9 +358,14 @@ public class LoadFileExecutor {
 					history.setErrorMessage("Thread isInterrupted");
 					throw new RuntimeException("Thread isInterrupted");
 				}
+				ph.progressProcess();
 			}
+			ph.finishProcess();
 		} else {
 			// Deprecate path — per-row update (sets obsolete=true)
+			ProcessDisplayHelper ph = new ProcessDisplayHelper(10000);
+			ph.startProcess("Deletion/deprecation of: " + dataProviderName + " " + loadTypeString, idsToRemove.size());
+
 			for (Long id : idsToRemove) {
 				try {
 					service.deprecateOrDelete(id, false, loadDescription, deprecate);
@@ -381,10 +386,12 @@ public class LoadFileExecutor {
 					throw new RuntimeException("Thread isInterrupted");
 				}
 			}
+			ph.finishProcess();
 		}
+		Log.info("Saving history");
 		updateHistory(history);
 		updateExceptions(history);
-		ph.finishProcess();
+		Log.info("Finished cleanup");
 	}
 
 	protected void failLoad(BulkLoadFileHistory bulkLoadFileHistory, Exception e) {

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/LoadFileExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/LoadFileExecutor.java
@@ -7,7 +7,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.config.RestDefaultObjectMapper;
@@ -35,7 +34,6 @@ import org.alliancegenome.curation_api.services.base.BaseEntityCrudService;
 import org.alliancegenome.curation_api.services.processing.LoadProcessDisplayService;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -302,10 +300,15 @@ public class LoadFileExecutor {
 		}
 		Log.debug("runLoad: After: " + dataProviderName + " " + annotationIdsAfter.size());
 
-		List<Long> distinctAfter = annotationIdsAfter.stream().distinct().collect(Collectors.toList());
+		Set<Long> distinctAfter = new LinkedHashSet<>(annotationIdsAfter);
 		Log.debug("runLoad: Distinct: " + dataProviderName + " " + distinctAfter.size());
 
-		List<Long> idsToRemove = ListUtils.subtract(annotationIdsBefore, distinctAfter);
+		List<Long> idsToRemove = new ArrayList<>();
+		for (Long id : annotationIdsBefore) {
+			if (!distinctAfter.contains(id)) {
+				idsToRemove.add(id);
+			}
+		}
 		Log.debug("runLoad: Remove: " + dataProviderName + " " + idsToRemove.size());
 
 		String countType = loadTypeString + " Deleted";
@@ -318,24 +321,65 @@ public class LoadFileExecutor {
 		ProcessDisplayHelper ph = new ProcessDisplayHelper(10000);
 		ph.startProcess("Deletion/deprecation of: " + dataProviderName + " " + loadTypeString, idsToRemove.size());
 		updateHistory(history);
-		for (Long id : idsToRemove) {
-			try {
-				service.deprecateOrDelete(id, false, loadDescription, deprecate);
-				history.incrementCompleted(countType);
-			} catch (Exception e) {
-				e.printStackTrace();
-				history.incrementFailed(countType);
-				addException(history, new ObjectUpdateExceptionData(new IdObject(id), e.getMessage(), e.getStackTrace()));
+
+		if (!deprecate) {
+			// Batch delete path — bulk JPQL DELETE, fall back to per-row on FK errors
+			int batchSize = 3000;
+			for (int i = 0; i < idsToRemove.size(); i += batchSize) {
+				int end = Math.min(i + batchSize, idsToRemove.size());
+				List<Long> batch = idsToRemove.subList(i, end);
+				try {
+					service.removeByIds(batch);
+					for (int j = 0; j < batch.size(); j++) {
+						history.incrementCompleted(countType);
+						ph.progressProcess();
+					}
+				} catch (Exception batchEx) {
+					// FK constraint or other error — fall back to per-row for this batch
+					Log.debug("Batch delete failed, falling back to per-row: " + batchEx.getMessage());
+					for (Long id : batch) {
+						try {
+							service.deprecateOrDelete(id, false, loadDescription, false);
+							history.incrementCompleted(countType);
+						} catch (Exception e) {
+							e.printStackTrace();
+							history.incrementFailed(countType);
+							addException(history, new ObjectUpdateExceptionData(new IdObject(id), e.getMessage(), e.getStackTrace()));
+						}
+						ph.progressProcess();
+					}
+				}
+				if (history.getErrorRate(countType) > 0.25) {
+					Log.error(countType + " failure rate > 25% aborting load");
+					failLoadAboveErrorRateCutoff(history);
+					break;
+				}
+				if (Thread.currentThread().isInterrupted()) {
+					history.setErrorMessage("Thread isInterrupted");
+					throw new RuntimeException("Thread isInterrupted");
+				}
 			}
-			if (history.getErrorRate(countType) > 0.25) {
-				Log.error(countType + " failure rate > 25% aborting load");
-				failLoadAboveErrorRateCutoff(history);
-				break;
-			}
-			ph.progressProcess();
-			if (Thread.currentThread().isInterrupted()) {
-				history.setErrorMessage("Thread isInterrupted");
-				throw new RuntimeException("Thread isInterrupted");
+		} else {
+			// Deprecate path — per-row update (sets obsolete=true)
+			for (Long id : idsToRemove) {
+				try {
+					service.deprecateOrDelete(id, false, loadDescription, deprecate);
+					history.incrementCompleted(countType);
+				} catch (Exception e) {
+					e.printStackTrace();
+					history.incrementFailed(countType);
+					addException(history, new ObjectUpdateExceptionData(new IdObject(id), e.getMessage(), e.getStackTrace()));
+				}
+				if (history.getErrorRate(countType) > 0.25) {
+					Log.error(countType + " failure rate > 25% aborting load");
+					failLoadAboveErrorRateCutoff(history);
+					break;
+				}
+				ph.progressProcess();
+				if (Thread.currentThread().isInterrupted()) {
+					history.setErrorMessage("Thread isInterrupted");
+					throw new RuntimeException("Thread isInterrupted");
+				}
 			}
 		}
 		updateHistory(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3CDSExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3CDSExecutor.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
@@ -16,11 +15,9 @@ import org.alliancegenome.curation_api.model.ingest.dto.fms.Gff3DTO;
 import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.LoadHistoryResponce;
 import org.alliancegenome.curation_api.services.CodingSequenceService;
-import org.alliancegenome.curation_api.services.Gff3Service;
 import org.alliancegenome.curation_api.services.associations.CodingSequenceGenomicLocationAssociationService;
 import org.alliancegenome.curation_api.services.associations.TranscriptCodingSequenceAssociationService;
 import org.alliancegenome.curation_api.services.helpers.Gff3AttributesHelper;
-import org.alliancegenome.curation_api.services.validation.dto.Gff3DtoValidator;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -37,11 +34,7 @@ import jakarta.inject.Inject;
 public class Gff3CDSExecutor extends Gff3Executor {
 
 	@Inject
-	Gff3Service gff3Service;
-	@Inject
 	CodingSequenceService cdsService;
-	@Inject
-	Gff3DtoValidator gff3DtoValidator;
 	@Inject
 	CodingSequenceGenomicLocationAssociationService cdsLocationService;
 	@Inject
@@ -113,48 +106,13 @@ public class Gff3CDSExecutor extends Gff3Executor {
 		history.setCount("Associations", gffData.size());
 		updateHistory(history);
 
-		String countType = null;
-		for (ImmutablePair<Gff3DTO, Map<String, String>> gff3EntryPair : gffData) {
+		int batchSize = 3000;
+		for (int i = 0; i < gffData.size(); i += batchSize) {
+			int end = Math.min(i + batchSize, gffData.size());
+			List<ImmutablePair<Gff3DTO, Map<String, String>>> batch = gffData.subList(i, end);
 
-			countType = "Entities";
-			try {
-				gff3DtoValidator.validateCdsEntry(gff3EntryPair.getKey(), gff3EntryPair.getValue(), entityIdsAdded, dataProvider);
-				history.incrementCompleted(countType);
-			} catch (ObjectUpdateException e) {
-				history.incrementFailed(countType);
-				addException(history, e.getData());
-			} catch (Exception e) {
-				e.printStackTrace();
-				history.incrementFailed(countType);
-				addException(history, new ObjectUpdateExceptionData(gff3EntryPair.getKey(), e.getMessage(), e.getStackTrace()));
-			}
-			if (assemblyId != null) {
-				countType = "Locations";
-				try {
-					gff3Service.loadCDSLocationAssociations(gff3EntryPair, locationIdsAdded, dataProvider, assemblyId);
-					history.incrementCompleted(countType);
-				} catch (ObjectUpdateException e) {
-					history.incrementFailed(countType);
-					addException(history, e.getData());
-				} catch (Exception e) {
-					e.printStackTrace();
-					history.incrementFailed(countType);
-					addException(history, new ObjectUpdateExceptionData(gff3EntryPair.getKey(), e.getMessage(), e.getStackTrace()));
-				}
-			}
-			countType = "Associations";
-			try {
-				gff3Service.loadCDSParentChildAssociations(gff3EntryPair, associationIdsAdded, dataProvider);
-				history.incrementCompleted(countType);
-			} catch (ObjectUpdateException e) {
-				history.incrementFailed(countType);
-				addException(history, e.getData());
-			} catch (Exception e) {
-				e.printStackTrace();
-				history.incrementFailed(countType);
-				addException(history, new ObjectUpdateExceptionData(gff3EntryPair.getKey(), e.getMessage(), e.getStackTrace()));
-			}
-			ph.progressProcess();
+			gff3Service.loadCdsBatch(batch, entityIdsAdded, locationIdsAdded, associationIdsAdded, dataProvider, assemblyId, history, ph);
+
 			if (Thread.currentThread().isInterrupted()) {
 				history.setErrorMessage("Thread isInterrupted");
 				throw new RuntimeException("Thread isInterrupted");

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3CDSExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3CDSExecutor.java
@@ -60,8 +60,7 @@ public class Gff3CDSExecutor extends Gff3Executor {
 		List<Gff3DTO> gffFileData = new ArrayList<>();
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.startProcess("GFF CDS header pre-processing", gffRawData.size());
-		while (!gffRawData.isEmpty()) {
-			Gff3DTO gffLine = gffRawData.remove(0);
+		for (Gff3DTO gffLine : gffRawData) {
 			if (gffLine.getSeqId().startsWith("#")) {
 				gffHeaderData.add(gffLine.getSeqId());
 			} else {
@@ -70,6 +69,7 @@ public class Gff3CDSExecutor extends Gff3Executor {
 			ph.progressProcess();
 		}
 		ph.finishProcess();
+		gffRawData.clear();
 
 		BulkFMSLoad fmsLoad = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
 		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fmsLoad.getFmsDataSubType());

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3ExonExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3ExonExecutor.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
@@ -19,7 +18,6 @@ import org.alliancegenome.curation_api.services.ExonService;
 import org.alliancegenome.curation_api.services.associations.ExonGenomicLocationAssociationService;
 import org.alliancegenome.curation_api.services.associations.TranscriptExonAssociationService;
 import org.alliancegenome.curation_api.services.helpers.Gff3AttributesHelper;
-import org.alliancegenome.curation_api.services.validation.dto.Gff3DtoValidator;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -41,8 +39,6 @@ public class Gff3ExonExecutor extends Gff3Executor {
 	ExonGenomicLocationAssociationService exonLocationService;
 	@Inject
 	TranscriptExonAssociationService transcriptExonService;
-	@Inject
-	Gff3DtoValidator gff3DtoValidator;
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) throws Exception {
 
@@ -56,8 +52,7 @@ public class Gff3ExonExecutor extends Gff3Executor {
 		List<Gff3DTO> gffFileData = new ArrayList<>();
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.startProcess("GFF Exon header pre-processing", gffRawData.size());
-		while (!gffRawData.isEmpty()) {
-			Gff3DTO gffLine = gffRawData.remove(0);
+		for (Gff3DTO gffLine : gffRawData) {
 			if (gffLine.getSeqId().startsWith("#")) {
 				gffHeaderData.add(gffLine.getSeqId());
 			} else {
@@ -66,6 +61,7 @@ public class Gff3ExonExecutor extends Gff3Executor {
 			ph.progressProcess();
 		}
 		ph.finishProcess();
+		gffRawData.clear();
 
 		BulkFMSLoad fmsLoad = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
 		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fmsLoad.getFmsDataSubType());
@@ -108,52 +104,13 @@ public class Gff3ExonExecutor extends Gff3Executor {
 		history.setCount("Associations", gffData.size());
 		updateHistory(history);
 
-		String countType = null;
-		for (ImmutablePair<Gff3DTO, Map<String, String>> gff3EntryPair : gffData) {
+		int batchSize = 3000;
+		for (int i = 0; i < gffData.size(); i += batchSize) {
+			int end = Math.min(i + batchSize, gffData.size());
+			List<ImmutablePair<Gff3DTO, Map<String, String>>> batch = gffData.subList(i, end);
 
-			countType = "Entities";
-			try {
-				gff3DtoValidator.validateExonEntry(gff3EntryPair.getKey(), gff3EntryPair.getValue(), entityIdsAdded, dataProvider);
+			gff3Service.loadExonBatch(batch, entityIdsAdded, locationIdsAdded, associationIdsAdded, dataProvider, assemblyId, history, ph);
 
-				history.incrementCompleted(countType);
-			} catch (ObjectUpdateException e) {
-				history.incrementFailed(countType);
-				addException(history, e.getData());
-			} catch (Exception e) {
-				e.printStackTrace();
-				history.incrementFailed(countType);
-				addException(history, new ObjectUpdateExceptionData(gff3EntryPair.getKey(), e.getMessage(), e.getStackTrace()));
-			}
-
-			if (assemblyId != null) {
-				countType = "Locations";
-				try {
-					gff3Service.loadExonLocationAssociations(gff3EntryPair, locationIdsAdded, dataProvider, assemblyId);
-					history.incrementCompleted(countType);
-				} catch (ObjectUpdateException e) {
-					history.incrementFailed(countType);
-					addException(history, e.getData());
-				} catch (Exception e) {
-					e.printStackTrace();
-					history.incrementFailed(countType);
-					addException(history, new ObjectUpdateExceptionData(gff3EntryPair.getKey(), e.getMessage(), e.getStackTrace()));
-				}
-			}
-
-			countType = "Associations";
-			try {
-				gff3Service.loadExonParentChildAssociations(gff3EntryPair, associationIdsAdded, dataProvider);
-				history.incrementCompleted(countType);
-			} catch (ObjectUpdateException e) {
-				history.incrementFailed(countType);
-				addException(history, e.getData());
-			} catch (Exception e) {
-				e.printStackTrace();
-				history.incrementFailed(countType);
-				addException(history, new ObjectUpdateExceptionData(gff3EntryPair.getKey(), e.getMessage(), e.getStackTrace()));
-			}
-
-			ph.progressProcess();
 			if (Thread.currentThread().isInterrupted()) {
 				history.setErrorMessage("Thread isInterrupted");
 				throw new RuntimeException("Thread isInterrupted");

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3GeneExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3GeneExecutor.java
@@ -51,8 +51,7 @@ public class Gff3GeneExecutor extends Gff3Executor {
 		List<Gff3DTO> gffFileData = new ArrayList<>();
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.startProcess("GFF Gene header pre-processing", gffRawData.size());
-		while (!gffRawData.isEmpty()) {
-			Gff3DTO gffLine = gffRawData.remove(0);
+		for (Gff3DTO gffLine : gffRawData) {
 			if (gffLine.getSeqId().startsWith("#")) {
 				gffHeaderData.add(gffLine.getSeqId());
 			} else {
@@ -61,6 +60,7 @@ public class Gff3GeneExecutor extends Gff3Executor {
 			ph.progressProcess();
 		}
 		ph.finishProcess();
+		gffRawData.clear();
 
 		BulkFMSLoad fmsLoad = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
 		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fmsLoad.getFmsDataSubType());

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3TranscriptExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3TranscriptExecutor.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
-import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
@@ -19,7 +18,6 @@ import org.alliancegenome.curation_api.services.TranscriptService;
 import org.alliancegenome.curation_api.services.associations.TranscriptGeneAssociationService;
 import org.alliancegenome.curation_api.services.associations.TranscriptGenomicLocationAssociationService;
 import org.alliancegenome.curation_api.services.helpers.Gff3AttributesHelper;
-import org.alliancegenome.curation_api.services.validation.dto.Gff3DtoValidator;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -41,8 +39,6 @@ public class Gff3TranscriptExecutor extends Gff3Executor {
 	TranscriptGenomicLocationAssociationService transcriptLocationService;
 	@Inject
 	TranscriptGeneAssociationService transcriptGeneService;
-	@Inject
-	Gff3DtoValidator gff3DtoValidator;
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) throws Exception {
 
@@ -110,48 +106,13 @@ public class Gff3TranscriptExecutor extends Gff3Executor {
 		history.setCount("Associations", gffData.size());
 		updateHistory(history);
 
-		String countType = null;
-		for (ImmutablePair<Gff3DTO, Map<String, String>> gff3EntryPair : gffData) {
-			countType = "Entities";
-			try {
-				gff3DtoValidator.validateTranscriptEntry(gff3EntryPair.getKey(), gff3EntryPair.getValue(), entityIdsAdded, dataProvider);
-				history.incrementCompleted(countType);
-			} catch (ObjectUpdateException e) {
-				history.incrementFailed(countType);
-				addException(history, e.getData());
-			} catch (Exception e) {
-				e.printStackTrace();
-				history.incrementFailed(countType);
-				addException(history, new ObjectUpdateExceptionData(gff3EntryPair.getKey(), e.getMessage(), e.getStackTrace()));
-			}
+		int batchSize = 3000;
+		for (int i = 0; i < gffData.size(); i += batchSize) {
+			int end = Math.min(i + batchSize, gffData.size());
+			List<ImmutablePair<Gff3DTO, Map<String, String>>> batch = gffData.subList(i, end);
 
-			if (assemblyId != null) {
-				countType = "Locations";
-				try {
-					gff3Service.loadTranscriptLocationAssociations(gff3EntryPair, locationIdsAdded, dataProvider, assemblyId);
-					history.incrementCompleted(countType);
-				} catch (ObjectUpdateException e) {
-					history.incrementFailed(countType);
-					addException(history, e.getData());
-				} catch (Exception e) {
-					e.printStackTrace();
-					history.incrementFailed(countType);
-					addException(history, new ObjectUpdateExceptionData(gff3EntryPair.getKey(), e.getMessage(), e.getStackTrace()));
-				}
-			}
-			countType = "Associations";
-			try {
-				gff3Service.loadGeneParentChildAssociations(gff3EntryPair, associationIdsAdded, dataProvider, geneIdCurieMap);
-				history.incrementCompleted(countType);
-			} catch (ObjectUpdateException e) {
-				history.incrementFailed(countType);
-				addException(history, e.getData());
-			} catch (Exception e) {
-				e.printStackTrace();
-				history.incrementFailed(countType);
-				addException(history, new ObjectUpdateExceptionData(gff3EntryPair.getKey(), e.getMessage(), e.getStackTrace()));
-			}
-			ph.progressProcess();
+			gff3Service.loadTranscriptBatch(batch, entityIdsAdded, locationIdsAdded, associationIdsAdded, dataProvider, assemblyId, geneIdCurieMap, history, ph);
+
 			if (Thread.currentThread().isInterrupted()) {
 				history.setErrorMessage("Thread isInterrupted");
 				throw new RuntimeException("Thread isInterrupted");

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3TranscriptExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3TranscriptExecutor.java
@@ -56,8 +56,7 @@ public class Gff3TranscriptExecutor extends Gff3Executor {
 		List<Gff3DTO> gffFileData = new ArrayList<>();
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.startProcess("GFF Transcript header pre-processing", gffRawData.size());
-		while (!gffRawData.isEmpty()) {
-			Gff3DTO gffLine = gffRawData.remove(0);
+		for (Gff3DTO gffLine : gffRawData) {
 			if (gffLine.getSeqId().startsWith("#")) {
 				gffHeaderData.add(gffLine.getSeqId());
 			} else {
@@ -66,6 +65,7 @@ public class Gff3TranscriptExecutor extends Gff3Executor {
 			ph.progressProcess();
 		}
 		ph.finishProcess();
+		gffRawData.clear();
 
 		BulkFMSLoad fmsLoad = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
 		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fmsLoad.getFmsDataSubType());

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSearchResultDocument.java
@@ -28,7 +28,6 @@ public class DiseaseSearchResultDocument extends ESDocument {
 	Set<String> genes = new HashSet<>();
 	Set<String> diseaseGroup = new HashSet<>();
 	Set<String> associatedSpecies = new HashSet<>();
-	@JsonProperty("name_key")
 	String nameKey;
 
 	Set<String> secondaryIds = new HashSet<>();

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSearchResultDocument.java
@@ -5,7 +5,6 @@ import java.util.Set;
 
 import org.alliancegenome.curation_api.view.CurationView;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 
 import lombok.Data;

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/GOSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/GOSearchResultDocument.java
@@ -23,7 +23,6 @@ public class GOSearchResultDocument extends ESDocument {
 	private String definition;
 	private String name;
 	private String href;
-	@JsonbProperty("name_key")
 	private String nameKey;
 	private Set<String> associatedSpecies;
 	private Set<String> genes;

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/GOSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/GOSearchResultDocument.java
@@ -6,7 +6,6 @@ import org.alliancegenome.curation_api.view.CurationView;
 
 import com.fasterxml.jackson.annotation.JsonView;
 
-import jakarta.json.bind.annotation.JsonbProperty;
 import lombok.Data;
 
 @Data

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneSearchResultDocument.java
@@ -22,7 +22,6 @@ public class GeneSearchResultDocument extends ESDocument {
 	private String automatedGeneDescription;
 	private String geneDescription;
 	private String name;
-	@JsonbProperty("name_key")
 	private String nameKey;
 	private String species;
 	private String symbol;
@@ -63,8 +62,7 @@ public class GeneSearchResultDocument extends ESDocument {
 
 	private Set<String> strictOrthologySymbols;
 
-	// Gene -> AlleleGeneAssociation -> Allele -> AgmAlleleAssociation -> AGM ->
-	// Symbol
-	// private Set<String> models;
+	// Gene -> AlleleGeneAssociation -> Allele -> AgmAlleleAssociation -> AGM -> Symbol
+	private Set<String> models;
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneSearchResultDocument.java
@@ -6,7 +6,6 @@ import org.alliancegenome.curation_api.view.CurationView;
 
 import com.fasterxml.jackson.annotation.JsonView;
 
-import jakarta.json.bind.annotation.JsonbProperty;
 import lombok.Data;
 
 @Data

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
@@ -62,23 +62,23 @@ public class Species extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "fullName_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class })
 	private String fullName;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "abbreviation_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class })
 	private String abbreviation;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "displayName_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class })
 	private String displayName;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "commonNames_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
 	@ElementCollection
-	@JsonView({ CurationView.FieldsAndLists.class, CurationView.GeneSummaryDocument.class })
+	@JsonView({ CurationView.FieldsAndLists.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class })
 	@JoinTable(indexes = @Index(name = "species_commonnames_species_id_index", columnList = "species_id"))
 	private List<String> commonNames;
 
@@ -89,7 +89,7 @@ public class Species extends AuditedObject {
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
 	@Fetch(FetchMode.SELECT)
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class })
 	protected Organization dataProvider;
 
 	@IndexedEmbedded(includePaths = {"displayName", "referencedCurie", "displayName_keyword", "referencedCurie_keyword"})
@@ -106,7 +106,7 @@ public class Species extends AuditedObject {
 
 	//@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	//@KeywordField(name = "assembly_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class })
 	//CHECKSTYLE:OFF: MemberName
 	private String assembly_curie;
 	//CHECKSTYLE:ON: MemberName

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java
@@ -26,7 +26,7 @@ import lombok.ToString;
 public class NCBITaxonTerm extends OntologyTerm {
 
 	@OneToOne(mappedBy = "taxon", cascade = CascadeType.ALL, orphanRemoval = true)
-	@JsonView(CurationView.GeneSummaryDocument.class)
+	@JsonView({CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class})
 	private Species species;
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/CodingSequenceService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/CodingSequenceService.java
@@ -2,12 +2,7 @@ package org.alliancegenome.curation_api.services;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
-import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.CodingSequenceDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
@@ -41,14 +36,13 @@ public class CodingSequenceService extends BaseEntityCrudService<CodingSequence,
 	}
 
 	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.TAXON, dataProvider.canonicalTaxonCurie);
-		}
-		List<Long> ids = codingSequenceDAO.findIdsByParams(params);
-		ids.removeIf(Objects::isNull);
-		return ids;
+		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
+		return codingSequenceDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	}
+
+	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
+		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
+			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
 	}
 
 	@Override

--- a/src/main/java/org/alliancegenome/curation_api/services/ExonService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ExonService.java
@@ -2,12 +2,7 @@ package org.alliancegenome.curation_api.services;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
-import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.ExonDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
@@ -85,14 +80,13 @@ public class ExonService extends BaseEntityCrudService<Exon, ExonDAO> {
 	}
 
 	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.TAXON, dataProvider.canonicalTaxonCurie);
-		}
-		List<Long> ids = exonDAO.findIdsByParams(params);
-		ids.removeIf(Objects::isNull);
-		return ids;
+		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
+		return exonDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	}
+
+	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
+		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
+			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
 	}
 
 	@Override

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
@@ -381,11 +381,12 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 		CompletableFuture<Map<Long, Set<String>>> anatomicalFuture = CompletableFuture.supplyAsync(() -> geneDAO.getExpressionAnatomical(geneIds), executor);
 		CompletableFuture<List<Object[]>> whereExpressedFuture = CompletableFuture.supplyAsync(() -> geneDAO.getWhereExpressedAndStages(geneIds), executor);
 		CompletableFuture<List<Object[]>> descriptionFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneDescriptions(geneIds), executor);
+		CompletableFuture<Map<Long, Set<String>>> modelsFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneModels(geneIds), executor);
 
 		CompletableFuture.allOf(baseInfoFuture, soAncestorsFuture, synonymsFuture, secondaryIdsFuture,
 			crossRefsFuture, chromosomesFuture, allelesFuture, phenotypesFuture, directDiseaseFuture,
 			strictOrthoFuture, orthoDiseaseFuture, goFuture, subcellularFuture, anatomicalFuture,
-			whereExpressedFuture, descriptionFuture).join();
+			whereExpressedFuture, descriptionFuture, modelsFuture).join();
 		executor.shutdown();
 
 		List<Object[]> baseInfoRows = baseInfoFuture.join();
@@ -404,6 +405,7 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 		Map<Long, Set<String>> anatomical = anatomicalFuture.join();
 		List<Object[]> whereExpressedRows = whereExpressedFuture.join();
 		List<Object[]> descriptionRows = descriptionFuture.join();
+		Map<Long, Set<String>> models = modelsFuture.join();
 
 		// Build base documents from Q1
 		Map<Long, GeneSearchResultDocument> docMap = new HashMap<>();
@@ -638,6 +640,11 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 					doc.setGeneDescription(freetext);
 				}
 			}
+		}
+
+		// Q16: Models (Gene -> Allele -> AGM)
+		for (Map.Entry<Long, GeneSearchResultDocument> entry : docMap.entrySet()) {
+			entry.getValue().setModels(models.getOrDefault(entry.getKey(), new HashSet<>()));
 		}
 
 		// Return documents in input order

--- a/src/main/java/org/alliancegenome/curation_api/services/Gff3Service.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/Gff3Service.java
@@ -1,8 +1,10 @@
 package org.alliancegenome.curation_api.services;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.alliancegenome.curation_api.constants.Gff3Constants;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
@@ -10,8 +12,13 @@ import org.alliancegenome.curation_api.dao.CodingSequenceDAO;
 import org.alliancegenome.curation_api.dao.ExonDAO;
 import org.alliancegenome.curation_api.dao.GenomeAssemblyDAO;
 import org.alliancegenome.curation_api.dao.TranscriptDAO;
+import org.alliancegenome.curation_api.dao.associations.ExonGenomicLocationAssociationDAO;
+import org.alliancegenome.curation_api.dao.associations.TranscriptExonAssociationDAO;
+import org.alliancegenome.curation_api.dao.loads.BulkLoadFileExceptionDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
+import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
+import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.CodingSequence;
@@ -25,6 +32,8 @@ import org.alliancegenome.curation_api.model.entities.associations.TranscriptCod
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptExonAssociation;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptGeneAssociation;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptGenomicLocationAssociation;
+import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileException;
+import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.Gff3DTO;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.associations.CodingSequenceGenomicLocationAssociationService;
@@ -36,6 +45,7 @@ import org.alliancegenome.curation_api.services.associations.TranscriptGeneAssoc
 import org.alliancegenome.curation_api.services.associations.TranscriptGenomicLocationAssociationService;
 import org.alliancegenome.curation_api.services.helpers.Gff3AttributesHelper;
 import org.alliancegenome.curation_api.services.helpers.Gff3UniqueIdHelper;
+import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
 import org.alliancegenome.curation_api.services.ontology.NcbiTaxonTermService;
 import org.alliancegenome.curation_api.services.validation.dto.Gff3DtoValidator;
 import org.apache.commons.lang3.StringUtils;
@@ -43,6 +53,8 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.FlushModeType;
 import jakarta.transaction.Transactional;
 
 @RequestScoped
@@ -52,6 +64,9 @@ public class Gff3Service {
 	@Inject ExonDAO exonDAO;
 	@Inject CodingSequenceDAO cdsDAO;
 	@Inject TranscriptDAO transcriptDAO;
+	@Inject BulkLoadFileExceptionDAO bulkLoadFileExceptionDAO;
+	@Inject ExonGenomicLocationAssociationDAO exonLocationDAO;
+	@Inject TranscriptExonAssociationDAO transcriptExonDAO;
 	@Inject ExonGenomicLocationAssociationService exonLocationService;
 	@Inject CodingSequenceGenomicLocationAssociationService cdsLocationService;
 	@Inject TranscriptGenomicLocationAssociationService transcriptLocationService;
@@ -60,8 +75,12 @@ public class Gff3Service {
 	@Inject TranscriptCodingSequenceAssociationService transcriptCdsService;
 	@Inject TranscriptExonAssociationService transcriptExonService;
 	@Inject NcbiTaxonTermService ncbiTaxonTermService;
+	@Inject OrganizationService organizationService;
 	@Inject Gff3DtoValidator gff3DtoValidator;
 	@Inject GeneService geneService;
+	@Inject EntityManager entityManager;
+
+	private Map<String, Transcript> transcriptCache = new HashMap<>();
 
 	@Transactional
 	public void loadExonLocationAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, BackendBulkDataProvider dataProvider, String assemblyId) throws ValidationException {
@@ -251,6 +270,144 @@ public class Gff3Service {
 			idsAdded.add(geneAssociation.getId());
 			transcriptGeneService.addAssociationToSubjectAndObject(geneAssociation);
 		}
+	}
+
+	@Transactional
+	public void loadExonBatch(
+			List<ImmutablePair<Gff3DTO, Map<String, String>>> batch,
+			List<Long> entityIdsAdded,
+			List<Long> locationIdsAdded,
+			List<Long> associationIdsAdded,
+			BackendBulkDataProvider dataProvider,
+			String assemblyId,
+			BulkLoadFileHistory history,
+			ProcessDisplayHelper ph) {
+
+		entityManager.setFlushMode(FlushModeType.COMMIT);
+
+		// Batch-load existing exons by uniqueId
+		Set<String> uniqueIds = new HashSet<>();
+		Set<String> parentIds = new HashSet<>();
+		for (ImmutablePair<Gff3DTO, Map<String, String>> pair : batch) {
+			uniqueIds.add(Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(pair.getKey(), pair.getValue(), dataProvider));
+			String parent = pair.getValue().get("Parent");
+			if (parent != null && !transcriptCache.containsKey(parent)) {
+				parentIds.add(parent);
+			}
+		}
+		Map<String, Exon> exonMap = exonDAO.findByUniqueIds(uniqueIds);
+
+		// Batch-load transcripts not yet cached
+		if (!parentIds.isEmpty()) {
+			transcriptCache.putAll(transcriptDAO.findByModInternalIds(parentIds));
+		}
+
+		// Batch-load existing associations for existing exons
+		Set<Long> existingExonIds = new HashSet<>();
+		for (Exon exon : exonMap.values()) {
+			if (exon.getId() != null) {
+				existingExonIds.add(exon.getId());
+			}
+		}
+		Map<Long, ExonGenomicLocationAssociation> locationAssocMap = assemblyId != null
+			? exonLocationDAO.findByExonIdsAndAssembly(existingExonIds, assemblyId)
+			: new HashMap<>();
+		Map<Long, TranscriptExonAssociation> transcriptExonAssocMap = transcriptExonDAO.findByExonIds(existingExonIds);
+
+		for (ImmutablePair<Gff3DTO, Map<String, String>> pair : batch) {
+			Gff3DTO gffEntry = pair.getKey();
+			Map<String, String> attributes = pair.getValue();
+			String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, attributes, dataProvider);
+
+			// Phase 1: Entity
+			Exon exon = null;
+			try {
+				if (!StringUtils.equals(gffEntry.getType(), "exon") && !StringUtils.equals(gffEntry.getType(), "noncoding_exon")) {
+					throw new ObjectValidationException(gffEntry, "Invalid Type: " + gffEntry.getType() + " for Exon Entity");
+				}
+
+				exon = exonMap.get(uniqueId);
+				if (exon == null) {
+					exon = new Exon();
+					exon.setUniqueId(uniqueId);
+				}
+
+				if (attributes.containsKey("Name")) {
+					exon.setName(attributes.get("Name"));
+				}
+
+				exon.setDataProvider(organizationService.getByAbbr(dataProvider.sourceOrganization).getEntity());
+				exon.setTaxon(ncbiTaxonTermService.getByCurie(dataProvider.canonicalTaxonCurie).getEntity());
+
+				exon = exonDAO.persist(exon);
+				entityIdsAdded.add(exon.getId());
+				history.incrementCompleted("Entities");
+			} catch (ObjectUpdateException e) {
+				history.incrementFailed("Entities");
+				addBatchException(history, e.getData());
+				exon = null;
+			} catch (Exception e) {
+				e.printStackTrace();
+				history.incrementFailed("Entities");
+				addBatchException(history, new ObjectUpdateExceptionData(gffEntry, e.getMessage(), e.getStackTrace()));
+				exon = null;
+			}
+
+			// Phase 2: Location
+			if (exon != null && assemblyId != null) {
+				try {
+					ExonGenomicLocationAssociation existingLocation = locationAssocMap.get(exon.getId());
+					ExonGenomicLocationAssociation exonLocation = gff3DtoValidator.validateExonLocation(gffEntry, exon, assemblyId, dataProvider, existingLocation);
+					if (exonLocation != null) {
+						locationIdsAdded.add(exonLocation.getId());
+					}
+					history.incrementCompleted("Locations");
+				} catch (ObjectUpdateException e) {
+					history.incrementFailed("Locations");
+					addBatchException(history, e.getData());
+				} catch (Exception e) {
+					e.printStackTrace();
+					history.incrementFailed("Locations");
+					addBatchException(history, new ObjectUpdateExceptionData(gffEntry, e.getMessage(), e.getStackTrace()));
+				}
+			}
+
+			// Phase 3: Transcript-Exon Association
+			if (exon != null) {
+				try {
+					if (!attributes.containsKey("Parent")) {
+						throw new ObjectValidationException(gffEntry, "Attributes - Parent - " + ValidationConstants.REQUIRED_MESSAGE);
+					}
+					Transcript parentTranscript = transcriptCache.get(attributes.get("Parent"));
+					if (parentTranscript == null) {
+						throw new ObjectValidationException(gffEntry, "Attributes - Parent - " + ValidationConstants.INVALID_MESSAGE + " (" + attributes.get("Parent") + ")");
+					}
+
+					TranscriptExonAssociation existingAssoc = transcriptExonAssocMap.get(exon.getId());
+					TranscriptExonAssociation transcriptAssociation = gff3DtoValidator.validateTranscriptExonAssociation(gffEntry, exon, parentTranscript, existingAssoc);
+					if (transcriptAssociation != null) {
+						associationIdsAdded.add(transcriptAssociation.getId());
+					}
+					history.incrementCompleted("Associations");
+				} catch (ObjectUpdateException e) {
+					history.incrementFailed("Associations");
+					addBatchException(history, e.getData());
+				} catch (Exception e) {
+					e.printStackTrace();
+					history.incrementFailed("Associations");
+					addBatchException(history, new ObjectUpdateExceptionData(gffEntry, e.getMessage(), e.getStackTrace()));
+				}
+			}
+
+			ph.progressProcess();
+		}
+	}
+
+	private void addBatchException(BulkLoadFileHistory history, ObjectUpdateExceptionData data) {
+		BulkLoadFileException exception = new BulkLoadFileException();
+		exception.setException(data);
+		exception.setBulkLoadFileHistory(history);
+		bulkLoadFileExceptionDAO.persist(exception);
 	}
 
 	public Map<String, String> getGeneIdCurieMap(List<Gff3DTO> gffData, BackendBulkDataProvider dataProvider) {

--- a/src/main/java/org/alliancegenome/curation_api/services/Gff3Service.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/Gff3Service.java
@@ -10,12 +10,16 @@ import org.alliancegenome.curation_api.constants.Gff3Constants;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.dao.CodingSequenceDAO;
 import org.alliancegenome.curation_api.dao.ExonDAO;
+import org.alliancegenome.curation_api.dao.GeneDAO;
 import org.alliancegenome.curation_api.dao.GenomeAssemblyDAO;
 import org.alliancegenome.curation_api.dao.TranscriptDAO;
 import org.alliancegenome.curation_api.dao.associations.CodingSequenceGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.dao.associations.ExonGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.dao.associations.TranscriptCodingSequenceAssociationDAO;
 import org.alliancegenome.curation_api.dao.associations.TranscriptExonAssociationDAO;
+import org.alliancegenome.curation_api.dao.associations.TranscriptGeneAssociationDAO;
+import org.alliancegenome.curation_api.dao.associations.TranscriptGenomicLocationAssociationDAO;
+import org.alliancegenome.curation_api.dao.ontology.SoTermDAO;
 import org.alliancegenome.curation_api.dao.loads.BulkLoadFileExceptionDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
@@ -27,6 +31,7 @@ import org.alliancegenome.curation_api.model.entities.CodingSequence;
 import org.alliancegenome.curation_api.model.entities.Exon;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.Transcript;
+import org.alliancegenome.curation_api.model.entities.ontology.SOTerm;
 import org.alliancegenome.curation_api.model.entities.associations.CodingSequenceGenomicLocationAssociation;
 import org.alliancegenome.curation_api.model.entities.associations.ExonGenomicLocationAssociation;
 import org.alliancegenome.curation_api.model.entities.associations.GeneGenomicLocationAssociation;
@@ -66,11 +71,15 @@ public class Gff3Service {
 	@Inject ExonDAO exonDAO;
 	@Inject CodingSequenceDAO cdsDAO;
 	@Inject TranscriptDAO transcriptDAO;
+	@Inject GeneDAO geneDAO;
 	@Inject BulkLoadFileExceptionDAO bulkLoadFileExceptionDAO;
 	@Inject ExonGenomicLocationAssociationDAO exonLocationDAO;
 	@Inject TranscriptExonAssociationDAO transcriptExonDAO;
 	@Inject CodingSequenceGenomicLocationAssociationDAO cdsLocationDAO;
 	@Inject TranscriptCodingSequenceAssociationDAO transcriptCdsDAO;
+	@Inject TranscriptGenomicLocationAssociationDAO transcriptLocationDAO;
+	@Inject TranscriptGeneAssociationDAO transcriptGeneDAO;
+	@Inject SoTermDAO soTermDAO;
 	@Inject ExonGenomicLocationAssociationService exonLocationService;
 	@Inject CodingSequenceGenomicLocationAssociationService cdsLocationService;
 	@Inject TranscriptGenomicLocationAssociationService transcriptLocationService;
@@ -543,6 +552,168 @@ public class Gff3Service {
 		exception.setException(data);
 		exception.setBulkLoadFileHistory(history);
 		bulkLoadFileExceptionDAO.persist(exception);
+	}
+
+	@Transactional
+	public void loadTranscriptBatch(
+			List<ImmutablePair<Gff3DTO, Map<String, String>>> batch,
+			List<Long> entityIdsAdded,
+			List<Long> locationIdsAdded,
+			List<Long> associationIdsAdded,
+			BackendBulkDataProvider dataProvider,
+			String assemblyId,
+			Map<String, String> geneIdCurieMap,
+			BulkLoadFileHistory history,
+			ProcessDisplayHelper ph) {
+
+		entityManager.setFlushMode(FlushModeType.COMMIT);
+
+		// Collect modInternalIds for batch transcript lookup
+		Set<String> modInternalIds = new HashSet<>();
+		Set<String> geneCuries = new HashSet<>();
+		for (ImmutablePair<Gff3DTO, Map<String, String>> pair : batch) {
+			Map<String, String> attributes = pair.getValue();
+			if (attributes.containsKey("ID")) {
+				modInternalIds.add(attributes.get("ID"));
+			}
+			if (attributes.containsKey("Parent")) {
+				String geneCurie = geneIdCurieMap.containsKey(attributes.get("Parent"))
+					? geneIdCurieMap.get(attributes.get("Parent"))
+					: attributes.get("Parent");
+				geneCuries.add(geneCurie);
+			}
+		}
+
+		// Batch-load existing transcripts
+		Map<String, Transcript> batchTranscriptMap = transcriptDAO.findByModInternalIds(modInternalIds);
+		transcriptCache.putAll(batchTranscriptMap);
+
+		// Batch-load genes
+		Map<String, Gene> geneMap = geneDAO.findByIdentifiers(geneCuries);
+
+		// Batch-load existing associations for existing transcripts
+		Set<Long> existingTranscriptIds = new HashSet<>();
+		for (Transcript t : batchTranscriptMap.values()) {
+			if (t.getId() != null) {
+				existingTranscriptIds.add(t.getId());
+			}
+		}
+		Map<Long, TranscriptGenomicLocationAssociation> locationAssocMap = assemblyId != null
+			? transcriptLocationDAO.findByTranscriptIdsAndAssembly(existingTranscriptIds, assemblyId)
+			: new HashMap<>();
+		Map<Long, TranscriptGeneAssociation> geneAssocMap = transcriptGeneDAO.findByTranscriptIds(existingTranscriptIds);
+
+		// SOTerm cache for this batch
+		Map<String, SOTerm> soTermCache = new HashMap<>();
+
+		for (ImmutablePair<Gff3DTO, Map<String, String>> pair : batch) {
+			Gff3DTO gffEntry = pair.getKey();
+			Map<String, String> attributes = pair.getValue();
+
+			// Phase 1: Entity
+			Transcript transcript = null;
+			try {
+				if (!Gff3Constants.TRANSCRIPT_TYPES.contains(gffEntry.getType())) {
+					throw new ObjectValidationException(gffEntry, "Invalid Type: " + gffEntry.getType() + " for Transcript Entity");
+				}
+
+				if (!attributes.containsKey("ID")) {
+					throw new ObjectValidationException(gffEntry, "attributes - ID - " + ValidationConstants.REQUIRED_MESSAGE);
+				}
+
+				transcript = transcriptCache.get(attributes.get("ID"));
+				if (transcript == null) {
+					transcript = new Transcript();
+					transcript.setModInternalId(attributes.get("ID"));
+				}
+
+				SOTerm soTerm = soTermCache.computeIfAbsent(gffEntry.getType(), type -> {
+					SearchResponse<SOTerm> soResponse = soTermDAO.findByField("name", type);
+					return soResponse != null ? soResponse.getSingleResult() : null;
+				});
+				transcript.setTranscriptType(soTerm);
+
+				if (attributes.containsKey("Name")) {
+					transcript.setName(attributes.get("Name"));
+				} else {
+					transcript.setName(null);
+				}
+
+				if (attributes.containsKey("transcript_id")) {
+					transcript.setTranscriptId(attributes.get("transcript_id"));
+				} else {
+					transcript.setTranscriptId(null);
+				}
+
+				transcript.setDataProvider(organizationService.getByAbbr(dataProvider.sourceOrganization).getEntity());
+				transcript.setTaxon(ncbiTaxonTermService.getByCurie(dataProvider.canonicalTaxonCurie).getEntity());
+
+				transcript = transcriptDAO.persist(transcript);
+				transcriptCache.put(attributes.get("ID"), transcript);
+				entityIdsAdded.add(transcript.getId());
+				history.incrementCompleted("Entities");
+			} catch (ObjectUpdateException e) {
+				history.incrementFailed("Entities");
+				addBatchException(history, e.getData());
+				transcript = null;
+			} catch (Exception e) {
+				e.printStackTrace();
+				history.incrementFailed("Entities");
+				addBatchException(history, new ObjectUpdateExceptionData(gffEntry, e.getMessage(), e.getStackTrace()));
+				transcript = null;
+			}
+
+			// Phase 2: Location
+			if (transcript != null && assemblyId != null) {
+				try {
+					TranscriptGenomicLocationAssociation existingLocation = locationAssocMap.get(transcript.getId());
+					TranscriptGenomicLocationAssociation transcriptLocation = gff3DtoValidator.validateTranscriptLocation(gffEntry, transcript, assemblyId, dataProvider, existingLocation);
+					if (transcriptLocation != null) {
+						locationIdsAdded.add(transcriptLocation.getId());
+					}
+					history.incrementCompleted("Locations");
+				} catch (ObjectUpdateException e) {
+					history.incrementFailed("Locations");
+					addBatchException(history, e.getData());
+				} catch (Exception e) {
+					e.printStackTrace();
+					history.incrementFailed("Locations");
+					addBatchException(history, new ObjectUpdateExceptionData(gffEntry, e.getMessage(), e.getStackTrace()));
+				}
+			}
+
+			// Phase 3: Gene Association
+			if (transcript != null) {
+				try {
+					if (!attributes.containsKey("Parent")) {
+						throw new ObjectValidationException(gffEntry, "Attributes - Parent - " + ValidationConstants.REQUIRED_MESSAGE);
+					}
+					String geneCurie = geneIdCurieMap.containsKey(attributes.get("Parent"))
+						? geneIdCurieMap.get(attributes.get("Parent"))
+						: attributes.get("Parent");
+					Gene parentGene = geneMap.get(geneCurie);
+					if (parentGene == null) {
+						throw new ObjectValidationException(gffEntry, "Attributes - Parent - " + ValidationConstants.INVALID_MESSAGE + " (" + attributes.get("Parent") + ")");
+					}
+
+					TranscriptGeneAssociation existingAssoc = geneAssocMap.get(transcript.getId());
+					TranscriptGeneAssociation geneAssociation = gff3DtoValidator.validateTranscriptGeneAssociation(gffEntry, transcript, parentGene, existingAssoc);
+					if (geneAssociation != null) {
+						associationIdsAdded.add(geneAssociation.getId());
+					}
+					history.incrementCompleted("Associations");
+				} catch (ObjectUpdateException e) {
+					history.incrementFailed("Associations");
+					addBatchException(history, e.getData());
+				} catch (Exception e) {
+					e.printStackTrace();
+					history.incrementFailed("Associations");
+					addBatchException(history, new ObjectUpdateExceptionData(gffEntry, e.getMessage(), e.getStackTrace()));
+				}
+			}
+
+			ph.progressProcess();
+		}
 	}
 
 	public Map<String, String> getGeneIdCurieMap(List<Gff3DTO> gffData, BackendBulkDataProvider dataProvider) {

--- a/src/main/java/org/alliancegenome/curation_api/services/Gff3Service.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/Gff3Service.java
@@ -12,7 +12,9 @@ import org.alliancegenome.curation_api.dao.CodingSequenceDAO;
 import org.alliancegenome.curation_api.dao.ExonDAO;
 import org.alliancegenome.curation_api.dao.GenomeAssemblyDAO;
 import org.alliancegenome.curation_api.dao.TranscriptDAO;
+import org.alliancegenome.curation_api.dao.associations.CodingSequenceGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.dao.associations.ExonGenomicLocationAssociationDAO;
+import org.alliancegenome.curation_api.dao.associations.TranscriptCodingSequenceAssociationDAO;
 import org.alliancegenome.curation_api.dao.associations.TranscriptExonAssociationDAO;
 import org.alliancegenome.curation_api.dao.loads.BulkLoadFileExceptionDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
@@ -67,6 +69,8 @@ public class Gff3Service {
 	@Inject BulkLoadFileExceptionDAO bulkLoadFileExceptionDAO;
 	@Inject ExonGenomicLocationAssociationDAO exonLocationDAO;
 	@Inject TranscriptExonAssociationDAO transcriptExonDAO;
+	@Inject CodingSequenceGenomicLocationAssociationDAO cdsLocationDAO;
+	@Inject TranscriptCodingSequenceAssociationDAO transcriptCdsDAO;
 	@Inject ExonGenomicLocationAssociationService exonLocationService;
 	@Inject CodingSequenceGenomicLocationAssociationService cdsLocationService;
 	@Inject TranscriptGenomicLocationAssociationService transcriptLocationService;
@@ -385,6 +389,137 @@ public class Gff3Service {
 
 					TranscriptExonAssociation existingAssoc = transcriptExonAssocMap.get(exon.getId());
 					TranscriptExonAssociation transcriptAssociation = gff3DtoValidator.validateTranscriptExonAssociation(gffEntry, exon, parentTranscript, existingAssoc);
+					if (transcriptAssociation != null) {
+						associationIdsAdded.add(transcriptAssociation.getId());
+					}
+					history.incrementCompleted("Associations");
+				} catch (ObjectUpdateException e) {
+					history.incrementFailed("Associations");
+					addBatchException(history, e.getData());
+				} catch (Exception e) {
+					e.printStackTrace();
+					history.incrementFailed("Associations");
+					addBatchException(history, new ObjectUpdateExceptionData(gffEntry, e.getMessage(), e.getStackTrace()));
+				}
+			}
+
+			ph.progressProcess();
+		}
+	}
+
+	@Transactional
+	public void loadCdsBatch(
+			List<ImmutablePair<Gff3DTO, Map<String, String>>> batch,
+			List<Long> entityIdsAdded,
+			List<Long> locationIdsAdded,
+			List<Long> associationIdsAdded,
+			BackendBulkDataProvider dataProvider,
+			String assemblyId,
+			BulkLoadFileHistory history,
+			ProcessDisplayHelper ph) {
+
+		entityManager.setFlushMode(FlushModeType.COMMIT);
+
+		// Batch-load existing CDS by uniqueId
+		Set<String> uniqueIds = new HashSet<>();
+		Set<String> parentIds = new HashSet<>();
+		for (ImmutablePair<Gff3DTO, Map<String, String>> pair : batch) {
+			uniqueIds.add(Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(pair.getKey(), pair.getValue(), dataProvider));
+			String parent = pair.getValue().get("Parent");
+			if (parent != null && !transcriptCache.containsKey(parent)) {
+				parentIds.add(parent);
+			}
+		}
+		Map<String, CodingSequence> cdsMap = cdsDAO.findByUniqueIds(uniqueIds);
+
+		// Batch-load transcripts not yet cached
+		if (!parentIds.isEmpty()) {
+			transcriptCache.putAll(transcriptDAO.findByModInternalIds(parentIds));
+		}
+
+		// Batch-load existing associations for existing CDS
+		Set<Long> existingCdsIds = new HashSet<>();
+		for (CodingSequence cds : cdsMap.values()) {
+			if (cds.getId() != null) {
+				existingCdsIds.add(cds.getId());
+			}
+		}
+		Map<Long, CodingSequenceGenomicLocationAssociation> locationAssocMap = assemblyId != null
+			? cdsLocationDAO.findByCdsIdsAndAssembly(existingCdsIds, assemblyId)
+			: new HashMap<>();
+		Map<Long, TranscriptCodingSequenceAssociation> transcriptCdsAssocMap = transcriptCdsDAO.findByCdsIds(existingCdsIds);
+
+		for (ImmutablePair<Gff3DTO, Map<String, String>> pair : batch) {
+			Gff3DTO gffEntry = pair.getKey();
+			Map<String, String> attributes = pair.getValue();
+			String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, attributes, dataProvider);
+
+			// Phase 1: Entity
+			CodingSequence cds = null;
+			try {
+				if (!StringUtils.equals(gffEntry.getType(), "CDS")) {
+					throw new ObjectValidationException(gffEntry, "Invalid Type: " + gffEntry.getType() + " for CDS Entity");
+				}
+
+				cds = cdsMap.get(uniqueId);
+				if (cds == null) {
+					cds = new CodingSequence();
+					cds.setUniqueId(uniqueId);
+				}
+
+				if (attributes.containsKey("Name")) {
+					cds.setName(attributes.get("Name"));
+				}
+
+				cds.setDataProvider(organizationService.getByAbbr(dataProvider.sourceOrganization).getEntity());
+				cds.setTaxon(ncbiTaxonTermService.getByCurie(dataProvider.canonicalTaxonCurie).getEntity());
+
+				cds = cdsDAO.persist(cds);
+				entityIdsAdded.add(cds.getId());
+				history.incrementCompleted("Entities");
+			} catch (ObjectUpdateException e) {
+				history.incrementFailed("Entities");
+				addBatchException(history, e.getData());
+				cds = null;
+			} catch (Exception e) {
+				e.printStackTrace();
+				history.incrementFailed("Entities");
+				addBatchException(history, new ObjectUpdateExceptionData(gffEntry, e.getMessage(), e.getStackTrace()));
+				cds = null;
+			}
+
+			// Phase 2: Location
+			if (cds != null && assemblyId != null) {
+				try {
+					CodingSequenceGenomicLocationAssociation existingLocation = locationAssocMap.get(cds.getId());
+					CodingSequenceGenomicLocationAssociation cdsLocation = gff3DtoValidator.validateCdsLocation(gffEntry, cds, assemblyId, dataProvider, existingLocation);
+					if (cdsLocation != null) {
+						locationIdsAdded.add(cdsLocation.getId());
+					}
+					history.incrementCompleted("Locations");
+				} catch (ObjectUpdateException e) {
+					history.incrementFailed("Locations");
+					addBatchException(history, e.getData());
+				} catch (Exception e) {
+					e.printStackTrace();
+					history.incrementFailed("Locations");
+					addBatchException(history, new ObjectUpdateExceptionData(gffEntry, e.getMessage(), e.getStackTrace()));
+				}
+			}
+
+			// Phase 3: Transcript-CDS Association
+			if (cds != null) {
+				try {
+					if (!attributes.containsKey("Parent")) {
+						throw new ObjectValidationException(gffEntry, "Attributes - Parent - " + ValidationConstants.REQUIRED_MESSAGE);
+					}
+					Transcript parentTranscript = transcriptCache.get(attributes.get("Parent"));
+					if (parentTranscript == null) {
+						throw new ObjectValidationException(gffEntry, "Attributes - Parent - " + ValidationConstants.INVALID_MESSAGE + " (" + attributes.get("Parent") + ")");
+					}
+
+					TranscriptCodingSequenceAssociation existingAssoc = transcriptCdsAssocMap.get(cds.getId());
+					TranscriptCodingSequenceAssociation transcriptAssociation = gff3DtoValidator.validateTranscriptCodingSequenceAssociation(gffEntry, cds, parentTranscript, existingAssoc);
 					if (transcriptAssociation != null) {
 						associationIdsAdded.add(transcriptAssociation.getId());
 					}

--- a/src/main/java/org/alliancegenome/curation_api/services/TranscriptService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/TranscriptService.java
@@ -2,12 +2,8 @@ package org.alliancegenome.curation_api.services;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 
-import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.TranscriptDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
@@ -40,14 +36,13 @@ public class TranscriptService extends BaseEntityCrudService<Transcript, Transcr
 	}
 
 	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.TAXON, dataProvider.canonicalTaxonCurie);
-		}
-		List<Long> ids = transcriptDAO.findIdsByParams(params);
-		ids.removeIf(Objects::isNull);
-		return ids;
+		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
+		return transcriptDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	}
+
+	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
+		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
+			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
 	}
 
 	public ObjectResponse<Transcript> deleteByIdentifier(String identifierString) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/CodingSequenceGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/CodingSequenceGenomicLocationAssociationService.java
@@ -4,10 +4,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.CodingSequenceGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
@@ -38,15 +36,13 @@ public class CodingSequenceGenomicLocationAssociationService extends BaseEntityC
 
 
 	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.CODING_SEQUENCE_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.CODING_SEQUENCE_ASSOCIATION_SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
-		}
-		List<Long> associationIds = codingSequenceGenomicLocationAssociationDAO.findIdsByParams(params);
-		associationIds.removeIf(Objects::isNull);
+		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
+		return codingSequenceGenomicLocationAssociationDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	}
 
-		return associationIds;
+	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
+		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
+			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
 	}
 
 	public ObjectResponse<CodingSequenceGenomicLocationAssociation> getLocationAssociation(Long codingSequenceId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/ExonGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/ExonGenomicLocationAssociationService.java
@@ -4,10 +4,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.ExonGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
@@ -38,15 +36,13 @@ public class ExonGenomicLocationAssociationService extends BaseEntityCrudService
 
 
 	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.EXON_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.EXON_ASSOCIATION_SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
-		}
-		List<Long> associationIds = exonGenomicLocationAssociationDAO.findIdsByParams(params);
-		associationIds.removeIf(Objects::isNull);
+		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
+		return exonGenomicLocationAssociationDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	}
 
-		return associationIds;
+	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
+		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
+			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
 	}
 
 	public ObjectResponse<ExonGenomicLocationAssociation> getLocationAssociation(Long exonId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptCodingSequenceAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptCodingSequenceAssociationService.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
@@ -39,15 +38,13 @@ public class TranscriptCodingSequenceAssociationService extends BaseEntityCrudSe
 
 
 	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.TRANSCRIPT_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.TRANSCRIPT_ASSOCIATION_SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
-		}
-		List<Long> associationIds = transcriptCodingSequenceAssociationDAO.findIdsByParams(params);
-		associationIds.removeIf(Objects::isNull);
+		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
+		return transcriptCodingSequenceAssociationDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	}
 
-		return associationIds;
+	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
+		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
+			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
 	}
 
 	public ObjectResponse<TranscriptCodingSequenceAssociation> getLocationAssociation(Long transcriptId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptExonAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptExonAssociationService.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
@@ -39,15 +38,13 @@ public class TranscriptExonAssociationService extends BaseEntityCrudService<Tran
 
 
 	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.TRANSCRIPT_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.TRANSCRIPT_ASSOCIATION_SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
-		}
-		List<Long> associationIds = transcriptExonAssociationDAO.findIdsByParams(params);
-		associationIds.removeIf(Objects::isNull);
+		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
+		return transcriptExonAssociationDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	}
 
-		return associationIds;
+	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
+		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
+			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
 	}
 
 	public ObjectResponse<TranscriptExonAssociation> getLocationAssociation(Long transcriptId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptGeneAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptGeneAssociationService.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
@@ -39,15 +38,13 @@ public class TranscriptGeneAssociationService extends BaseEntityCrudService<Tran
 
 
 	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.TRANSCRIPT_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.TRANSCRIPT_ASSOCIATION_SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
-		}
-		List<Long> associationIds = transcriptGeneAssociationDAO.findIdsByParams(params);
-		associationIds.removeIf(Objects::isNull);
+		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
+		return transcriptGeneAssociationDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	}
 
-		return associationIds;
+	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
+		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
+			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
 	}
 
 	public ObjectResponse<TranscriptGeneAssociation> getLocationAssociation(Long transcriptId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptGenomicLocationAssociationService.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
@@ -23,6 +22,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 
+
 @RequestScoped
 public class TranscriptGenomicLocationAssociationService extends BaseEntityCrudService<TranscriptGenomicLocationAssociation, TranscriptGenomicLocationAssociationDAO> {
 
@@ -38,15 +38,13 @@ public class TranscriptGenomicLocationAssociationService extends BaseEntityCrudS
 
 
 	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.TRANSCRIPT_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.TRANSCRIPT_ASSOCIATION_SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
-		}
-		List<Long> associationIds = transcriptGenomicLocationAssociationDAO.findIdsByParams(params);
-		associationIds.removeIf(Objects::isNull);
+		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
+		return transcriptGenomicLocationAssociationDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	}
 
-		return associationIds;
+	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
+		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
+			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
 	}
 
 	public ObjectResponse<TranscriptGenomicLocationAssociation> getLocationAssociation(Long transcriptId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/base/BaseEntityCrudService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/base/BaseEntityCrudService.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.curation_api.services.base;
 
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -173,6 +174,11 @@ public abstract class BaseEntityCrudService<E extends AuditedObject, D extends B
 		}
 
 		return null;
+	}
+
+	@Transactional
+	public int removeByIds(Collection<Long> ids) {
+		return dao.removeByIds(ids);
 	}
 
 	public SearchResponse<E> findByField(String field, String value) {

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/Gff3DtoValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/Gff3DtoValidator.java
@@ -249,12 +249,31 @@ public class Gff3DtoValidator {
 		}
 		locationAssociation.setExonAssociationSubject(exon);
 		locationAssociation.setStrand(gffEntry.getStrand());
-		
+
 		ObjectResponse<ExonGenomicLocationAssociation> locationResponse = validateLocationAssociation(locationAssociation, gffEntry, assemblyComponent);
 		if (locationResponse.hasErrors()) {
 			throw new ObjectValidationException(gffEntry, locationResponse.errorMessagesString());
 		}
-		
+
+		return exonLocationDAO.persist(locationResponse.getEntity());
+	}
+
+	@Transactional
+	public ExonGenomicLocationAssociation validateExonLocation(Gff3DTO gffEntry, Exon exon, String assemblyId, BackendBulkDataProvider dataProvider, ExonGenomicLocationAssociation existingAssociation) throws ObjectValidationException {
+		AssemblyComponent assemblyComponent = null;
+		ExonGenomicLocationAssociation locationAssociation = existingAssociation != null ? existingAssociation : new ExonGenomicLocationAssociation();
+		if (StringUtils.isNotBlank(gffEntry.getSeqId())) {
+			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, dataProvider.canonicalTaxonCurie, dataProvider);
+			locationAssociation.setExonGenomicLocationAssociationObject(assemblyComponent);
+		}
+		locationAssociation.setExonAssociationSubject(exon);
+		locationAssociation.setStrand(gffEntry.getStrand());
+
+		ObjectResponse<ExonGenomicLocationAssociation> locationResponse = validateLocationAssociation(locationAssociation, gffEntry, assemblyComponent);
+		if (locationResponse.hasErrors()) {
+			throw new ObjectValidationException(gffEntry, locationResponse.errorMessagesString());
+		}
+
 		return exonLocationDAO.persist(locationResponse.getEntity());
 	}
 
@@ -415,7 +434,22 @@ public class Gff3DtoValidator {
 
 		return transcriptExonDAO.persist(association);
 	}
-	
+
+	@Transactional
+	public TranscriptExonAssociation validateTranscriptExonAssociation(Gff3DTO gffEntry, Exon exon, Transcript parentTranscript) throws ObjectValidationException {
+		return validateTranscriptExonAssociation(gffEntry, exon, parentTranscript, null);
+	}
+
+	@Transactional
+	public TranscriptExonAssociation validateTranscriptExonAssociation(Gff3DTO gffEntry, Exon exon, Transcript parentTranscript, TranscriptExonAssociation existingAssociation) throws ObjectValidationException {
+		TranscriptExonAssociation association = existingAssociation != null ? existingAssociation : new TranscriptExonAssociation();
+		association.setTranscriptAssociationSubject(parentTranscript);
+		association.setTranscriptExonAssociationObject(exon);
+		association.setRelation(vocabularyTermService.getTermInVocabulary(VocabularyConstants.TRANSCRIPT_RELATION_VOCABULARY, VocabularyConstants.TRANSCRIPT_PARENT_TERM).getEntity());
+
+		return transcriptExonDAO.persist(association);
+	}
+
 	private <E extends LocationAssociation> ObjectResponse<E> validateLocationAssociation(E association, Gff3DTO dto, AssemblyComponent assemblyComponent) {
 		ObjectResponse<E> associationResponse = new ObjectResponse<E>();
 		

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/Gff3DtoValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/Gff3DtoValidator.java
@@ -325,6 +325,48 @@ public class Gff3DtoValidator {
 	}
 
 	@Transactional
+	public TranscriptGenomicLocationAssociation validateTranscriptLocation(Gff3DTO gffEntry, Transcript transcript, String assemblyId, BackendBulkDataProvider dataProvider, TranscriptGenomicLocationAssociation existingAssociation) throws ObjectValidationException {
+		AssemblyComponent assemblyComponent = null;
+		TranscriptGenomicLocationAssociation locationAssociation = existingAssociation != null ? existingAssociation : new TranscriptGenomicLocationAssociation();
+		if (StringUtils.isNotBlank(gffEntry.getSeqId())) {
+			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, dataProvider.canonicalTaxonCurie, dataProvider);
+			locationAssociation.setTranscriptGenomicLocationAssociationObject(assemblyComponent);
+		}
+		locationAssociation.setTranscriptAssociationSubject(transcript);
+		locationAssociation.setStrand(gffEntry.getStrand());
+		locationAssociation.setPhase(gffEntry.getPhase());
+
+		ObjectResponse<TranscriptGenomicLocationAssociation> locationResponse = validateLocationAssociation(locationAssociation, gffEntry, assemblyComponent);
+		if (locationResponse.hasErrors()) {
+			throw new ObjectValidationException(gffEntry, locationResponse.errorMessagesString());
+		}
+
+		return transcriptLocationDAO.persist(locationResponse.getEntity());
+	}
+
+	@Transactional
+	public TranscriptGeneAssociation validateTranscriptGeneAssociation(Gff3DTO gffEntry, Transcript transcript, Gene parentGene, TranscriptGeneAssociation existingAssociation) throws ObjectValidationException {
+		TranscriptGeneAssociation association;
+		boolean newAssociation;
+		if (existingAssociation != null) {
+			association = existingAssociation;
+			newAssociation = false;
+		} else {
+			association = new TranscriptGeneAssociation();
+			newAssociation = true;
+		}
+		association.setTranscriptAssociationSubject(transcript);
+		association.setTranscriptGeneAssociationObject(parentGene);
+		association.setRelation(vocabularyTermService.getTermInVocabulary(VocabularyConstants.TRANSCRIPT_RELATION_VOCABULARY, VocabularyConstants.TRANSCRIPT_CHILD_TERM).getEntity());
+
+		if (newAssociation) {
+			return transcriptGeneDAO.persist(association);
+		} else {
+			return association;
+		}
+	}
+
+	@Transactional
 	public GeneGenomicLocationAssociation validateGeneLocation(Gff3DTO gffEntry, Gene gene, String assemblyId, BackendBulkDataProvider dataProvider) throws ObjectValidationException {
 		AssemblyComponent assemblyComponent = null;
 		GeneGenomicLocationAssociation locationAssociation = new GeneGenomicLocationAssociation();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/Gff3DtoValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/Gff3DtoValidator.java
@@ -232,6 +232,26 @@ public class Gff3DtoValidator {
 	}
 
 	@Transactional
+	public CodingSequenceGenomicLocationAssociation validateCdsLocation(Gff3DTO gffEntry, CodingSequence cds, String assemblyId, BackendBulkDataProvider dataProvider, CodingSequenceGenomicLocationAssociation existingAssociation) throws ObjectValidationException {
+		AssemblyComponent assemblyComponent = null;
+		CodingSequenceGenomicLocationAssociation locationAssociation = existingAssociation != null ? existingAssociation : new CodingSequenceGenomicLocationAssociation();
+		if (StringUtils.isNotBlank(gffEntry.getSeqId())) {
+			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, dataProvider.canonicalTaxonCurie, dataProvider);
+			locationAssociation.setCodingSequenceGenomicLocationAssociationObject(assemblyComponent);
+		}
+		locationAssociation.setCodingSequenceAssociationSubject(cds);
+		locationAssociation.setStrand(gffEntry.getStrand());
+		locationAssociation.setPhase(gffEntry.getPhase());
+
+		ObjectResponse<CodingSequenceGenomicLocationAssociation> locationResponse = validateLocationAssociation(locationAssociation, gffEntry, assemblyComponent);
+		if (locationResponse.hasErrors()) {
+			throw new ObjectValidationException(gffEntry, locationResponse.errorMessagesString());
+		}
+
+		return cdsLocationDAO.persist(locationResponse.getEntity());
+	}
+
+	@Transactional
 	public ExonGenomicLocationAssociation validateExonLocation(Gff3DTO gffEntry, Exon exon, String assemblyId, BackendBulkDataProvider dataProvider) throws ObjectValidationException {
 		AssemblyComponent assemblyComponent = null;
 		ExonGenomicLocationAssociation locationAssociation = new ExonGenomicLocationAssociation();
@@ -401,7 +421,17 @@ public class Gff3DtoValidator {
 
 		return transcriptCdsDAO.persist(association);
 	}
-	
+
+	@Transactional
+	public TranscriptCodingSequenceAssociation validateTranscriptCodingSequenceAssociation(Gff3DTO gffEntry, CodingSequence cds, Transcript parentTranscript, TranscriptCodingSequenceAssociation existingAssociation) throws ObjectValidationException {
+		TranscriptCodingSequenceAssociation association = existingAssociation != null ? existingAssociation : new TranscriptCodingSequenceAssociation();
+		association.setTranscriptAssociationSubject(parentTranscript);
+		association.setTranscriptCodingSequenceAssociationObject(cds);
+		association.setRelation(vocabularyTermService.getTermInVocabulary(VocabularyConstants.TRANSCRIPT_RELATION_VOCABULARY, VocabularyConstants.TRANSCRIPT_PARENT_TERM).getEntity());
+
+		return transcriptCdsDAO.persist(association);
+	}
+
 	@Transactional
 	public TranscriptExonAssociation validateTranscriptExonAssociation(Gff3DTO gffEntry, Exon exon, Map<String, String> attributes) throws ObjectValidationException {
 		TranscriptExonAssociation association = new TranscriptExonAssociation();


### PR DESCRIPTION
## Jira Tickets

- [SCRUM-5829](https://agr-jira.atlassian.net/browse/SCRUM-5829) — Create new Allele Search Result Elasticsearch document
- [SCRUM-5931](https://agr-jira.atlassian.net/browse/SCRUM-5931) — GFF bulk load performance: batch Exon, CDS, and Transcript processing

## Summary

- **Populate `models` field on GeneSearchResultDocument**: Add batch SQL query in GeneDAO that traverses Gene → AlleleGeneAssociation → Allele → AgmAlleleAssociation → AGM → AgmFullNameSlotAnnotation to fetch associated model names. Wire into parallel executor in GeneService.buildSearchResultDocuments().
- **Include Species fields in AlleleSummaryDocument JSON view**: Add `CurationView.AlleleSummaryDocument` to `@JsonView` annotations on Species entity fields (fullName, abbreviation, displayName, commonNames, dataProvider, assembly_curie) and NCBITaxonTerm.species so allele summary documents include species data.
- **Normalize nameKey serialization**: Remove `@JsonProperty("name_key")` / `@JsonbProperty("name_key")` annotations from GeneSearchResultDocument, DiseaseSearchResultDocument, and GOSearchResultDocument so the field serializes as `nameKey` consistently.
- **GFF exon+CDS+transcript batch performance (~25x improvement)**:
  - Batch entity loading: 3000 rows per transaction instead of 3 separate transactions per row
  - Batch-load entities, transcripts, genes, and existing associations via JPQL IN queries
  - Set Hibernate flush mode to COMMIT to eliminate auto-flush overhead
  - Request-scoped transcript and gene caches shared across batches
  - Remove unnecessary addAssociationToSubject/Object lazy collection loads
  - Fix O(n²) `remove(0)` in all GFF header pre-processing loops
  - Add overloaded validator methods accepting pre-loaded associations
- **Cleanup phase optimizations**:
  - Batch deletes via JPQL `DELETE WHERE id IN` (3000 per batch, per-row FK fallback)
  - Replace O(n*m) `ListUtils.subtract` with HashSet-based O(n) diff
  - Replace CriteriaBuilder `getIdsByDataProvider` with direct JPQL (all exon/CDS/transcript services)
  - Add `BaseSQLDAO.removeByIds` bulk delete method

### Performance Results (Human GFF, worst case)
| Load | Before | After | Improvement |
|---|---|---|---|
| Exon (5.4M rows) | ~150 r/s | ~3,800 r/s | 25x |
| CDS (3.9M rows) | ~160 r/s | ~4,000 r/s | 25x |
| Transcript (556K rows) | ~150 r/s | ~3,400 r/s | 23x |
| Cleanup phase | 7+ min | sub-second | - |

## Test plan
- [ ] Deploy to alpha and verify gene search result documents include `models` field with AGM names
- [ ] Verify allele summary documents now include species data
- [ ] Verify `nameKey` (not `name_key`) appears in gene, disease, and GO search result JSON responses
- [ ] Reindex after deploy to populate new fields in ES
- [ ] Run GFF bulk load for HUMAN — verify ~3,500+ r/s for exon, CDS, and transcript
- [ ] Run GFF bulk load for WB — verify cleanup completes in seconds
- [ ] Verify entity counts, location associations, and transcript associations match previous run
- [ ] Verify error reporting still works at per-row granularity (Entities, Locations, Associations)
- [ ] Verify RGD and XB loads correctly filter by taxon in cleanup phase

[SCRUM-5829]: https://agr-jira.atlassian.net/browse/SCRUM-5829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCRUM-5931]: https://agr-jira.atlassian.net/browse/SCRUM-5931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ