### PR TITLE
Release v0.47.17: populate diseasesAgrSlim on gene documents

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
@@ -352,6 +352,32 @@ public class GeneDAO extends BaseSQLDAO<Gene> {
 			""", geneIds);
 	}
 
+	public Map<Long, Set<String>> getGeneDiseaseAgrSlim(List<Long> geneIds) {
+		if (CollectionUtils.isEmpty(geneIds)) {
+			return new HashMap<>();
+		}
+		return runJdbcSetQuery("""
+			SELECT gene_id, ancestor.name
+			FROM (
+				SELECT DISTINCT gda.diseaseannotationsubject_id AS gene_id, da.diseaseannotationobject_id AS doterm_id
+				FROM genediseaseannotation gda
+				JOIN diseaseannotation da ON da.id = gda.id
+				WHERE gda.diseaseannotationsubject_id IN :geneIds
+				UNION
+				SELECT DISTINCT o.subjectgene_id AS gene_id, da.diseaseannotationobject_id AS doterm_id
+				FROM genetogeneorthology o
+				JOIN genetogeneorthologygenerated og ON og.id = o.id AND og.strictfilter = true
+				JOIN genediseaseannotation gda ON gda.diseaseannotationsubject_id = o.objectgene_id
+				JOIN diseaseannotation da ON da.id = gda.id
+				WHERE o.subjectgene_id IN :geneIds
+			) gene_diseases
+			JOIN ontologytermclosure otc ON otc.closuresubject_id = gene_diseases.doterm_id
+			JOIN ontologyterm ancestor ON ancestor.id = otc.closureobject_id
+			JOIN ontologyterm_subsets sub ON sub.ontologyterm_id = ancestor.id
+			WHERE sub.subsets = 'DO_AGR_slim'
+			""", geneIds);
+	}
+
 	public Map<Long, Set<String>> getStrictOrthologySymbols(List<Long> geneIds) {
 		if (CollectionUtils.isEmpty(geneIds)) {
 			return new HashMap<>();

--- a/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
@@ -524,6 +524,22 @@ public class GeneDAO extends BaseSQLDAO<Gene> {
 			""", geneIds);
 	}
 
