### PR TITLE
release/v0.47.20

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
@@ -24,6 +24,7 @@ import org.alliancegenome.curation_api.model.entities.Note;
 import org.alliancegenome.curation_api.model.entities.Organization;
 import org.alliancegenome.curation_api.model.entities.PredictedVariantConsequence;
 import org.alliancegenome.curation_api.model.entities.ResourceDescriptorPage;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.Transcript;
 import org.alliancegenome.curation_api.model.entities.Variant;
 import org.alliancegenome.curation_api.model.entities.VocabularyTerm;
@@ -275,7 +276,11 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 			org.id,
 			org.abbreviation,
 			org.fullname,
-			org.shortname
+			org.shortname,
+			sp.abbreviation,
+			sp.fullname,
+			sp.displayname,
+			sp.assembly_curie
 			FROM Allele a
 			INNER JOIN BiologicalEntity b ON b.id = a.id
 			INNER JOIN SlotAnnotation s ON a.id = s.singleallele_id
@@ -285,6 +290,7 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 			INNER JOIN CrossReference cr ON cr.id = b.dataprovidercrossreference_id
 			INNER JOIN resourceDescriptorPage rd ON rd.id = cr.resourcedescriptorpage_id
 			INNER JOIN organization org ON org.id = b.dataprovider_id
