### PR TITLE
SCRUM-5936: Enable editing of Species curation table

### DIFF
--- a/src/main/cliapp/src/components/Editors/StringListEditor.jsx
+++ b/src/main/cliapp/src/components/Editors/StringListEditor.jsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import { InputText } from 'primereact/inputtext';
+import { ErrorMessageComponent } from '../Error/ErrorMessageComponent';
+
+export function StringListEditor({ rowProps, fieldName }) {
+	const initialValue = Array.isArray(rowProps.rowData[fieldName])
+		? rowProps.rowData[fieldName].join(', ')
+		: '';
+	const [fieldValue, setFieldValue] = useState(initialValue);
+
+	const onChange = (e) => {
+		const value = e.target.value;
+		setFieldValue(value);
+		let updatedEntities = [...rowProps.props.value];
+		updatedEntities[rowProps.rowIndex][fieldName] = value
+			? value.split(',').map((s) => s.trim()).filter((s) => s.length > 0)
+			: [];
+	};
+
+	return (
+		<>
+			<InputText aria-label={fieldName} value={fieldValue} onChange={onChange} style={{ width: '100%' }} />
+		</>
+	);
+}

--- a/src/main/cliapp/src/containers/speciesPage/SpeciesTable.jsx
+++ b/src/main/cliapp/src/containers/speciesPage/SpeciesTable.jsx
@@ -1,16 +1,17 @@
 import React, { useRef, useState, useMemo } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { GenericDataTable } from '../../components/GenericDataTable/GenericDataTable';
-import { Dropdown } from 'primereact/dropdown';
 import { Toast } from 'primereact/toast';
 import { getDefaultTableState } from '../../service/TableStateService';
 import { FILTER_CONFIGS } from '../../constants/FilterFields';
 import { CommaSeparatedArrayTemplate } from '../../components/Templates/CommaSeparatedArrayTemplate';
 import { InputTextEditor } from '../../components/InputTextEditor';
 import { StringListEditor } from '../../components/Editors/StringListEditor';
+import { ControlledVocabularyDropdown } from '../../components/ControlledVocabularySelector';
 import { ErrorMessageComponent } from '../../components/Error/ErrorMessageComponent';
 import { useGetTableData } from '../../service/useGetTableData';
 import { useGetUserSettings } from '../../service/useGetUserSettings';
+import { useOrganizationService } from '../../service/useOrganizationService';
 
 import { SearchService } from '../../service/SearchService';
 import { SpeciesService } from '../../service/SpeciesService';
