### PR TITLE
fix: use species.fullname for gene search result species

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
@@ -219,7 +219,7 @@ public class GeneDAO extends BaseSQLDAO<Gene> {
 			return new ArrayList<>();
 		}
 		return runJdbcQuery("""
-			SELECT g.id, be.primaryexternalid, fn.formattext, ot_taxon.name, sp.abbreviation,
+			SELECT g.id, be.primaryexternalid, fn.formattext, sp.fullname, sp.abbreviation,
 				sym.displaytext, so.curie, so.name
 			FROM gene g
 			JOIN biologicalentity be ON be.id = g.id AND be.obsolete = false AND be.internal = false


### PR DESCRIPTION
## Summary
- Use `sp.fullname` instead of `ot_taxon.name` in gene search result document query
- Fixes two species mismatches: "Saccharomyces cerevisiae S288C" -> "Saccharomyces cerevisiae" and "Severe acute respiratory syndrome coronavirus 2" -> "SARS-CoV-2"
- Aligns gene search results with how allele summary documents already populate species

## Test plan
- [ ] Verify gene search results show correct species names after reindex
- [ ] Confirm SGD and SARS-CoV-2 genes display updated species names