### PR TITLE
refactor: remove dead code from transgenic allele endpoint

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/document/builders/TransgenicAlleleDocumentBuilder.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/builders/TransgenicAlleleDocumentBuilder.java
@@ -1,29 +1,14 @@
 package org.alliancegenome.curation_api.model.document.builders;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import org.alliancegenome.curation_api.dao.VocabularyTermDAO;
 import org.alliancegenome.curation_api.model.document.es.TransgenicAlleleDocument;
 import org.alliancegenome.curation_api.model.entities.AGMDiseaseAnnotation;
 import org.alliancegenome.curation_api.model.entities.AGMPhenotypeAnnotation;
 import org.alliancegenome.curation_api.model.entities.Allele;
-import org.alliancegenome.curation_api.model.entities.Construct;
-import org.alliancegenome.curation_api.model.entities.Gene;
-import org.alliancegenome.curation_api.model.entities.VocabularyTerm;
 import org.alliancegenome.curation_api.model.entities.associations.AlleleConstructAssociation;
-import org.alliancegenome.curation_api.model.entities.slotAnnotations.ConstructComponentSlotAnnotation;
-import org.alliancegenome.curation_api.model.entities.slotAnnotations.GeneSymbolSlotAnnotation;
-import org.alliancegenome.curation_api.model.input.Pagination;
-import org.alliancegenome.curation_api.response.SearchResponse;
 import org.apache.commons.collections4.CollectionUtils;
-import org.jetbrains.annotations.NotNull;
 
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
 public class TransgenicAlleleDocumentBuilder {
 
 	public TransgenicAlleleDocument buildTransgenicAlleleDocument(AlleleConstructAssociation association) {
@@ -47,65 +32,6 @@ public class TransgenicAlleleDocumentBuilder {
 			transgenicAlleleDocument.setHasPhenotypeAnnotations(hasPhenotypeAnnotation);
 		}
 		return transgenicAlleleDocument;
-	}
-
-	@NotNull
-	private static List<Gene> getNonBgiComponents(List<Construct> constructs) {
-		List<ConstructComponentSlotAnnotation> annotations = constructs.stream().flatMap(construct -> construct.getConstructComponents().stream()).toList();
-		return annotations.stream().map(annotation -> {
-			Gene nonBgiGene = new Gene();
-			GeneSymbolSlotAnnotation symbol = new GeneSymbolSlotAnnotation();
-			symbol.setDisplayText(annotation.getComponentSymbol());
-			symbol.setFormatText(annotation.getComponentSymbol());
-			nonBgiGene.setGeneSymbol(symbol);
-			return nonBgiGene;
-		}).toList();
-	}
-
-	private Map<Gene, List<Construct>> getExpressedGeneConstructMap(AlleleConstructAssociation association) {
-		Map<Gene, List<Construct>> geneConstructMap = new HashMap<>();
-		association.getAlleleConstructAssociationObject().getConstructGenomicEntityAssociations().forEach(constructGenomicEntityAssociation -> {
-			if (constructGenomicEntityAssociation.getConstructGenomicEntityAssociationObject() instanceof Gene Gene) {
-				if (constructGenomicEntityAssociation.getRelation().equals(getConstructRelation("expresses")) || constructGenomicEntityAssociation.getRelation().equals(getConstructRelation("is_regulated_by"))) {
-					List<Construct> constructList = geneConstructMap.computeIfAbsent(Gene, k -> new ArrayList<>());
-					constructList.add(association.getAlleleConstructAssociationObject());
-				}
-			}
-		});
-
-		return geneConstructMap;
-	}
-
-	private List<Gene> getExpressedGeneList(Construct construct, String relationName) {
-		List<Gene> expressedGenes = new ArrayList<>();
-		construct.getConstructGenomicEntityAssociations().forEach(constructGenomicEntityAssociation -> {
-			if (constructGenomicEntityAssociation.getConstructGenomicEntityAssociationObject() instanceof Gene gene && constructGenomicEntityAssociation.getRelation().equals(getConstructRelation(relationName))) {
-				expressedGenes.add(gene);
-			}
-		});
-		return expressedGenes;
-	}
-
-	private HashMap<String, VocabularyTerm> terms;
-	VocabularyTermDAO vocabularyTermDAO;
-
-	public void setVocabularyTermDAO(VocabularyTermDAO vocabularyTermDAO) {
-		this.vocabularyTermDAO = vocabularyTermDAO;
-	}
-
-	private VocabularyTerm getConstructRelation(String termName) {
-		if (terms != null) {
-			return terms.get(termName);
-		}
-
-		HashMap<String, Object> params = new HashMap<>();
-		params.put("vocabulary.name", "Construct Relation");
-		SearchResponse<VocabularyTerm> response = vocabularyTermDAO.findByParams(new Pagination(), params);
-		terms = new HashMap<>();
-		for (VocabularyTerm vt : response.getResults()) {
-			terms.put(vt.getName(), vt);
-		}
-		return terms.get(termName);
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/TransgenicAlleleDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/TransgenicAlleleDocument.java
@@ -4,9 +4,6 @@ import java.util.List;
 
 import org.alliancegenome.curation_api.model.entities.Allele;
 import org.alliancegenome.curation_api.model.entities.Construct;
-import org.alliancegenome.curation_api.model.entities.Gene;
-import org.alliancegenome.curation_api.model.entities.SequenceTargetingReagent;
-import org.alliancegenome.curation_api.model.entities.TransgenicAlleleConstruct;
 import org.alliancegenome.curation_api.view.CurationView;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -22,20 +19,9 @@ public class TransgenicAlleleDocument extends ESDocument {
 		category = "transgenic_allele_annotation";
 	}
 
-	private Gene gene;
 	private Allele allele;
-	/**
-	 * This collection is the association between a construct and the corresponding expressedGene, regulatoryGene, or sequenceTargetingReagent.
-	 */
-	private List<TransgenicAlleleConstruct> transgenicAlleleConstructs;
 
 	public List<Construct> constructList;
-
-	public List<Gene> expressedGenes;
-
-	public List<SequenceTargetingReagent> sequenceTargetingReagents;
-
-	public List<Gene> regulatoryGenes;
 
 	private Boolean hasDiseaseAnnotations;
 


### PR DESCRIPTION
## Summary
- Removed 5 dead methods and 2 dead fields from `TransgenicAlleleDocumentBuilder` (copy-pasted from java indexer but never called)
- Removed 5 never-populated fields from `TransgenicAlleleDocument` (`gene`, `transgenicAlleleConstructs`, `expressedGenes`, `sequenceTargetingReagents`, `regulatoryGenes`)
- Cleaned up unused imports

## Details
The transgenic allele endpoint (`POST /allele/document/transgenic`) only uses `buildTransgenicAlleleDocument()` in the builder, which populates `allele`, `constructList`, `hasDiseaseAnnotations`, and `hasPhenotypeAnnotations`. All gene-extraction logic lives in the java indexer (`TransgenicAlleleCurationIndexer`), making the curation-side copies dead code.

`TransgenicAlleleConstruct` is intentionally kept — it is used by the java indexer.

## Test plan
- [x] `mvn compile` passes
- [ ] Verify transgenic allele endpoint still returns expected data
- [ ] Verify indexer successfully indexes transgenic allele data