### PR TITLE
SCRUM-5928 Fix Running Time timezone offset on remote server

### DIFF
--- a/src/main/cliapp/src/containers/dataLoadsPage/DurationCell.jsx
+++ b/src/main/cliapp/src/containers/dataLoadsPage/DurationCell.jsx
@@ -1,31 +1,34 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import duration from 'dayjs/plugin/duration';
 
+dayjs.extend(utc);
 dayjs.extend(duration);
 
 export const DurationCell = ({ rowData }) => {
-	const [now, setNow] = useState(() => dayjs());
+	const [now, setNow] = useState(() => dayjs.utc());
 	const isRunning =
 		!rowData.loadFinished && rowData.bulkloadStatus !== 'FAILED' && rowData.bulkloadStatus !== 'STOPPED';
 
 	useEffect(() => {
 		if (!isRunning) return;
-		const interval = setInterval(() => setNow(dayjs()), 1000);
+		const interval = setInterval(() => setNow(dayjs.utc()), 1000);
 		return () => clearInterval(interval);
 	}, [isRunning]);
 
-	const started = dayjs(rowData.loadStarted);
-	const finished = rowData.loadFinished ? dayjs(rowData.loadFinished) : now;
-	const elapsed = dayjs.duration(finished.diff(started)).format('HH:mm:ss');
+	// Parse as UTC (server stores UTC without Z suffix), then .local() for display
+	const startedUtc = dayjs.utc(rowData.loadStarted);
+	const finishedUtc = rowData.loadFinished ? dayjs.utc(rowData.loadFinished) : now;
+	const elapsed = dayjs.duration(finishedUtc.diff(startedUtc)).format('HH:mm:ss');
 
 	return (
 		<>
-			Start: {started.format('YYYY-MM-DD HH:mm:ss')}
+			Start: {startedUtc.local().format('YYYY-MM-DD HH:mm:ss')}
 			<br />
 			{rowData.loadFinished && (
 				<>
-					End: {finished.format('YYYY-MM-DD HH:mm:ss')}
+					End: {finishedUtc.local().format('YYYY-MM-DD HH:mm:ss')}
 					<br />
 					Duration: {elapsed}
 				</>


### PR DESCRIPTION
Parse load timestamps as UTC and use dayjs.utc() for "now" so the duration diff is correct regardless of server timezone. Convert to local time for display via .local().