+	public Map<Long, Set<String>> getExpressionAnatomicalSlim(List<Long> geneIds) {
+		if (CollectionUtils.isEmpty(geneIds)) {
+			return new HashMap<>();
+		}
+		return runJdbcSetQuery("""
+			SELECT gea.expressionannotationsubject_id, ot.name
+			FROM geneexpressionannotation gea
+			JOIN expressionpattern ep ON ep.id = gea.expressionpattern_id
+			JOIN anatomicalsite ans ON ans.id = ep.whereexpressed_id
+			JOIN anatomicalsite_anatomicalstructureuberonterms asut
+				ON asut.anatomicalsite_id = ans.id
+			JOIN ontologyterm ot ON ot.id = asut.anatomicalstructureuberonterms_id
+			WHERE gea.expressionannotationsubject_id IN :geneIds
+			""", geneIds);
+	}
+
 	public List<Object[]> getWhereExpressedAndStages(List<Long> geneIds) {
 		if (CollectionUtils.isEmpty(geneIds)) {
 			return new ArrayList<>();

--- a/src/main/java/org/alliancegenome/curation_api/model/document/builders/HTPDatasetDocumentBuilder.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/builders/HTPDatasetDocumentBuilder.java
@@ -80,7 +80,7 @@ public class HTPDatasetDocumentBuilder {
 
 		if (sampleAnnots != null && !sampleAnnots.isEmpty()) {
 			Set<String> whereExpressed = new HashSet<>();
-			Set<String> anatomicalExpression = new HashSet<>();
+			Set<String> anatomicalExpressionSlim = new HashSet<>();
 			Set<String> anatomicalExpressionWithParents = new HashSet<>();
 			Set<String> sampleIds = new HashSet<>();
 			Set<String> assays = new HashSet<>();
@@ -102,7 +102,7 @@ public class HTPDatasetDocumentBuilder {
 									return site.getAnatomicalStructure().getName();
 								}).collect(Collectors.toList()));
 
-				anatomicalExpression.addAll(
+				anatomicalExpressionSlim.addAll(
 						sampleAnnot
 								.getHtpExpressionSampleLocations()
 								.stream()
@@ -136,7 +136,7 @@ public class HTPDatasetDocumentBuilder {
 			}
 
 			doc.setWhereExpressed(whereExpressed);
-			doc.setAnatomicalExpression(anatomicalExpression);
+			doc.setAnatomicalExpressionSlim(anatomicalExpressionSlim);
 			doc.setAnatomicalExpressionWithParents(anatomicalExpressionWithParents);
 			doc.setSampleIds(sampleIds);
 			doc.setAssays(assays);

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneSearchResultDocument.java
@@ -24,26 +24,22 @@ public class GeneSearchResultDocument extends ESDocument {
 	private String nameKey;
 	private String species;
 	private String symbol;
-
+	private String soTermId;
+	private String soTermName;
+	
 	private Set<String> chromosomes;
 	private Set<String> crossReferences;
 	private Set<String> synonyms;
 	private Set<String> secondaryIds;
 	private Set<String> alleles;
-
 	private Set<String> phenotypeStatements;
-
 	private Set<String> biotypes;
 	private Set<String> biotype0;
 	private Set<String> biotype1;
 	private Set<String> biotype2;
-	private String soTermId;
-	private String soTermName;
 	private Set<String> soTermNameWithParents;
-
 	private Set<String> expressionStages;
 	private Set<String> whereExpressed;
-
 	private Set<String> diseases;
 	private Set<String> diseasesAgrSlim;
 	private Set<String> diseasesWithParents;
@@ -55,13 +51,9 @@ public class GeneSearchResultDocument extends ESDocument {
 	private Set<String> cellularComponentWithParents;
 	private Set<String> subcellularExpressionAgrSlim;
 	private Set<String> subcellularExpressionWithParents;
-
 	private Set<String> anatomicalExpressionSlim;
 	private Set<String> anatomicalExpressionWithParents;
-
 	private Set<String> strictOrthologySymbols;
-
-	// Gene -> AlleleGeneAssociation -> Allele -> AgmAlleleAssociation -> AGM -> Symbol
 	private Set<String> models;
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneSearchResultDocument.java
@@ -56,7 +56,7 @@ public class GeneSearchResultDocument extends ESDocument {
 	private Set<String> subcellularExpressionAgrSlim;
 	private Set<String> subcellularExpressionWithParents;
 
-	// private Set<String> anatomicalExpression; // uberon slim
+	private Set<String> anatomicalExpressionSlim;
 	private Set<String> anatomicalExpressionWithParents;
 
 	private Set<String> strictOrthologySymbols;

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneSearchResultDocument.java
@@ -45,7 +45,7 @@ public class GeneSearchResultDocument extends ESDocument {
 	private Set<String> whereExpressed;
 
 	private Set<String> diseases;
-	// private Set<String> diseasesAgrSlim;
+	private Set<String> diseasesAgrSlim;
 	private Set<String> diseasesWithParents;
 	private Set<String> molecularFunctionAgrSlim;
 	private Set<String> molecularFunctionWithParents;

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/HTPDatasetSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/HTPDatasetSearchResultDocument.java
@@ -27,7 +27,7 @@ public class HTPDatasetSearchResultDocument extends ESDocument {
 	private Set<String> tags;
 	private Set<String> variantType;
 	private Set<String> whereExpressed;
-	private Set<String> anatomicalExpression;
+	private Set<String> anatomicalExpressionSlim;
 	private Set<String> anatomicalExpressionWithParents;
 	private Set<String> assays;
 	private Set<String> crossReferences;

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
@@ -382,11 +382,12 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 		CompletableFuture<List<Object[]>> whereExpressedFuture = CompletableFuture.supplyAsync(() -> geneDAO.getWhereExpressedAndStages(geneIds), executor);
 		CompletableFuture<List<Object[]>> descriptionFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneDescriptions(geneIds), executor);
 		CompletableFuture<Map<Long, Set<String>>> modelsFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneModels(geneIds), executor);
+		CompletableFuture<Map<Long, Set<String>>> diseaseAgrSlimFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneDiseaseAgrSlim(geneIds), executor);
 
 		CompletableFuture.allOf(baseInfoFuture, soAncestorsFuture, synonymsFuture, secondaryIdsFuture,
 			crossRefsFuture, chromosomesFuture, allelesFuture, phenotypesFuture, directDiseaseFuture,
 			strictOrthoFuture, orthoDiseaseFuture, goFuture, subcellularFuture, anatomicalFuture,
-			whereExpressedFuture, descriptionFuture, modelsFuture).join();
+			whereExpressedFuture, descriptionFuture, modelsFuture, diseaseAgrSlimFuture).join();
 		executor.shutdown();
 
 		List<Object[]> baseInfoRows = baseInfoFuture.join();
@@ -406,6 +407,7 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 		List<Object[]> whereExpressedRows = whereExpressedFuture.join();
 		List<Object[]> descriptionRows = descriptionFuture.join();
 		Map<Long, Set<String>> models = modelsFuture.join();
+		Map<Long, Set<String>> diseaseAgrSlim = diseaseAgrSlimFuture.join();
 
 		// Build base documents from Q1
 		Map<Long, GeneSearchResultDocument> docMap = new HashMap<>();
@@ -525,6 +527,7 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 			GeneSearchResultDocument doc = entry.getValue();
 			doc.setDiseases(diseases.getOrDefault(id, new HashSet<>()));
 			doc.setDiseasesWithParents(diseasesWithParents.getOrDefault(id, new HashSet<>()));
+			doc.setDiseasesAgrSlim(diseaseAgrSlim.getOrDefault(id, new HashSet<>()));
 		}
 
 		// Q10a: Strict orthology symbols

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
@@ -379,6 +379,7 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 		CompletableFuture<List<Object[]>> goFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneGoTerms(geneIds), executor);
 		CompletableFuture<List<Object[]>> subcellularFuture = CompletableFuture.supplyAsync(() -> geneDAO.getExpressionSubcellularCC(geneIds), executor);
 		CompletableFuture<Map<Long, Set<String>>> anatomicalFuture = CompletableFuture.supplyAsync(() -> geneDAO.getExpressionAnatomical(geneIds), executor);
+		CompletableFuture<Map<Long, Set<String>>> anatomicalSlimFuture = CompletableFuture.supplyAsync(() -> geneDAO.getExpressionAnatomicalSlim(geneIds), executor);
 		CompletableFuture<List<Object[]>> whereExpressedFuture = CompletableFuture.supplyAsync(() -> geneDAO.getWhereExpressedAndStages(geneIds), executor);
 		CompletableFuture<List<Object[]>> descriptionFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneDescriptions(geneIds), executor);
 		CompletableFuture<Map<Long, Set<String>>> modelsFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneModels(geneIds), executor);
@@ -387,7 +388,7 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 		CompletableFuture.allOf(baseInfoFuture, soAncestorsFuture, synonymsFuture, secondaryIdsFuture,
 			crossRefsFuture, chromosomesFuture, allelesFuture, phenotypesFuture, directDiseaseFuture,
 			strictOrthoFuture, orthoDiseaseFuture, goFuture, subcellularFuture, anatomicalFuture,
-			whereExpressedFuture, descriptionFuture, modelsFuture, diseaseAgrSlimFuture).join();
+			anatomicalSlimFuture, whereExpressedFuture, descriptionFuture, modelsFuture, diseaseAgrSlimFuture).join();
 		executor.shutdown();
 
 		List<Object[]> baseInfoRows = baseInfoFuture.join();
