### PR TITLE
feat: add GET /soterm/severity-ranking endpoint (SCRUM-5881)

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/controllers/crud/ontology/SoTermCrudController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/crud/ontology/SoTermCrudController.java
@@ -1,5 +1,7 @@
 package org.alliancegenome.curation_api.controllers.crud.ontology;
 
+import java.util.Map;
+
 import org.alliancegenome.curation_api.controllers.base.BaseOntologyTermController;
 import org.alliancegenome.curation_api.dao.ontology.SoTermDAO;
 import org.alliancegenome.curation_api.interfaces.crud.ontology.SoTermCrudInterface;
@@ -20,6 +22,11 @@ public class SoTermCrudController extends BaseOntologyTermController<SoTermServi
 	@PostConstruct
 	public void init() {
 		setService(soTermService, SOTerm.class);
+	}
+
+	@Override
+	public Map<String, Integer> getSeverityRanking() {
+		return soTermService.getSeverityRanking();
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/dao/ontology/SoTermDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ontology/SoTermDAO.java
@@ -1,15 +1,33 @@
 package org.alliancegenome.curation_api.dao.ontology;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.entities.ontology.SOTerm;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.Query;
 
 @ApplicationScoped
 public class SoTermDAO extends BaseSQLDAO<SOTerm> {
 
 	protected SoTermDAO() {
 		super(SOTerm.class);
+	}
+
+	public Map<String, Integer> getSeverityRanking() {
+		Query query = entityManager.createNativeQuery(
+			"SELECT name, severityorder FROM ontologyterm WHERE ontologytermtype = 'SOTerm' AND severityorder IS NOT NULL"
+		);
+		@SuppressWarnings("unchecked")
+		List<Object[]> rows = query.getResultList();
+		Map<String, Integer> ranking = new HashMap<>();
+		for (Object[] row : rows) {
+			ranking.put((String) row[0], (Integer) row[1]);
+		}
+		return ranking;
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ontology/SoTermCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ontology/SoTermCrudInterface.java
@@ -1,10 +1,13 @@
 package org.alliancegenome.curation_api.interfaces.crud.ontology;
 
+import java.util.Map;
+
 import org.alliancegenome.curation_api.interfaces.base.BaseOntologyTermCrudInterface;
 import org.alliancegenome.curation_api.model.entities.ontology.SOTerm;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
@@ -14,5 +17,9 @@ import jakarta.ws.rs.core.MediaType;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public interface SoTermCrudInterface extends BaseOntologyTermCrudInterface<SOTerm> {
+
+	@GET
+	@Path("/severity-ranking")
+	Map<String, Integer> getSeverityRanking();
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/ontology/SoTermService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ontology/SoTermService.java
@@ -1,5 +1,7 @@
 package org.alliancegenome.curation_api.services.ontology;
 
+import java.util.Map;
+
 import org.alliancegenome.curation_api.dao.ontology.SoTermDAO;
 import org.alliancegenome.curation_api.model.entities.ontology.SOTerm;
 import org.alliancegenome.curation_api.services.base.BaseOntologyTermService;
@@ -18,6 +20,10 @@ public class SoTermService extends BaseOntologyTermService<SOTerm, SoTermDAO> {
 	@PostConstruct
 	protected void init() {
 		setSQLDao(soTermDAO);
+	}
+
+	public Map<String, Integer> getSeverityRanking() {
+		return soTermDAO.getSeverityRanking();
 	}
 
 }


### PR DESCRIPTION
Returns a map of SO term name to severity order for VEP consequence ranking. Used by the variant indexer to sort vepConsequences by Ensembl severity (most severe first) when processing VCF files.