### PR TITLE
SCRUM-2758 Add TransgenicAllelesDocument to SearchResponse JsonView

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/response/SearchResponse.java
+++ b/src/main/java/org/alliancegenome/curation_api/response/SearchResponse.java
@@ -30,7 +30,8 @@ import lombok.Data;
 	CurationView.VariantSummaryDocument.class,
 	CurationView.SequenceSummaryDocument.class,
 	CurationView.HTPDatasetSearchResultDocument.class,
-	CurationView.GeneExpressionDocument.class
+	CurationView.GeneExpressionDocument.class,
+	CurationView.TransgenicAllelesDocument.class
 })
 public class SearchResponse<E> extends APIResponse {
 


### PR DESCRIPTION
## Summary
- Add `TransgenicAllelesDocument` to `SearchResponse` class-level `@JsonView` list
- Without this, the transgenic allele document endpoint (`/allele/document/transgenic`) returns `{}` because the entire SearchResponse is stripped by the view

## Test plan
- [ ] Verify `POST /allele/document/transgenic?limit=1` returns results with `allele.taxon.species.fullName` populated