### PR TITLE
Release v0.47.16: addRelatedDataLinks field population

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ontology/DoTermDAO.java
@@ -130,6 +130,56 @@ public class DoTermDAO extends BaseSQLDAO<DOTerm> {
 		return entityManager.createNativeQuery(sql).getResultList();
 	}
 
+	public List<Object[]> findAllAlleleSymbols() {
+		String sql = """
+			SELECT sa.singleallele_id, sa.formattext, sp.abbreviation,
+				sp.fullname AS genus_species
+			FROM slotannotation sa
+			JOIN biologicalentity be ON be.id = sa.singleallele_id
+			JOIN ontologyterm taxon ON taxon.id = be.taxon_id
+			JOIN species sp ON sp.taxon_id = taxon.id
+			WHERE sa.slotannotationtype = 'AlleleSymbolSlotAnnotation'
+			AND sa.singleallele_id IS NOT NULL
+			""";
+		return entityManager.createNativeQuery(sql).getResultList();
+	}
+
+	public List<Object[]> findAllAgmNames() {
+		String sql = """
+			SELECT sa.singleagm_id, sa.formattext, sp.abbreviation,
+				sp.fullname AS genus_species
+			FROM slotannotation sa
+			JOIN biologicalentity be ON be.id = sa.singleagm_id
+			JOIN ontologyterm taxon ON taxon.id = be.taxon_id
+			JOIN species sp ON sp.taxon_id = taxon.id
+			WHERE sa.slotannotationtype = 'AgmFullNameSlotAnnotation'
+			AND sa.singleagm_id IS NOT NULL
+			""";
+		return entityManager.createNativeQuery(sql).getResultList();
+	}
+
+	public List<Object[]> findDiseaseAlleleIds() {
+		String sql = """
+			SELECT da.diseaseannotationobject_id AS doterm_id,
+				ada.diseaseannotationsubject_id AS allele_id
+			FROM diseaseannotation da
+			JOIN allelediseaseannotation ada ON ada.id = da.id
+			WHERE da.internal = false AND da.obsolete = false
+			""";
+		return entityManager.createNativeQuery(sql).getResultList();
+	}
+
+	public List<Object[]> findDiseaseAgmIds() {
+		String sql = """
+			SELECT da.diseaseannotationobject_id AS doterm_id,
+				agmda.diseaseannotationsubject_id AS agm_id
+			FROM diseaseannotation da
+			JOIN agmdiseaseannotation agmda ON agmda.id = da.id
+			WHERE da.internal = false AND da.obsolete = false
+			""";
+		return entityManager.createNativeQuery(sql).getResultList();
+	}
+
 	public List<Object[]> findAllDiseaseGroups() {
 		String sql = """
 			SELECT DISTINCT otc.closuresubject_id, ancestor.name

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSearchResultDocument.java
@@ -25,6 +25,8 @@ public class DiseaseSearchResultDocument extends ESDocument {
 	String primaryKey;
 	Set<String> crossReferences = new HashSet<>();
 	Set<String> genes = new HashSet<>();
+	Set<String> alleles = new HashSet<>();
+	Set<String> models = new HashSet<>();
 	Set<String> diseaseGroup = new HashSet<>();
 	Set<String> associatedSpecies = new HashSet<>();
 	String nameKey;

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
@@ -644,7 +644,18 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 
 		// Q16: Models (Gene -> Allele -> AGM)
 		for (Map.Entry<Long, GeneSearchResultDocument> entry : docMap.entrySet()) {
-			entry.getValue().setModels(models.getOrDefault(entry.getKey(), new HashSet<>()));
+			Long id = entry.getKey();
+			Set<String> rawModels = models.getOrDefault(id, new HashSet<>());
+			String abbrev = speciesAbbrevMap.get(id);
+			if (abbrev != null && !rawModels.isEmpty()) {
+				Set<String> formattedModels = new HashSet<>();
+				for (String model : rawModels) {
+					formattedModels.add(model + " (" + abbrev + ")");
+				}
+				entry.getValue().setModels(formattedModels);
+			} else {
+				entry.getValue().setModels(rawModels);
+			}
 		}
 
 		// Return documents in input order

--- a/src/main/java/org/alliancegenome/curation_api/services/ontology/DoTermService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ontology/DoTermService.java
@@ -63,6 +63,14 @@ public class DoTermService extends BaseOntologyTermService<DOTerm, DoTermDAO> im
 		log.info("Loading disease groups...");
 		Map<Long, Set<String>> diseaseGroupMap = groupToSet(doTermDAO.findAllDiseaseGroups());
 
+		log.info("Loading allele symbol cache...");
+		Map<Long, String[]> alleleSymbolCache = buildAlleleSymbolCache();
+		log.info("Cached {} allele symbols", alleleSymbolCache.size());
+
+		log.info("Loading AGM name cache...");
+		Map<Long, String[]> agmNameCache = buildAgmNameCache();
+		log.info("Cached {} AGM names", agmNameCache.size());
+
 		log.info("Loading disease-gene mappings...");
 		List<Object[]> geneIdRows = doTermDAO.findDiseaseGeneIds();
 		log.info("Loaded {} disease-gene pairs", geneIdRows.size());
@@ -83,6 +91,40 @@ public class DoTermService extends BaseOntologyTermService<DOTerm, DoTermDAO> im
 			speciesMap.computeIfAbsent(dotermId, k -> new HashSet<>()).add(genusSpecies);
 		}
 
+		log.info("Loading disease-allele mappings...");
+		List<Object[]> alleleIdRows = doTermDAO.findDiseaseAlleleIds();
+		log.info("Loaded {} disease-allele pairs", alleleIdRows.size());
+
+		Map<Long, Set<String>> allelesMap = new HashMap<>();
+		for (Object[] row : alleleIdRows) {
+			Long dotermId = (Long) row[0];
+			Long alleleId = (Long) row[1];
+			String[] alleleInfo = alleleSymbolCache.get(alleleId);
+			if (alleleInfo == null) {
+				continue;
+			}
+			String symbol = alleleInfo[0];
+			String abbreviation = alleleInfo[1];
+			allelesMap.computeIfAbsent(dotermId, k -> new HashSet<>()).add(symbol + " (" + abbreviation + ")");
+		}
+
+		log.info("Loading disease-model mappings...");
+		List<Object[]> agmIdRows = doTermDAO.findDiseaseAgmIds();
+		log.info("Loaded {} disease-model pairs", agmIdRows.size());
+
+		Map<Long, Set<String>> modelsMap = new HashMap<>();
+		for (Object[] row : agmIdRows) {
+			Long dotermId = (Long) row[0];
+			Long agmId = (Long) row[1];
+			String[] agmInfo = agmNameCache.get(agmId);
+			if (agmInfo == null) {
+				continue;
+			}
+			String name = agmInfo[0];
+			String abbreviation = agmInfo[1];
+			modelsMap.computeIfAbsent(dotermId, k -> new HashSet<>()).add(name + " (" + abbreviation + ")");
+		}
+
 		log.info("Assembling documents...");
 		List<DiseaseSearchResultDocument> docs = new ArrayList<>();
 		for (Object[] base : baseFields) {
@@ -101,6 +143,8 @@ public class DoTermService extends BaseOntologyTermService<DOTerm, DoTermDAO> im
 			doc.setCrossReferences(crossRefsMap.getOrDefault(id, new HashSet<>()));
 			doc.setSecondaryIds(secondaryIdsMap.getOrDefault(id, new HashSet<>()));
 			doc.setGenes(genesMap.getOrDefault(id, new HashSet<>()));
+			doc.setAlleles(allelesMap.getOrDefault(id, new HashSet<>()));
+			doc.setModels(modelsMap.getOrDefault(id, new HashSet<>()));
 			doc.setAssociatedSpecies(speciesMap.getOrDefault(id, new HashSet<>()));
 			doc.setDiseaseGroup(diseaseGroupMap.getOrDefault(id, new HashSet<>()));
 			docs.add(doc);
@@ -119,6 +163,32 @@ public class DoTermService extends BaseOntologyTermService<DOTerm, DoTermDAO> im
 			String abbreviation = (String) row[2];
 			String genusSpecies = (String) row[3];
 			cache.put(geneId, new String[]{symbol, abbreviation, genusSpecies});
+		}
+		return cache;
+	}
+
+	private Map<Long, String[]> buildAlleleSymbolCache() {
+		List<Object[]> rows = doTermDAO.findAllAlleleSymbols();
+		Map<Long, String[]> cache = new HashMap<>();
+		for (Object[] row : rows) {
+			Long alleleId = (Long) row[0];
+			String symbol = (String) row[1];
+			String abbreviation = (String) row[2];
+			String genusSpecies = (String) row[3];
+			cache.put(alleleId, new String[]{symbol, abbreviation, genusSpecies});
+		}
+		return cache;
+	}
+
+	private Map<Long, String[]> buildAgmNameCache() {
+		List<Object[]> rows = doTermDAO.findAllAgmNames();
+		Map<Long, String[]> cache = new HashMap<>();
+		for (Object[] row : rows) {
+			Long agmId = (Long) row[0];
+			String name = (String) row[1];
+			String abbreviation = (String) row[2];
+			String genusSpecies = (String) row[3];
+			cache.put(agmId, new String[]{name, abbreviation, genusSpecies});
 		}
 		return cache;
 	}


### PR DESCRIPTION
## Summary
- Append species abbreviation to `models` field on gene search result documents (matching model `nameKey` format for cross-category linking)
- Add `alleles` and `models` fields to disease search result documents with species abbreviation
- Add DAO queries for disease-allele and disease-model associations, allele symbol cache, and AGM name cache

## Context
These changes support the `addRelatedDataLinks` feature in the search API, which links search results across categories (gene, disease, allele, model) using `nameKey` field lookups. Previously, gene `models` values lacked the species abbreviation suffix, and disease documents had no `alleles` or `models` fields.

## Test plan
- [ ] Verify gene documents have `models` values with species abbreviation (e.g., `"modelName (Mmu)"`)
- [ ] Verify disease documents have populated `alleles` and `models` fields
- [ ] Run addRelatedDataLinks audit on stage after indexer run to confirm cross-category links resolve