+			LEFT JOIN species sp ON sp.taxon_id = ot.id
 			WHERE a.id IN :alleleIds
 			""";
 
@@ -321,6 +327,14 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 				NCBITaxonTerm term = new NCBITaxonTerm();
 				term.setCurie((String) row[6]);
 				term.setName((String) row[7]);
+				if (row[16] != null) {
+					Species species = new Species();
+					species.setAbbreviation((String) row[16]);
+					species.setFullName((String) row[17]);
+					species.setDisplayName((String) row[18]);
+					species.setAssembly_curie((String) row[19]);
+					term.setSpecies(species);
+				}
 				allele.setTaxon(term);
 			}
 			if (row[8] != null || row[9] != null) {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
@@ -117,7 +117,7 @@ public class OntologyTerm extends CurieObject {
 
 	@JsonView({ CurationView.GeneSummaryDocument.class })
 	@JsonSerialize(using = OntologyTermAncestorSerializer.class)
-	@JsonDeserialize(using = OntologyTermAncestorDeserializer.class)
+	@JsonDeserialize(converter = OntologyTermAncestorDeserializer.class)
 	@OneToMany(mappedBy = "closureSubject")
 	private Set<OntologyTermClosure> ancestors;
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
@@ -9,6 +9,7 @@ import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
 import org.alliancegenome.curation_api.model.entities.CrossReference;
 import org.alliancegenome.curation_api.model.entities.Synonym;
 import org.alliancegenome.curation_api.model.entities.base.CurieObject;
+import org.alliancegenome.curation_api.model.serializers.OntologyTermAncestorDeserializer;
 import org.alliancegenome.curation_api.model.serializers.OntologyTermAncestorSerializer;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.hibernate.search.engine.backend.types.Aggregable;
@@ -22,6 +23,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordFie
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import jakarta.persistence.Column;
@@ -115,6 +117,7 @@ public class OntologyTerm extends CurieObject {
 
 	@JsonView({ CurationView.GeneSummaryDocument.class })
 	@JsonSerialize(using = OntologyTermAncestorSerializer.class)
+	@JsonDeserialize(using = OntologyTermAncestorDeserializer.class)
 	@OneToMany(mappedBy = "closureSubject")
 	private Set<OntologyTermClosure> ancestors;
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
@@ -116,7 +116,7 @@ public class OntologyTerm extends CurieObject {
 	private List<CrossReference> crossReferences;
 
 	@JsonView({ CurationView.GeneSummaryDocument.class })
-	@JsonSerialize(using = OntologyTermAncestorSerializer.class)
+	@JsonSerialize(converter = OntologyTermAncestorSerializer.class)
 	@JsonDeserialize(converter = OntologyTermAncestorDeserializer.class)
 	@OneToMany(mappedBy = "closureSubject")
 	private Set<OntologyTermClosure> ancestors;

--- a/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorDeserializer.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorDeserializer.java
@@ -1,0 +1,27 @@
+package org.alliancegenome.curation_api.model.serializers;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.alliancegenome.curation_api.model.entities.ontology.OntologyTermClosure;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+public class OntologyTermAncestorDeserializer extends JsonDeserializer<Set<OntologyTermClosure>> {
+
+	@Override
+	public Set<OntologyTermClosure> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+		Set<OntologyTermClosure> closures = new HashSet<>();
+		if (p.currentToken() == JsonToken.START_ARRAY) {
+			while (p.nextToken() != JsonToken.END_ARRAY) {
+				// Skip the curie strings - they are only needed for ES indexing
+			}
+		}
+		return closures;
+	}
+
+}

--- a/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorDeserializer.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorDeserializer.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.alliancegenome.curation_api.model.entities.ontology.OntologyTerm;
 import org.alliancegenome.curation_api.model.entities.ontology.OntologyTermClosure;
 
 import com.fasterxml.jackson.core.JsonParser;
@@ -18,7 +19,12 @@ public class OntologyTermAncestorDeserializer extends JsonDeserializer<Set<Ontol
 		Set<OntologyTermClosure> closures = new HashSet<>();
 		if (p.currentToken() == JsonToken.START_ARRAY) {
 			while (p.nextToken() != JsonToken.END_ARRAY) {
-				// Skip the curie strings - they are only needed for ES indexing
+				String curie = p.getText();
+				OntologyTerm term = new OntologyTerm();
+				term.setCurie(curie);
+				OntologyTermClosure closure = new OntologyTermClosure();
+				closure.setClosureObject(term);
+				closures.add(closure);
 			}
 		}
 		return closures;

--- a/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorDeserializer.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorDeserializer.java
@@ -1,29 +1,25 @@
 package org.alliancegenome.curation_api.model.serializers;
 
-import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.alliancegenome.curation_api.model.entities.ontology.OntologyTerm;
 import org.alliancegenome.curation_api.model.entities.ontology.OntologyTermClosure;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.util.StdConverter;
 
-public class OntologyTermAncestorDeserializer extends JsonDeserializer<Set<OntologyTermClosure>> {
+public class OntologyTermAncestorDeserializer extends StdConverter<List<String>, Set<OntologyTermClosure>> {
 
 	@Override
-	public Set<OntologyTermClosure> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+	public Set<OntologyTermClosure> convert(List<String> curies) {
 		Set<OntologyTermClosure> closures = new HashSet<>();
-		if (p.currentToken() == JsonToken.START_ARRAY) {
-			while (p.nextToken() != JsonToken.END_ARRAY) {
-				String curie = p.getText();
-				OntologyTerm term = new OntologyTerm();
-				term.setCurie(curie);
+		if (curies != null) {
+			for (String curie : curies) {
+				OntologyTerm ancestorTerm = new OntologyTerm();
+				ancestorTerm.setCurie(curie);
 				OntologyTermClosure closure = new OntologyTermClosure();
-				closure.setClosureObject(term);
+				closure.setClosureObject(ancestorTerm);
 				closures.add(closure);
 			}
 		}

--- a/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorSerializer.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorSerializer.java
@@ -1,20 +1,17 @@
 package org.alliancegenome.curation_api.model.serializers;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 import org.alliancegenome.curation_api.model.entities.ontology.OntologyTermClosure;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.util.StdConverter;
 
-public class OntologyTermAncestorSerializer extends JsonSerializer<Set<OntologyTermClosure>> {
+public class OntologyTermAncestorSerializer extends StdConverter<Set<OntologyTermClosure>, List<String>> {
 
 	@Override
-	public void serialize(Set<OntologyTermClosure> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+	public List<String> convert(Set<OntologyTermClosure> value) {
 		List<String> ancestorCuries = new ArrayList<>();
 		if (value != null) {
 			for (OntologyTermClosure closure : value) {
@@ -23,7 +20,7 @@ public class OntologyTermAncestorSerializer extends JsonSerializer<Set<OntologyT
 				}
 			}
 		}
-		gen.writeObject(ancestorCuries);
+		return ancestorCuries;
 	}
 
 }


### PR DESCRIPTION
## Summary
- Add `OntologyTermAncestorSerializer` to serialize ontology term ancestors as a `List<String>` of curies for the `GeneSummaryDocument` JSON view
- Add `OntologyTermAncestorDeserializer` (`StdConverter<List<String>, Set<OntologyTermClosure>>`) to reconstruct minimal closure objects from curie strings during indexer deserialization
- Expose `ancestors` field on `OntologyTerm` in the `GeneSummaryDocument` view (previously `@JsonIgnore`)
- Include species data in allele summary document endpoint

## Test plan
- [ ] Verify GeneSummaryCurationIndexer completes without `UndeclaredThrowableException`
- [ ] Confirm gene summary documents in ES contain ancestor curie arrays
- [ ] Validate round-trip: DB → API serialization → indexer deserialization → ES indexing preserves all ancestor curies

🤖 Generated with [Claude Code](https://claude.com/claude-code)