### PR TITLE
release/v0.47.25

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/VariantSummaryDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/VariantSummaryDocument.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.alliancegenome.curation_api.model.entities.Variant;
 import org.alliancegenome.curation_api.view.CurationView;
+
 import com.fasterxml.jackson.annotation.JsonView;
 
 import lombok.Data;
@@ -16,6 +17,8 @@ public class VariantSummaryDocument extends AVSParentDocument {
 
 	{
 		category = "variant_summary";
+		alterationType = "variant";
+		alterationTypeSortOrder = 4;
 	}
 	private List<Variant> variants;
 }


### PR DESCRIPTION
## Summary
- Set `alterationType` to `"variant"` and `alterationTypeSortOrder` to `4` on `VariantSummaryDocument` initializer block

## Test plan
- [ ] Verify variant summary documents include the new fields when serialized
- [ ] Confirm variant indexer picks up the alterationType for search result categorization