### PR TITLE
KANBAN-965: exclude bad VMA21 orthology pairs

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/OrthologyFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/OrthologyFmsDTOValidator.java
@@ -37,7 +37,11 @@ public class OrthologyFmsDTOValidator {
 	}
 
 	// KANBAN-965: temporary local exclusion for known bad VMA21/pdcd-2 DIOPT data.
-	// Remove this once the upstream DIOPT data is corrected and the bad pairs stop appearing.
+	// When DIOPT fixes the upstream data and the bad pairs no longer appear in orthology loads,
+	// remove this exclusion together with:
+	// - src/test/resources/bulk/fms/02_orthology/KI_01_excluded_vma21_pdcd2_pair.json
+	// - orthologyBulkUploadExcludedKnownIssuePair() in IT_0602_OrthologyBulkUploadFmsITCase
+	// - orthologyBulkExecutorCleanupDeletesExcludedKnownIssuePair() in IT_0602_OrthologyBulkUploadFmsITCase
 	private static final Set<ExcludedOrthologyPair> EXCLUDED_ORTHOLOGY_PAIRS = Set.of(
 		new ExcludedOrthologyPair("WB:WBGene00011116", "MGI:1914298"),
 		new ExcludedOrthologyPair("WB:WBGene00011116", "RGD:620474"),
@@ -77,6 +81,9 @@ public class OrthologyFmsDTOValidator {
 
 		if (isExcludedOrthologyPair(subjectGeneIdentifier, objectGeneIdentifier)) {
 			// KANBAN-965: skip the temporary exclusion here so provider cleanup removes any stale row.
+			// The executor-backed cleanup behavior is covered by
+			// orthologyBulkExecutorCleanupDeletesExcludedKnownIssuePair() in
+			// IT_0602_OrthologyBulkUploadFmsITCase.
 			throw new KnownIssueValidationException("Skipping excluded orthology pair: "
 				+ subjectGeneIdentifier + " <-> " + objectGeneIdentifier);
 		}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/OrthologyFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/OrthologyFmsDTOValidator.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
@@ -32,6 +33,20 @@ import jakarta.transaction.Transactional;
 @RequestScoped
 public class OrthologyFmsDTOValidator {
 
+	private record ExcludedOrthologyPair(String subjectGeneIdentifier, String objectGeneIdentifier) {
+	}
+
+	private static final Set<ExcludedOrthologyPair> EXCLUDED_ORTHOLOGY_PAIRS = Set.of(
+		new ExcludedOrthologyPair("WB:WBGene00011116", "MGI:1914298"),
+		new ExcludedOrthologyPair("WB:WBGene00011116", "RGD:620474"),
+		new ExcludedOrthologyPair("WB:WBGene00011116", "RGD:727913"),
+		new ExcludedOrthologyPair("WB:WBGene00011116", "HGNC:22082"),
+		new ExcludedOrthologyPair("MGI:1914298", "WB:WBGene00011116"),
+		new ExcludedOrthologyPair("RGD:620474", "WB:WBGene00011116"),
+		new ExcludedOrthologyPair("RGD:727913", "WB:WBGene00011116"),
+		new ExcludedOrthologyPair("HGNC:22082", "WB:WBGene00011116")
+	);
+
 	@Inject GeneToGeneOrthologyGeneratedDAO generatedOrthologyDAO;
 	@Inject GeneService geneService;
 	@Inject NcbiTaxonTermService ncbiTaxonTermService;
@@ -56,6 +71,11 @@ public class OrthologyFmsDTOValidator {
 			orthologyResponse.addErrorMessage("gene2", ValidationConstants.REQUIRED_MESSAGE);
 		} else {
 			objectGeneIdentifier = convertToModCurie(dto.getGene2(), dto.getGene2Species());
+		}
+
+		if (isExcludedOrthologyPair(subjectGeneIdentifier, objectGeneIdentifier)) {
+			throw new KnownIssueValidationException("Skipping excluded orthology pair: "
+				+ subjectGeneIdentifier + " <-> " + objectGeneIdentifier);
 		}
 
 		Gene subjectGene = null;
@@ -235,6 +255,13 @@ public class OrthologyFmsDTOValidator {
 		}
 
 		return curie;
+	}
+
+	private boolean isExcludedOrthologyPair(String subjectGeneIdentifier, String objectGeneIdentifier) {
+		if (StringUtils.isAnyBlank(subjectGeneIdentifier, objectGeneIdentifier)) {
+			return false;
+		}
+		return EXCLUDED_ORTHOLOGY_PAIRS.contains(new ExcludedOrthologyPair(subjectGeneIdentifier, objectGeneIdentifier));
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/OrthologyFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/OrthologyFmsDTOValidator.java
@@ -36,6 +36,8 @@ public class OrthologyFmsDTOValidator {
 	private record ExcludedOrthologyPair(String subjectGeneIdentifier, String objectGeneIdentifier) {
 	}
 
+	// KANBAN-965: temporary local exclusion for known bad VMA21/pdcd-2 DIOPT data.
+	// Remove this once the upstream DIOPT data is corrected and the bad pairs stop appearing.
 	private static final Set<ExcludedOrthologyPair> EXCLUDED_ORTHOLOGY_PAIRS = Set.of(
 		new ExcludedOrthologyPair("WB:WBGene00011116", "MGI:1914298"),
 		new ExcludedOrthologyPair("WB:WBGene00011116", "RGD:620474"),
@@ -74,6 +76,7 @@ public class OrthologyFmsDTOValidator {
 		}
 
 		if (isExcludedOrthologyPair(subjectGeneIdentifier, objectGeneIdentifier)) {
+			// KANBAN-965: skip the temporary exclusion here so provider cleanup removes any stale row.
 			throw new KnownIssueValidationException("Skipping excluded orthology pair: "
 				+ subjectGeneIdentifier + " <-> " + objectGeneIdentifier);
 		}

--- a/src/test/java/org/alliancegenome/curation_api/IT_0602_OrthologyBulkUploadFmsITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_0602_OrthologyBulkUploadFmsITCase.java
@@ -4,8 +4,29 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPOutputStream;
 
 import org.alliancegenome.curation_api.base.BaseITCase;
+import org.alliancegenome.curation_api.constants.VocabularyConstants;
+import org.alliancegenome.curation_api.enums.BackendBulkLoadType;
+import org.alliancegenome.curation_api.model.entities.Gene;
+import org.alliancegenome.curation_api.model.entities.Organization;
+import org.alliancegenome.curation_api.model.entities.VocabularyTerm;
+import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
+import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFile;
+import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
+import org.alliancegenome.curation_api.model.entities.orthology.GeneToGeneOrthologyGenerated;
 import org.alliancegenome.curation_api.resources.TestContainerResource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -119,6 +140,110 @@ public class IT_0602_OrthologyBulkUploadFmsITCase extends BaseITCase {
 
 	@Test
 	@Order(5)
+	public void orthologyBulkUploadExcludedKnownIssuePair() throws Exception {
+		checkSkippedBulkLoad(orthologyBulkPostEndpoint, orthologyTestFilePath + "KI_01_excluded_vma21_pdcd2_pair.json");
+	}
+
+	@Test
+	@Order(6)
+	public void orthologyBulkExecutorCleanupDeletesExcludedKnownIssuePair() throws Exception {
+		Organization mgiDataProvider = getOrganization("MGI");
+		Organization wbDataProvider = getOrganization("WB");
+		VocabularyTerm symbolTerm = getVocabularyTerm(getVocabulary(VocabularyConstants.NAME_TYPE_VOCABULARY), "nomenclature_symbol");
+
+		Gene subjectGene = createGene("MGI:1914298", "NCBITaxon:10090", symbolTerm, false, mgiDataProvider);
+		Gene objectGene = createGene("WB:WBGene00011116", "NCBITaxon:6239", symbolTerm, false, wbDataProvider);
+
+		GeneToGeneOrthologyGenerated staleOrthology = new GeneToGeneOrthologyGenerated();
+		staleOrthology.setSubjectGene(subjectGene);
+		staleOrthology.setObjectGene(objectGene);
+		staleOrthology.setIsBestScore(getVocabularyTerm(getVocabulary(VocabularyConstants.ORTHOLOGY_BEST_SCORE_VOCABULARY), "Yes"));
+		staleOrthology.setIsBestScoreReverse(getVocabularyTerm(getVocabularyTermSet(VocabularyConstants.ORTHOLOGY_BEST_REVERSE_SCORE_VOCABULARY_TERM_SET).getVocabularyTermSetVocabulary(), "Yes"));
+		staleOrthology.setConfidence(getVocabularyTerm(getVocabulary(VocabularyConstants.HOMOLOGY_CONFIDENCE_VOCABULARY), "high"));
+		staleOrthology.setStrictFilter(true);
+		staleOrthology.setModerateFilter(true);
+		staleOrthology.setObsolete(false);
+		staleOrthology.setInternal(false);
+
+		Long staleOrthologyId = RestAssured.given().
+			contentType("application/json").
+			body(staleOrthology).
+			when().
+			post("/api/orthologygenerated").
+			then().
+			statusCode(200).
+			extract().jsonPath().getLong("entity.id");
+
+		assertNotNull(staleOrthologyId);
+		assertEquals(staleOrthologyId, RestAssured.given().
+			when().
+			get("/api/orthologygenerated/" + staleOrthologyId).
+			then().
+			statusCode(200).
+			extract().jsonPath().getLong("entity.id"));
+
+		Path gzipFile = createGzipFromResource(orthologyTestFilePath + "KI_01_excluded_vma21_pdcd2_pair.json");
+
+		BulkFMSLoad bulkLoad = new BulkFMSLoad();
+		bulkLoad.setName("KANBAN-965 orthology cleanup test");
+		bulkLoad.setBackendBulkLoadType(BackendBulkLoadType.ORTHOLOGY);
+		bulkLoad.setFmsDataType("Orthology");
+		bulkLoad.setFmsDataSubType("MGI");
+		bulkLoad.setId(RestAssured.given().
+			contentType("application/json").
+			body(bulkLoad).
+			when().
+			post("/api/bulkfmsload").
+			then().
+			statusCode(200).
+			extract().jsonPath().getLong("entity.id"));
+
+		BulkLoadFile bulkLoadFile = new BulkLoadFile();
+		bulkLoadFile.setLocalFilePath(gzipFile.toString());
+		bulkLoadFile.setMd5Sum("KANBAN-965-" + System.nanoTime());
+		bulkLoadFile.setId(RestAssured.given().
+			contentType("application/json").
+			body(bulkLoadFile).
+			when().
+			post("/api/bulkloadfile").
+			then().
+			statusCode(200).
+			extract().jsonPath().getLong("entity.id"));
+
+		BulkLoadFileHistory bulkLoadFileHistory = new BulkLoadFileHistory();
+		bulkLoadFileHistory.setBulkLoad(bulkLoad);
+		bulkLoadFileHistory.setBulkLoadFile(bulkLoadFile);
+		Long originalHistoryId = RestAssured.given().
+			contentType("application/json").
+			body(bulkLoadFileHistory).
+			when().
+			post("/api/bulkloadfilehistory").
+			then().
+			statusCode(200).
+			extract().jsonPath().getLong("entity.id");
+
+		RestAssured.given().
+			when().
+			get("/api/bulkloadfilehistory/restartloadhistory/" + originalHistoryId).
+			then().
+			statusCode(200);
+
+		Long cleanupHistoryId = waitForCleanupHistoryId(bulkLoad.getId(), bulkLoadFile.getId(), originalHistoryId);
+		Map<String, Object> cleanupHistory = waitForBulkLoadHistoryToFinish(cleanupHistoryId);
+		Map<String, Map<String, Number>> counts = (Map<String, Map<String, Number>>) cleanupHistory.get("counts");
+
+		assertEquals(1, counts.get("Records").get("skipped").intValue());
+		assertEquals(1, counts.get("Orthology Deleted").get("completed").intValue());
+		assertNull(RestAssured.given().
+			when().
+			get("/api/orthologygenerated/" + staleOrthologyId).
+			then().
+			statusCode(200).
+			extract().path("entity"));
+	}
+
+	@Test
+	@Order(7)
 	public void orthologyBulkUploadUpdateMissingNonRequiredFields() throws Exception {
 
 		checkSuccessfulBulkLoad(orthologyBulkPostEndpoint, orthologyTestFilePath + "UM_01_update_no_non_required_fields.json");
@@ -140,7 +265,7 @@ public class IT_0602_OrthologyBulkUploadFmsITCase extends BaseITCase {
 	}
 
 	@Test
-	@Order(6)
+	@Order(8)
 	public void orthologyBulkUploadUpdateEmptyNonRequiredFields() throws Exception {
 
 		checkSuccessfulBulkLoad(orthologyBulkPostEndpoint, orthologyTestFilePath + "AF_01_all_fields.json");
@@ -174,6 +299,67 @@ public class IT_0602_OrthologyBulkUploadFmsITCase extends BaseITCase {
 			body("results[0]", not(hasKey("predictionMethodsMatched"))).
 			body("results[0]", not(hasKey("predictionMethodsNotMatched"))).
 			body("results[0]", not(hasKey("predictionMethodsNotCalled")));
+	}
+
+	private Path createGzipFromResource(String resourcePath) throws Exception {
+		Path gzipFile = Files.createTempFile("kanban-965-orthology-", ".json.gz");
+		gzipFile.toFile().deleteOnExit();
+		try (GZIPOutputStream outputStream = new GZIPOutputStream(Files.newOutputStream(gzipFile))) {
+			outputStream.write(Files.readString(Path.of(resourcePath)).getBytes(StandardCharsets.UTF_8));
+		}
+		return gzipFile;
+	}
+
+	private Long waitForCleanupHistoryId(Long bulkLoadId, Long bulkLoadFileId, Long originalHistoryId) throws Exception {
+		long timeoutAt = System.currentTimeMillis() + 30000;
+		while (System.currentTimeMillis() < timeoutAt) {
+			List<Integer> historyIds = RestAssured.given().
+				contentType("application/json").
+				body("{\"bulkLoad.id\": " + bulkLoadId + ", \"bulkLoadFile.id\": " + bulkLoadFileId + "}").
+				when().
+				post("/api/bulkloadfilehistory/find?limit=10&page=0").
+				then().
+				statusCode(200).
+				extract().path("results.id");
+
+			if (historyIds != null && !historyIds.isEmpty()) {
+				Long latestHistoryId = historyIds.stream().map(Integer::longValue).max(Comparator.naturalOrder()).orElse(originalHistoryId);
+				if (latestHistoryId > originalHistoryId) {
+					return latestHistoryId;
+				}
+			}
+
+			Thread.sleep(500);
+		}
+
+		fail("Timed out waiting for cleanup history to be created");
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> waitForBulkLoadHistoryToFinish(Long historyId) throws Exception {
+		long timeoutAt = System.currentTimeMillis() + 30000;
+		while (System.currentTimeMillis() < timeoutAt) {
+			Map<String, Object> history = RestAssured.given().
+				when().
+				get("/api/bulkloadfilehistory/" + historyId).
+				then().
+				statusCode(200).
+				extract().path("entity");
+
+			String bulkloadStatus = (String) history.get("bulkloadStatus");
+			if ("FINISHED".equals(bulkloadStatus)) {
+				return history;
+			}
+			if ("FAILED".equals(bulkloadStatus) || "FORCED_STOPPED".equals(bulkloadStatus) || "STOPPED".equals(bulkloadStatus)) {
+				fail("Cleanup load ended with status " + bulkloadStatus + ": " + history.get("errorMessage"));
+			}
+
+			Thread.sleep(500);
+		}
+
+		fail("Timed out waiting for cleanup history to finish");
+		return null;
 	}
 
 }

--- a/src/test/java/org/alliancegenome/curation_api/IT_0602_OrthologyBulkUploadFmsITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_0602_OrthologyBulkUploadFmsITCase.java
@@ -141,12 +141,21 @@ public class IT_0602_OrthologyBulkUploadFmsITCase extends BaseITCase {
 	@Test
 	@Order(5)
 	public void orthologyBulkUploadExcludedKnownIssuePair() throws Exception {
+		// KANBAN-965: this fixture represents the known bad VMA21/pdcd-2 DIOPT pair that is
+		// temporarily excluded in OrthologyFmsDTOValidator.EXCLUDED_ORTHOLOGY_PAIRS.
+		// Remove this test together with that exclusion, the KI_01 fixture below, and the cleanup
+		// test if/when the upstream DIOPT data is fixed and regenerated cleanly.
 		checkSkippedBulkLoad(orthologyBulkPostEndpoint, orthologyTestFilePath + "KI_01_excluded_vma21_pdcd2_pair.json");
 	}
 
 	@Test
 	@Order(6)
 	public void orthologyBulkExecutorCleanupDeletesExcludedKnownIssuePair() throws Exception {
+		// KANBAN-965: this covers the failure mode that originally escaped the loader-side fix:
+		// a bad row can already exist in agr_curation even though new ingest now skips it.
+		// Keep this aligned with OrthologyFmsDTOValidator.EXCLUDED_ORTHOLOGY_PAIRS and the
+		// KI_01_excluded_vma21_pdcd2_pair.json fixture, and remove all three together once the
+		// upstream DIOPT source data is corrected.
 		Organization mgiDataProvider = getOrganization("MGI");
 		Organization wbDataProvider = getOrganization("WB");
 		VocabularyTerm symbolTerm = getVocabularyTerm(getVocabulary(VocabularyConstants.NAME_TYPE_VOCABULARY), "nomenclature_symbol");
@@ -182,6 +191,8 @@ public class IT_0602_OrthologyBulkUploadFmsITCase extends BaseITCase {
 			statusCode(200).
 			extract().jsonPath().getLong("entity.id"));
 
+		// KANBAN-965: reuse the same temporary KI_01 fixture here so the cleanup-path coverage
+		// stays tied to the exact excluded pair list used by the validator.
 		Path gzipFile = createGzipFromResource(orthologyTestFilePath + "KI_01_excluded_vma21_pdcd2_pair.json");
 
 		BulkFMSLoad bulkLoad = new BulkFMSLoad();

--- a/src/test/java/org/alliancegenome/curation_api/IT_0602_OrthologyBulkUploadFmsITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_0602_OrthologyBulkUploadFmsITCase.java
@@ -19,13 +19,12 @@ import java.util.zip.GZIPOutputStream;
 
 import org.alliancegenome.curation_api.base.BaseITCase;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
+import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.enums.BackendBulkLoadType;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.Organization;
 import org.alliancegenome.curation_api.model.entities.VocabularyTerm;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFile;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
+import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
 import org.alliancegenome.curation_api.model.entities.orthology.GeneToGeneOrthologyGenerated;
 import org.alliancegenome.curation_api.resources.TestContainerResource;
 import org.junit.jupiter.api.BeforeEach;
@@ -155,7 +154,10 @@ public class IT_0602_OrthologyBulkUploadFmsITCase extends BaseITCase {
 		// a bad row can already exist in agr_curation even though new ingest now skips it.
 		// Keep this aligned with OrthologyFmsDTOValidator.EXCLUDED_ORTHOLOGY_PAIRS and the
 		// KI_01_excluded_vma21_pdcd2_pair.json fixture, and remove all three together once the
-		// upstream DIOPT source data is corrected.
+		// upstream DIOPT source data is corrected. This test intentionally uses the DQM manual
+		// submission path (/api/data/submit with ORTHOLOGY_MGI) because it exercises the same
+		// file-history creation and async cleanup flow that CI rejected when the test tried to
+		// create BulkLoadFileHistory directly.
 		Organization mgiDataProvider = getOrganization("MGI");
 		Organization wbDataProvider = getOrganization("WB");
 		VocabularyTerm symbolTerm = getVocabularyTerm(getVocabulary(VocabularyConstants.NAME_TYPE_VOCABULARY), "nomenclature_symbol");
@@ -195,51 +197,28 @@ public class IT_0602_OrthologyBulkUploadFmsITCase extends BaseITCase {
 		// stays tied to the exact excluded pair list used by the validator.
 		Path gzipFile = createGzipFromResource(orthologyTestFilePath + "KI_01_excluded_vma21_pdcd2_pair.json");
 
-		BulkFMSLoad bulkLoad = new BulkFMSLoad();
+		BulkManualLoad bulkLoad = new BulkManualLoad();
 		bulkLoad.setName("KANBAN-965 orthology cleanup test");
 		bulkLoad.setBackendBulkLoadType(BackendBulkLoadType.ORTHOLOGY);
-		bulkLoad.setFmsDataType("Orthology");
-		bulkLoad.setFmsDataSubType("MGI");
+		bulkLoad.setDataProvider(BackendBulkDataProvider.MGI);
 		bulkLoad.setId(RestAssured.given().
 			contentType("application/json").
 			body(bulkLoad).
 			when().
-			post("/api/bulkfmsload").
+			post("/api/bulkmanualload").
 			then().
 			statusCode(200).
 			extract().jsonPath().getLong("entity.id"));
-
-		BulkLoadFile bulkLoadFile = new BulkLoadFile();
-		bulkLoadFile.setLocalFilePath(gzipFile.toString());
-		bulkLoadFile.setMd5Sum("KANBAN-965-" + System.nanoTime());
-		bulkLoadFile.setId(RestAssured.given().
-			contentType("application/json").
-			body(bulkLoadFile).
-			when().
-			post("/api/bulkloadfile").
-			then().
-			statusCode(200).
-			extract().jsonPath().getLong("entity.id"));
-
-		BulkLoadFileHistory bulkLoadFileHistory = new BulkLoadFileHistory();
-		bulkLoadFileHistory.setBulkLoad(bulkLoad);
-		bulkLoadFileHistory.setBulkLoadFile(bulkLoadFile);
-		Long originalHistoryId = RestAssured.given().
-			contentType("application/json").
-			body(bulkLoadFileHistory).
-			when().
-			post("/api/bulkloadfilehistory").
-			then().
-			statusCode(200).
-			extract().jsonPath().getLong("entity.id");
 
 		RestAssured.given().
+			multiPart("ORTHOLOGY_MGI", gzipFile.toFile(), "application/gzip").
 			when().
-			get("/api/bulkloadfilehistory/restartloadhistory/" + originalHistoryId).
+			post("/api/data/submit?cleanUp=true").
 			then().
-			statusCode(200);
+			statusCode(200).
+			body(is("OK"));
 
-		Long cleanupHistoryId = waitForCleanupHistoryId(bulkLoad.getId(), bulkLoadFile.getId(), originalHistoryId);
+		Long cleanupHistoryId = waitForCleanupHistoryId(bulkLoad.getId());
 		Map<String, Object> cleanupHistory = waitForBulkLoadHistoryToFinish(cleanupHistoryId);
 		Map<String, Map<String, Number>> counts = (Map<String, Map<String, Number>>) cleanupHistory.get("counts");
 
@@ -321,12 +300,12 @@ public class IT_0602_OrthologyBulkUploadFmsITCase extends BaseITCase {
 		return gzipFile;
 	}
 
-	private Long waitForCleanupHistoryId(Long bulkLoadId, Long bulkLoadFileId, Long originalHistoryId) throws Exception {
+	private Long waitForCleanupHistoryId(Long bulkLoadId) throws Exception {
 		long timeoutAt = System.currentTimeMillis() + 30000;
 		while (System.currentTimeMillis() < timeoutAt) {
 			List<Integer> historyIds = RestAssured.given().
 				contentType("application/json").
-				body("{\"bulkLoad.id\": " + bulkLoadId + ", \"bulkLoadFile.id\": " + bulkLoadFileId + "}").
+				body("{\"bulkLoad.id\": " + bulkLoadId + "}").
 				when().
 				post("/api/bulkloadfilehistory/find?limit=10&page=0").
 				then().
@@ -334,10 +313,7 @@ public class IT_0602_OrthologyBulkUploadFmsITCase extends BaseITCase {
 				extract().path("results.id");
 
 			if (historyIds != null && !historyIds.isEmpty()) {
-				Long latestHistoryId = historyIds.stream().map(Integer::longValue).max(Comparator.naturalOrder()).orElse(originalHistoryId);
-				if (latestHistoryId > originalHistoryId) {
-					return latestHistoryId;
-				}
+				return historyIds.stream().map(Integer::longValue).max(Comparator.naturalOrder()).orElse(null);
 			}
 
 			Thread.sleep(500);

--- a/src/test/resources/bulk/fms/02_orthology/KI_01_excluded_vma21_pdcd2_pair.json
+++ b/src/test/resources/bulk/fms/02_orthology/KI_01_excluded_vma21_pdcd2_pair.json
@@ -1,0 +1,37 @@
+{
+  "data": [
+    {
+      "confidence": "high",
+      "gene1": "DRSC:MGI:1914298",
+      "gene1Species": 10090,
+      "gene2": "DRSC:WB:WBGene00011116",
+      "gene2Species": 6239,
+      "isBestRevScore": "Yes",
+      "isBestScore": "Yes",
+      "moderateFilter": true,
+      "predictionMethodsMatched": [
+        "Ensembl Compara"
+      ],
+      "predictionMethodsNotCalled": [
+        "HGNC"
+      ],
+      "predictionMethodsNotMatched": [
+        "OMA"
+      ],
+      "strictFilter": true
+    }
+  ],
+  "metaData": {
+    "dataProvider": {
+      "crossReference": {
+        "id": "MGI",
+        "pages": [
+          "homepage"
+        ]
+      },
+      "type": "curated"
+    },
+    "dateProduced": "2026-04-10T14:00:00Z",
+    "release": "9"
+  }
+}


### PR DESCRIPTION
## Summary
This change blocks a known bad DIOPT orthology mapping between VMA21 genes and C. elegans `pdcd-2` from being reloaded into `agr_curation`. It also adds regression coverage for the stale-row cleanup path so future orthology reloads prove that pre-existing bad rows are removed when the excluded pair is skipped.

## Changes
- Added an explicit exclusion list for the eight known bad VMA21/pdcd-2 orthology pairs in the orthology FMS validator.
- Added an orthology fixture for the excluded MGI to WB pair.
- Extended the orthology integration test to verify that the excluded pair is skipped during ingest.
- Extended the orthology integration test to create a stale bad orthology row, run the executor-backed bulk load flow, and assert that cleanup deletes the stale row.

## Testing
- Added integration coverage in `IT_0602_OrthologyBulkUploadFmsITCase` for both skipped ingest and stale-row cleanup.
- Local test execution was not possible in this session because the environment does not provide `mvn` or a repo `mvnw` wrapper.