@@ -31,6 +32,8 @@ export const SpeciesTable = () => {
 
 	let speciesService = new SpeciesService();
 
+	const organizations = useOrganizationService();
+
 	const mutation = useMutation({
 		mutationFn: (updatedSpecies) => {
 			if (!speciesService) {
@@ -49,42 +52,24 @@ export const SpeciesTable = () => {
 		);
 	};
 
-	const { data: organizationsData } = useQuery({
-		queryKey: ['organizations'],
-		queryFn: () => searchService.find('organization', 100, 0, {}),
-		refetchOnWindowFocus: false,
-	});
+	const onDataProviderEditorValueChange = (props, event) => {
+		let updatedEntities = [...props.props.value];
+		updatedEntities[props.rowIndex].dataProvider = event.value;
+	};
 
-	const organizations = useMemo(() => organizationsData?.results || [], [organizationsData]);
-
-	const DataProviderDropdownEditor = ({ rowProps }) => {
-		const [selectedValue, setSelectedValue] = useState(rowProps.rowData.dataProvider);
-
-		const onShow = () => {
-			setSelectedValue(rowProps.rowData.dataProvider);
-		};
-
-		const onChange = (e) => {
-			setSelectedValue(e.value);
-			let updatedEntities = [...rowProps.props.value];
-			updatedEntities[rowProps.rowIndex].dataProvider = e.value;
-		};
-
+	const dataProviderEditor = (props) => {
 		return (
 			<>
-				<Dropdown
-					ariaLabel="dataProvider"
-					value={selectedValue}
+				<ControlledVocabularyDropdown
+					field="dataProvider"
 					options={organizations}
-					optionLabel="abbreviation"
-					dataKey="id"
-					onShow={onShow}
-					onChange={onChange}
+					editorChange={onDataProviderEditorValueChange}
+					props={props}
 					showClear={false}
-					placeholder={rowProps.rowData.dataProvider?.abbreviation}
-					style={{ width: '100%' }}
+					dataKey="id"
+					placeholderText={props.rowData.dataProvider?.abbreviation}
 				/>
-				<ErrorMessageComponent errorMessages={errorMessagesRef.current[rowProps.rowIndex]} errorField="dataProvider" />
+				<ErrorMessageComponent errorMessages={errorMessagesRef.current[props.rowIndex]} errorField="dataProvider" />
 			</>
 		);
 	};
@@ -142,7 +127,7 @@ export const SpeciesTable = () => {
 				sortable: true,
 				filter: true,
 				filterConfig: FILTER_CONFIGS.speciesDataProviderFilterConfig,
-				editor: (props) => <DataProviderDropdownEditor rowProps={props} />,
+				editor: (props) => dataProviderEditor(props),
 			},
 			{
 				field: 'phylogeneticOrder',
@@ -159,7 +144,7 @@ export const SpeciesTable = () => {
 			},
 		],
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[]
+		[organizations]
 	);
 
 	const DEFAULT_COLUMN_WIDTH = 10;

--- a/src/main/cliapp/src/containers/speciesPage/SpeciesTable.jsx
+++ b/src/main/cliapp/src/containers/speciesPage/SpeciesTable.jsx
@@ -1,13 +1,19 @@
 import React, { useRef, useState, useMemo } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { GenericDataTable } from '../../components/GenericDataTable/GenericDataTable';
+import { Dropdown } from 'primereact/dropdown';
 import { Toast } from 'primereact/toast';
 import { getDefaultTableState } from '../../service/TableStateService';
 import { FILTER_CONFIGS } from '../../constants/FilterFields';
 import { CommaSeparatedArrayTemplate } from '../../components/Templates/CommaSeparatedArrayTemplate';
+import { InputTextEditor } from '../../components/InputTextEditor';
+import { StringListEditor } from '../../components/Editors/StringListEditor';
+import { ErrorMessageComponent } from '../../components/Error/ErrorMessageComponent';
 import { useGetTableData } from '../../service/useGetTableData';
 import { useGetUserSettings } from '../../service/useGetUserSettings';
 
 import { SearchService } from '../../service/SearchService';
+import { SpeciesService } from '../../service/SpeciesService';
 import { Endpoints } from '../../constants/Endpoints';
 
 export const SpeciesTable = () => {
@@ -18,8 +24,70 @@ export const SpeciesTable = () => {
 
 	const toast_topleft = useRef(null);
 	const toast_topright = useRef(null);
+	const errorMessagesRef = useRef();
+	errorMessagesRef.current = errorMessages;
 
 	const searchService = new SearchService();
+
+	let speciesService = new SpeciesService();
+
+	const mutation = useMutation({
+		mutationFn: (updatedSpecies) => {
+			if (!speciesService) {
+				speciesService = new SpeciesService();
+			}
+			return speciesService.saveSpecies(updatedSpecies);
+		},
+	});
+
+	const stringEditor = (props, field) => {
+		return (
+			<>
+				<InputTextEditor rowProps={props} fieldName={field} />
+				<ErrorMessageComponent errorMessages={errorMessagesRef.current[props.rowIndex]} errorField={field} />
+			</>
+		);
+	};
+
+	const { data: organizationsData } = useQuery({
+		queryKey: ['organizations'],
+		queryFn: () => searchService.find('organization', 100, 0, {}),
+		refetchOnWindowFocus: false,
+	});
+
+	const organizations = useMemo(() => organizationsData?.results || [], [organizationsData]);
+
+	const DataProviderDropdownEditor = ({ rowProps }) => {
+		const [selectedValue, setSelectedValue] = useState(rowProps.rowData.dataProvider);
+
+		const onShow = () => {
+			setSelectedValue(rowProps.rowData.dataProvider);
+		};
+
+		const onChange = (e) => {
+			setSelectedValue(e.value);
+			let updatedEntities = [...rowProps.props.value];
+			updatedEntities[rowProps.rowIndex].dataProvider = e.value;
+		};
+
+		return (
+			<>
+				<Dropdown
+					ariaLabel="dataProvider"
+					value={selectedValue}
+					options={organizations}
+					optionLabel="abbreviation"
+					dataKey="id"
+					onShow={onShow}
+					onChange={onChange}
+					showClear={false}
+					placeholder={rowProps.rowData.dataProvider?.abbreviation}
+					style={{ width: '100%' }}
+				/>
+				<ErrorMessageComponent errorMessages={errorMessagesRef.current[rowProps.rowIndex]} errorField="dataProvider" />
+			</>
+		);
+	};
 
 	const columns = useMemo(
 		() => [
@@ -36,6 +104,7 @@ export const SpeciesTable = () => {
 				sortable: true,
 				filter: true,
 				filterConfig: FILTER_CONFIGS.speciesFullNameFilterConfig,
+				editor: (props) => stringEditor(props, 'fullName'),
 			},
 			{
 				field: 'displayName',
@@ -43,6 +112,7 @@ export const SpeciesTable = () => {
 				sortable: true,
 				filter: true,
 				filterConfig: FILTER_CONFIGS.speciesDisplayNameFilterConfig,
+				editor: (props) => stringEditor(props, 'displayName'),
 			},
 			{
 				field: 'abbreviation',
@@ -50,6 +120,7 @@ export const SpeciesTable = () => {
 				sortable: true,
 				filter: true,
 				filterConfig: FILTER_CONFIGS.speciesAbbreviationFilterConfig,
+				editor: (props) => stringEditor(props, 'abbreviation'),
 			},
 			{
 				field: 'commonNames',
@@ -58,6 +129,12 @@ export const SpeciesTable = () => {
 				filter: true,
 				body: (rowData) => <CommaSeparatedArrayTemplate array={rowData.commonNames} />,
 				filterConfig: FILTER_CONFIGS.speciesCommonNameFilterConfig,
+				editor: (props) => (
+					<>
+						<StringListEditor rowProps={props} fieldName="commonNames" />
+						<ErrorMessageComponent errorMessages={errorMessagesRef.current[props.rowIndex]} errorField="commonNames" />
+					</>
+				),
 			},
 			{
 				field: 'dataProvider.abbreviation',
@@ -65,17 +142,20 @@ export const SpeciesTable = () => {
 				sortable: true,
 				filter: true,
 				filterConfig: FILTER_CONFIGS.speciesDataProviderFilterConfig,
+				editor: (props) => <DataProviderDropdownEditor rowProps={props} />,
 			},
 			{
 				field: 'phylogeneticOrder',
 				header: 'Phylogenetic Order',
 				sortable: true,
+				editor: (props) => stringEditor(props, 'phylogeneticOrder'),
 			},
 			{
 				field: 'assembly_curie',
 				header: 'Assembly',
 				sortable: false,
 				//filterConfig: FILTER_CONFIGS.speciesAssemblyFilterConfig
+				editor: (props) => stringEditor(props, 'assembly_curie'),
 			},
 		],
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -117,7 +197,8 @@ export const SpeciesTable = () => {
 					tableState={tableState}
 					setTableState={setTableState}
 					columns={columns}
-					isEditable={false}
+					isEditable={true}
+					mutation={mutation}
 					isInEditMode={isInEditMode}
 					setIsInEditMode={setIsInEditMode}
 					toasts={{ toast_topleft, toast_topright }}

--- a/src/main/cliapp/src/service/SpeciesService.js
+++ b/src/main/cliapp/src/service/SpeciesService.js
@@ -1,0 +1,14 @@
+import { BaseAuthService } from './BaseAuthService';
+import { DeletionService } from './DeletionService';
+import { Endpoints } from '../constants/Endpoints';
+
+export class SpeciesService extends BaseAuthService {
+	saveSpecies(updatedSpecies) {
+		return this.api.put(`/species`, updatedSpecies);
+	}
+
+	async deleteSpecies(species) {
+		const deletionService = new DeletionService();
+		return await deletionService.delete(Endpoints.Entity.SPECIES, species.id);
+	}
+}

--- a/src/main/cliapp/src/service/useOrganizationService.js
+++ b/src/main/cliapp/src/service/useOrganizationService.js
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { SearchService } from './SearchService';
+
+export function useOrganizationService() {
+	const [organizations, setOrganizations] = useState([]);
+	const searchService = new SearchService();
+
+	const { data, isSuccess } = useQuery({
+		queryKey: ['organizations'],
+		queryFn: () => searchService.find('organization', 100, 0, {}),
+		refetchOnWindowFocus: false,
+	});
+
+	useEffect(() => {
+		if (isSuccess && data) {
+			const orgs = (data.results || []).map((org) => ({
+				...org,
+				name: org.abbreviation,
+			}));
+			setOrganizations(orgs);
+		}
+	}, [data, isSuccess]);
+
+	return organizations;
+}

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/SpeciesCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/SpeciesCrudInterface.java
@@ -2,9 +2,14 @@ package org.alliancegenome.curation_api.interfaces.crud;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
 import org.alliancegenome.curation_api.model.entities.Species;
+import org.alliancegenome.curation_api.response.ObjectResponse;
+import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
+import com.fasterxml.jackson.annotation.JsonView;
+
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
@@ -14,4 +19,10 @@ import jakarta.ws.rs.core.MediaType;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public interface SpeciesCrudInterface extends BaseIdCrudInterface<Species> {
+
+	@Override
+	@PUT
+	@Path("/")
+	@JsonView(CurationView.SpeciesView.class)
+	ObjectResponse<Species> update(Species entity);
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
@@ -23,6 +23,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmb
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonView;
 
 import jakarta.persistence.ElementCollection;
@@ -56,7 +57,7 @@ public class Species extends AuditedObject {
 	@IndexedEmbedded(includePaths = {"name", "curie", "name_keyword", "curie_keyword"})
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@OneToOne
-	@JsonView({ CurationView.FieldsOnly.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.SpeciesView.class })
 	@Fetch(FetchMode.JOIN)
 	private NCBITaxonTerm taxon;
 
@@ -78,7 +79,7 @@ public class Species extends AuditedObject {
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "commonNames_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
 	@ElementCollection
-	@JsonView({ CurationView.FieldsAndLists.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.FieldsAndLists.class, CurationView.SpeciesView.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class })
 	@JoinTable(indexes = @Index(name = "species_commonnames_species_id_index", columnList = "species_id"))
 	private List<String> commonNames;
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/base/CurieObject.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/base/CurieObject.java
@@ -28,7 +28,7 @@ public class CurieObject extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "curie_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.DiseaseSummaryDocument.class, CurationView.ModelDocument.class, CurationView.GeneExpressionDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.DiseaseSummaryDocument.class, CurationView.ModelDocument.class, CurationView.GeneExpressionDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.SpeciesView.class })
 	@Column(nullable = false)
 	protected String curie;
 

--- a/src/main/java/org/alliancegenome/curation_api/services/SpeciesService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/SpeciesService.java
@@ -2,16 +2,20 @@ package org.alliancegenome.curation_api.services;
 
 import org.alliancegenome.curation_api.dao.SpeciesDAO;
 import org.alliancegenome.curation_api.model.entities.Species;
+import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.services.base.BaseEntityCrudService;
+import org.alliancegenome.curation_api.services.validation.SpeciesValidator;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 
 @RequestScoped
 public class SpeciesService extends BaseEntityCrudService<Species, SpeciesDAO> {
 
 	@Inject SpeciesDAO speciesDAO;
+	@Inject SpeciesValidator speciesValidator;
 
 	@Override
 	@PostConstruct
@@ -19,4 +23,17 @@ public class SpeciesService extends BaseEntityCrudService<Species, SpeciesDAO> {
 		setSQLDao(speciesDAO);
 	}
 
+	@Override
+	@Transactional
+	public ObjectResponse<Species> update(Species uiEntity) {
+		Species dbEntity = speciesValidator.validateSpeciesUpdate(uiEntity);
+		return new ObjectResponse<>(speciesDAO.persist(dbEntity));
+	}
+
+	@Override
+	@Transactional
+	public ObjectResponse<Species> create(Species uiEntity) {
+		Species dbEntity = speciesValidator.validateSpeciesCreate(uiEntity);
+		return new ObjectResponse<>(speciesDAO.persist(dbEntity));
+	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/SpeciesValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/SpeciesValidator.java
@@ -1,0 +1,104 @@
+package org.alliancegenome.curation_api.services.validation;
+
+import org.alliancegenome.curation_api.constants.ValidationConstants;
+import org.alliancegenome.curation_api.dao.SpeciesDAO;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
+import org.alliancegenome.curation_api.model.entities.CrossReference;
+import org.alliancegenome.curation_api.model.entities.Organization;
+import org.alliancegenome.curation_api.model.entities.Species;
+import org.alliancegenome.curation_api.model.entities.ontology.NCBITaxonTerm;
+import org.alliancegenome.curation_api.response.ObjectResponse;
+import org.alliancegenome.curation_api.services.validation.base.AuditedObjectValidator;
+import org.apache.commons.lang3.StringUtils;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+
+@RequestScoped
+public class SpeciesValidator extends AuditedObjectValidator<Species> {
+
+	@Inject SpeciesDAO speciesDAO;
+
+	private String errorMessage;
+
+	public Species validateSpeciesUpdate(Species uiEntity) {
+		response = new ObjectResponse<>(uiEntity);
+		errorMessage = "Could not update Species: [" + uiEntity.getId() + "]";
+
+		Long id = uiEntity.getId();
+		if (id == null) {
+			addMessageResponse("No Species ID provided");
+			throw new ApiErrorException(response);
+		}
+		Species dbEntity = speciesDAO.find(id);
+		if (dbEntity == null) {
+			addMessageResponse("Could not find Species with ID: [" + id + "]");
+			throw new ApiErrorException(response);
+		}
+
+		dbEntity = (Species) validateAuditedObjectFields(uiEntity, dbEntity, false);
+
+		return validateSpecies(uiEntity, dbEntity);
+	}
+
+	public Species validateSpeciesCreate(Species uiEntity) {
+		response = new ObjectResponse<>(uiEntity);
+		errorMessage = "Could not create Species";
+
+		Species dbEntity = new Species();
+
+		dbEntity = (Species) validateAuditedObjectFields(uiEntity, dbEntity, true);
+
+		return validateSpecies(uiEntity, dbEntity);
+	}
+
+	private Species validateSpecies(Species uiEntity, Species dbEntity) {
+		NCBITaxonTerm taxon = validateRequiredTaxon(uiEntity.getTaxon(), dbEntity.getTaxon());
+		dbEntity.setTaxon(taxon);
+
+		if (StringUtils.isBlank(uiEntity.getFullName())) {
+			addMessageResponse("fullName", ValidationConstants.REQUIRED_MESSAGE);
+		} else {
+			dbEntity.setFullName(uiEntity.getFullName());
+		}
+
+		if (StringUtils.isBlank(uiEntity.getDisplayName())) {
+			addMessageResponse("displayName", ValidationConstants.REQUIRED_MESSAGE);
+		} else {
+			dbEntity.setDisplayName(uiEntity.getDisplayName());
+		}
+
+		if (StringUtils.isBlank(uiEntity.getAbbreviation())) {
+			addMessageResponse("abbreviation", ValidationConstants.REQUIRED_MESSAGE);
+		} else {
+			dbEntity.setAbbreviation(uiEntity.getAbbreviation());
+		}
+
+		Organization dataProvider = validateDataProvider(uiEntity.getDataProvider(), dbEntity.getDataProvider(), false);
+		dbEntity.setDataProvider(dataProvider);
+
+		CrossReference dataProviderCrossReference = validateDataProviderCrossReference(uiEntity.getDataProviderCrossReference(), dbEntity.getDataProviderCrossReference());
+		dbEntity.setDataProviderCrossReference(dataProviderCrossReference);
+
+		if (uiEntity.getPhylogeneticOrder() == null) {
+			addMessageResponse("phylogeneticOrder", ValidationConstants.REQUIRED_MESSAGE);
+		} else {
+			dbEntity.setPhylogeneticOrder(uiEntity.getPhylogeneticOrder());
+		}
+
+		if (StringUtils.isBlank(uiEntity.getAssembly_curie())) {
+			addMessageResponse("assembly_curie", ValidationConstants.REQUIRED_MESSAGE);
+		} else {
+			dbEntity.setAssembly_curie(uiEntity.getAssembly_curie());
+		}
+
+		dbEntity.setCommonNames(uiEntity.getCommonNames());
+
+		if (response.hasErrors()) {
+			response.setErrorMessage(errorMessage);
+			throw new ApiErrorException(response);
+		}
+
+		return dbEntity;
+	}
+}

--- a/src/main/java/org/alliancegenome/curation_api/view/CurationView.java
+++ b/src/main/java/org/alliancegenome/curation_api/view/CurationView.java
@@ -115,6 +115,9 @@ public class CurationView {
 	public static class VariantDetailView extends VariantView {
 	}
 
+	public static class SpeciesView extends FieldsOnly {
+	}
+
 	public static class GeneInteractionView extends FieldsOnly {
 	}
 


### PR DESCRIPTION
## Summary
- Enable inline row editing on the Species curation table (previously read-only)
- Add backend validation for all Species fields (taxon, fullName, displayName, abbreviation, dataProvider, phylogeneticOrder, assembly_curie) via `SpeciesValidator`
- Add custom `SpeciesView` JsonView to include `taxon` and `commonNames` in PUT response without triggering lazy loading
- Add reusable `StringListEditor` component for inline editing of `List<String>` fields
- Add `useOrganizationService` hook and `ControlledVocabularyDropdown`-based data provider editor
- Add frontend `SpeciesService` for save/delete API calls

## New Files
- `src/main/cliapp/src/service/SpeciesService.js`
- `src/main/cliapp/src/service/useOrganizationService.js`
- `src/main/cliapp/src/components/Editors/StringListEditor.jsx`
- `src/main/java/.../services/validation/SpeciesValidator.java`

## Test plan
- [ ] Navigate to `/#/species` and verify edit icons appear on each row
- [ ] Edit text fields (fullName, displayName, abbreviation, assembly_curie) and save
- [ ] Edit phylogeneticOrder (integer field) and save
- [ ] Edit commonNames (comma-separated) and save
- [ ] Select a different data provider from dropdown and save
- [ ] Clear a required field and verify validation error is returned
- [ ] Verify taxon column remains read-only in edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)