### PR TITLE
fix: use Map for ancestor serialization round-trip (v0.47.30)

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorDeserializer.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorDeserializer.java
@@ -1,8 +1,8 @@
 package org.alliancegenome.curation_api.model.serializers;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.alliancegenome.curation_api.model.entities.ontology.OntologyTerm;
@@ -10,25 +10,24 @@ import org.alliancegenome.curation_api.model.entities.ontology.OntologyTermClosu
 
 import com.fasterxml.jackson.databind.util.StdConverter;
 
-public class OntologyTermAncestorDeserializer extends StdConverter<List<List<Object>>, Set<OntologyTermClosure>> {
+public class OntologyTermAncestorDeserializer extends StdConverter<List<Map<String, List<String>>>, Set<OntologyTermClosure>> {
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public Set<OntologyTermClosure> convert(List<List<Object>> pairs) {
+	public Set<OntologyTermClosure> convert(List<Map<String, List<String>>> ancestors) {
 		Set<OntologyTermClosure> closures = new HashSet<>();
-		if (pairs != null) {
-			for (List<Object> pair : pairs) {
-				if (pair == null || pair.size() < 2) {
+		if (ancestors != null) {
+			for (Map<String, List<String>> entry : ancestors) {
+				if (entry == null) {
 					continue;
 				}
-				String curie = (String) pair.get(0);
-				Set<String> types = new HashSet<>((Collection<String>) pair.get(1));
-				OntologyTerm ancestorTerm = new OntologyTerm();
-				ancestorTerm.setCurie(curie);
-				OntologyTermClosure closure = new OntologyTermClosure();
-				closure.setClosureObject(ancestorTerm);
-				closure.setClosureTypes(types);
-				closures.add(closure);
+				for (Map.Entry<String, List<String>> pair : entry.entrySet()) {
+					OntologyTerm ancestorTerm = new OntologyTerm();
+					ancestorTerm.setCurie(pair.getKey());
+					OntologyTermClosure closure = new OntologyTermClosure();
+					closure.setClosureObject(ancestorTerm);
+					closure.setClosureTypes(new HashSet<>(pair.getValue()));
+					closures.add(closure);
+				}
 			}
 		}
 		return closures;

--- a/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorSerializer.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/serializers/OntologyTermAncestorSerializer.java
@@ -2,26 +2,26 @@ package org.alliancegenome.curation_api.model.serializers;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.alliancegenome.curation_api.model.entities.ontology.OntologyTermClosure;
-import org.apache.commons.lang3.tuple.Pair;
 
 import com.fasterxml.jackson.databind.util.StdConverter;
 
-public class OntologyTermAncestorSerializer extends StdConverter<Set<OntologyTermClosure>, List<Pair<String, Set<String>>>> {
+public class OntologyTermAncestorSerializer extends StdConverter<Set<OntologyTermClosure>, List<Map<String, Set<String>>>> {
 
 	@Override
-	public List<Pair<String, Set<String>>> convert(Set<OntologyTermClosure> value) {
-		List<Pair<String, Set<String>>> ancestorCuries = new ArrayList<>();
+	public List<Map<String, Set<String>>> convert(Set<OntologyTermClosure> value) {
+		List<Map<String, Set<String>>> ancestors = new ArrayList<>();
 		if (value != null) {
 			for (OntologyTermClosure closure : value) {
 				if (closure.getClosureObject() != null && closure.getClosureObject().getCurie() != null) {
-					ancestorCuries.add(Pair.of(closure.getClosureObject().getCurie(), closure.getClosureTypes()));
+					ancestors.add(Map.of(closure.getClosureObject().getCurie(), closure.getClosureTypes()));
 				}
 			}
 		}
-		return ancestorCuries;
+		return ancestors;
 	}
 
 }


### PR DESCRIPTION
## Summary
- Replace `Pair<String, Set<String>>` with `Map<String, Set<String>>` in both `OntologyTermAncestorSerializer` and `OntologyTermAncestorDeserializer`
- v0.47.29 fixed the deserializer input type but the serializer still used `Pair`, causing a format mismatch
- JSON format: `[{"SO:0000110": ["is_a", "part_of"]}, {"SO:0001411": ["is_a"]}]`

## Test plan
- [x] Verified with TestAncestors.java against local curation API
- [ ] Verify indexer can deserialize gene summary documents with ancestors
- [ ] Verify API serves ancestors in correct format for UI