### PR TITLE
SCRUM-5854: serialize ancestors as curie-to-relationship-types map

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorDeserializer.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorDeserializer.java
@@ -1,7 +1,8 @@
 package org.alliancegenome.curation_api.model.serializers;
 
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.alliancegenome.curation_api.model.entities.ontology.OntologyTerm;
@@ -9,17 +10,18 @@ import org.alliancegenome.curation_api.model.entities.ontology.OntologyTermClosu
 
 import com.fasterxml.jackson.databind.util.StdConverter;
 
-public class OntologyTermAncestorDeserializer extends StdConverter<List<String>, Set<OntologyTermClosure>> {
+public class OntologyTermAncestorDeserializer extends StdConverter<HashMap<String, Set<String>>, Set<OntologyTermClosure>> {
 
 	@Override
-	public Set<OntologyTermClosure> convert(List<String> curies) {
+	public Set<OntologyTermClosure> convert(HashMap<String, Set<String>> curies) {
 		Set<OntologyTermClosure> closures = new HashSet<>();
 		if (curies != null) {
-			for (String curie : curies) {
+			for (Map.Entry<String, Set<String>> entry : curies.entrySet()) {
 				OntologyTerm ancestorTerm = new OntologyTerm();
-				ancestorTerm.setCurie(curie);
+				ancestorTerm.setCurie(entry.getKey());
 				OntologyTermClosure closure = new OntologyTermClosure();
 				closure.setClosureObject(ancestorTerm);
+				closure.setClosureTypes(entry.getValue());
 				closures.add(closure);
 			}
 		}

--- a/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorSerializer.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorSerializer.java
@@ -1,22 +1,21 @@
 package org.alliancegenome.curation_api.model.serializers;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Set;
 
 import org.alliancegenome.curation_api.model.entities.ontology.OntologyTermClosure;
 
 import com.fasterxml.jackson.databind.util.StdConverter;
 
-public class OntologyTermAncestorSerializer extends StdConverter<Set<OntologyTermClosure>, List<String>> {
+public class OntologyTermAncestorSerializer extends StdConverter<Set<OntologyTermClosure>, HashMap<String, Set<String>>> {
 
 	@Override
-	public List<String> convert(Set<OntologyTermClosure> value) {
-		List<String> ancestorCuries = new ArrayList<>();
+	public HashMap<String, Set<String>> convert(Set<OntologyTermClosure> value) {
+		HashMap<String, Set<String>> ancestorCuries = new HashMap<>();
 		if (value != null) {
 			for (OntologyTermClosure closure : value) {
 				if (closure.getClosureObject() != null && closure.getClosureObject().getCurie() != null) {
-					ancestorCuries.add(closure.getClosureObject().getCurie());
+					ancestorCuries.put(closure.getClosureObject().getCurie(), closure.getClosureTypes());
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- **OntologyTermAncestorSerializer**: Changed output from `List<String>` to `HashMap<String, Set<String>>` mapping ancestor curies to their closure relationship types (e.g., `is_a`, `part_of`)
- **OntologyTermAncestorDeserializer**: Fixed type signature and iteration to match the new map format, preserves `closureTypes` on reconstructed `OntologyTermClosure` objects

This enables the UI to distinguish `is_a`-only ancestors from `part_of` ancestors when classifying gene pages as "GENE" vs "GENOME FEATURE". Terms like `promoter` (SO:0000167), `CTCF_binding_site` (SO:0001974), and `intein_encoding_region` (SO:0002026) are ancestors of `gene` (SO:0000704) only via `part_of` relationships and should not be classified as genes.

## Test plan
- [ ] Verify API response for a gene page includes `geneType.ancestors` as a map of `{curie: [relationshipTypes]}`
- [ ] Verify `promoter` (SO:0000167) has `SO:0000704` with `["is_a", "part_of"]` (not `["is_a"]` alone)
- [ ] Verify `protein_coding_gene` (SO:0001217) has `SO:0000704` with `["is_a"]`
- [ ] Full re-index of gene summary documents after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)