### PR TITLE
SCRUM-2758 Add JsonView for taxon.species.fullName serialization

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/BiologicalEntity.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/BiologicalEntity.java
@@ -70,7 +70,7 @@ public class BiologicalEntity extends SubmittedObject {
 	@IndexedEmbedded(includePaths = {"name", "curie", "name_keyword", "curie_keyword"})
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.TransgenicAllelesDocument.class })
 	private NCBITaxonTerm taxon;
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
@@ -62,7 +62,7 @@ public class Species extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "fullName_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class })
 	private String fullName;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java
@@ -26,7 +26,7 @@ import lombok.ToString;
 public class NCBITaxonTerm extends OntologyTerm {
 
 	@OneToOne(mappedBy = "taxon", cascade = CascadeType.ALL, orphanRemoval = true)
-	@JsonView({CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class})
+	@JsonView({CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class})
 	private Species species;
 
 }


### PR DESCRIPTION
## Summary
- Add `ForPublic`, `GeneExpressionDocument`, and `TransgenicAllelesDocument` views to `NCBITaxonTerm.species` and `Species.fullName` so species name is serialized in disease annotation, interaction, expression, and transgenic allele document endpoints
- Add `TransgenicAllelesDocument` view to `BiologicalEntity.taxon` (was missing entirely)

## Test plan
- [ ] Deploy to stage and verify curation API endpoints return `taxon.species.fullName` in responses:
  - `POST /gene-disease-annotation/findForPublic`
  - `POST /genegeneticinteraction/document/byids`
  - `POST /genemolecularinteraction/document/byids`
  - `POST /gene-expression/document/`
  - `POST /allele/document/transgenic`
- [ ] Run indexer on stage and verify ES documents contain `taxon.species.fullName` field