### PR TITLE
release/v0.47.18

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
@@ -9,6 +9,7 @@ import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
 import org.alliancegenome.curation_api.model.entities.CrossReference;
 import org.alliancegenome.curation_api.model.entities.Synonym;
 import org.alliancegenome.curation_api.model.entities.base.CurieObject;
+import org.alliancegenome.curation_api.model.serializers.OntologyTermAncestorSerializer;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.hibernate.search.engine.backend.types.Aggregable;
 import org.hibernate.search.engine.backend.types.Searchable;
@@ -21,6 +22,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordFie
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorColumn;
@@ -111,7 +113,8 @@ public class OntologyTerm extends CurieObject {
 	@JsonView({ CurationView.FieldsAndLists.class })
 	private List<CrossReference> crossReferences;
 
-	@JsonIgnore // We are going to have individual endpoints for these fields
+	@JsonView({ CurationView.GeneSummaryDocument.class })
+	@JsonSerialize(using = OntologyTermAncestorSerializer.class)
 	@OneToMany(mappedBy = "closureSubject")
 	private Set<OntologyTermClosure> ancestors;
 

--- a/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorSerializer.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorSerializer.java
@@ -1,0 +1,29 @@
+package org.alliancegenome.curation_api.model.serializers;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.alliancegenome.curation_api.model.entities.ontology.OntologyTermClosure;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+public class OntologyTermAncestorSerializer extends JsonSerializer<Set<OntologyTermClosure>> {
+
+	@Override
+	public void serialize(Set<OntologyTermClosure> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+		List<String> ancestorCuries = new ArrayList<>();
+		if (value != null) {
+			for (OntologyTermClosure closure : value) {
+				if (closure.getClosureObject() != null && closure.getClosureObject().getCurie() != null) {
+					ancestorCuries.add(closure.getClosureObject().getCurie());
+				}
+			}
+		}
+		gen.writeObject(ancestorCuries);
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `OntologyTermAncestorSerializer` to serialize ontology term ancestors as an `ArrayList<String>` of curies (extracted from `OntologyTermClosure.closureObject.curie`)
- Expose `ancestors` field on `OntologyTerm` in the `GeneSummaryDocument` JSON view (previously `@JsonIgnore`)

## Test plan
- [ ] Verify gene summary document endpoint returns ancestor curies as a JSON array of strings
- [ ] Confirm ontology terms with no ancestors serialize as an empty array
- [ ] Validate no regression on other OntologyTerm serialization views

🤖 Generated with [Claude Code](https://claude.com/claude-code)