@@ -404,6 +405,7 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 		List<Object[]> goRows = goFuture.join();
 		List<Object[]> subcellularRows = subcellularFuture.join();
 		Map<Long, Set<String>> anatomical = anatomicalFuture.join();
+		Map<Long, Set<String>> anatomicalSlim = anatomicalSlimFuture.join();
 		List<Object[]> whereExpressedRows = whereExpressedFuture.join();
 		List<Object[]> descriptionRows = descriptionFuture.join();
 		Map<Long, Set<String>> models = modelsFuture.join();
@@ -606,6 +608,7 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 
 		// Q13: Expression anatomical
 		for (Map.Entry<Long, GeneSearchResultDocument> entry : docMap.entrySet()) {
+			entry.getValue().setAnatomicalExpressionSlim(anatomicalSlim.getOrDefault(entry.getKey(), new HashSet<>()));
 			entry.getValue().setAnatomicalExpressionWithParents(anatomical.getOrDefault(entry.getKey(), new HashSet<>()));
 		}
 


### PR DESCRIPTION
## Summary
- Populate `diseasesAgrSlim` field on gene search result documents
- Query covers both direct gene disease annotations and ortholog-inferred diseases
- Filters to DO_AGR_slim subset terms via ontology closure

## Test plan
- [ ] Verify gene documents have `diseasesAgrSlim` populated with DO slim terms
- [ ] Compare with allele document `diseasesAgrSlim` for consistency