### PR TITLE
SCRUM-5935: Enable editing of Resource Descriptors curation table

### DIFF
--- a/src/main/cliapp/src/containers/resourceDescriptorPage/ResourceDescriptorsTable.jsx
+++ b/src/main/cliapp/src/containers/resourceDescriptorPage/ResourceDescriptorsTable.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useMemo } from 'react';
+import { useMutation } from '@tanstack/react-query';
 import { GenericDataTable } from '../../components/GenericDataTable/GenericDataTable';
 import { Toast } from 'primereact/toast';
 import { getDefaultTableState } from '../../service/TableStateService';
@@ -6,10 +7,14 @@ import { FILTER_CONFIGS } from '../../constants/FilterFields';
 import { useGetTableData } from '../../service/useGetTableData';
 import { useGetUserSettings } from '../../service/useGetUserSettings';
 import { SearchService } from '../../service/SearchService';
+import { ResourceDescriptorService } from '../../service/ResourceDescriptorService';
 import { Endpoints } from '../../constants/Endpoints';
 
 import { StringTemplate } from '../../components/Templates/StringTemplate';
-import { StringListTemplate } from '../../components/Templates/StringListTemplate';
+import { CommaSeparatedArrayTemplate } from '../../components/Templates/CommaSeparatedArrayTemplate';
+import { InputTextEditor } from '../../components/InputTextEditor';
+import { StringListEditor } from '../../components/Editors/StringListEditor';
+import { ErrorMessageComponent } from '../../components/Error/ErrorMessageComponent';
 
 export const ResourceDescriptorsTable = () => {
 	const [isInEditMode, setIsInEditMode] = useState(false);
@@ -22,6 +27,28 @@ export const ResourceDescriptorsTable = () => {
 
 	const toast_topleft = useRef(null);
 	const toast_topright = useRef(null);
+	const errorMessagesRef = useRef();
+	errorMessagesRef.current = errorMessages;
+
+	let resourceDescriptorService = new ResourceDescriptorService();
+
+	const mutation = useMutation({
+		mutationFn: (updatedResourceDescriptor) => {
+			if (!resourceDescriptorService) {
+				resourceDescriptorService = new ResourceDescriptorService();
+			}
+			return resourceDescriptorService.saveResourceDescriptor(updatedResourceDescriptor);
+		},
+	});
+
+	const stringEditor = (props, field) => {
+		return (
+			<>
+				<InputTextEditor rowProps={props} fieldName={field} />
+				<ErrorMessageComponent errorMessages={errorMessagesRef.current[props.rowIndex]} errorField={field} />
+			</>
+		);
+	};
 
 	const columns = useMemo(
 		() => [
@@ -31,6 +58,7 @@ export const ResourceDescriptorsTable = () => {
 				sortable: true,
 				body: (rowData) => <StringTemplate string={rowData.prefix} />,
 				filterConfig: FILTER_CONFIGS.prefixFilterConfig,
+				editor: (props) => stringEditor(props, 'prefix'),
 			},
 			{
 				field: 'name',
@@ -38,12 +66,19 @@ export const ResourceDescriptorsTable = () => {
 				sortable: true,
 				body: (rowData) => <StringTemplate string={rowData.name} />,
 				filterConfig: FILTER_CONFIGS.nameFilterConfig,
+				editor: (props) => stringEditor(props, 'name'),
 			},
 			{
 				field: 'synonyms',
 				header: 'Synonyms',
-				body: (rowData) => <StringListTemplate list={rowData.synonyms} />,
+				body: (rowData) => <CommaSeparatedArrayTemplate array={rowData.synonyms} />,
 				filterConfig: FILTER_CONFIGS.synonymsFilterConfig,
+				editor: (props) => (
+					<>
+						<StringListEditor rowProps={props} fieldName="synonyms" />
+						<ErrorMessageComponent errorMessages={errorMessagesRef.current[props.rowIndex]} errorField="synonyms" />
+					</>
+				),
 			},
 			{
 				field: 'idPattern',
@@ -51,6 +86,7 @@ export const ResourceDescriptorsTable = () => {
 				sortable: true,
 				body: (rowData) => <StringTemplate string={rowData.idPattern} />,
 				filterConfig: FILTER_CONFIGS.idPatternFilterConfig,
+				editor: (props) => stringEditor(props, 'idPattern'),
 			},
 			{
 				field: 'idExample',
@@ -58,6 +94,7 @@ export const ResourceDescriptorsTable = () => {
 				sortable: true,
 				body: (rowData) => <StringTemplate string={rowData.idExample} />,
 				filterConfig: FILTER_CONFIGS.idExampleFilterConfig,
+				editor: (props) => stringEditor(props, 'idExample'),
 			},
 			{
 				field: 'defaultUrlTemplate',
@@ -65,6 +102,7 @@ export const ResourceDescriptorsTable = () => {
 				sortable: true,
 				body: (rowData) => <StringTemplate string={rowData.defaultUrlTemplate} />,
 				filterConfig: FILTER_CONFIGS.defaultUrlTemplateFilterConfig,
+				editor: (props) => stringEditor(props, 'defaultUrlTemplate'),
 			},
 		],
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -108,7 +146,8 @@ export const ResourceDescriptorsTable = () => {
 				tableState={tableState}
 				setTableState={setTableState}
 				columns={columns}
-				isEditable={false}
+				isEditable={true}
+				mutation={mutation}
 				isInEditMode={isInEditMode}
 				setIsInEditMode={setIsInEditMode}
 				toasts={{ toast_topleft, toast_topright }}

--- a/src/main/cliapp/src/containers/resourceDescriptorPagePage/ResourceDescriptorPagesTable.jsx
+++ b/src/main/cliapp/src/containers/resourceDescriptorPagePage/ResourceDescriptorPagesTable.jsx
@@ -80,7 +80,10 @@ export const ResourceDescriptorPagesTable = () => {
 					)}
 					onValueChangeHandler={onResourceDescriptorValueChange}
 				/>
-				<ErrorMessageComponent errorMessages={errorMessagesRef.current[props.rowIndex]} errorField="resourceDescriptor" />
+				<ErrorMessageComponent
+					errorMessages={errorMessagesRef.current[props.rowIndex]}
+					errorField="resourceDescriptor"
+				/>
 			</>
 		);
 	};

--- a/src/main/cliapp/src/containers/resourceDescriptorPagePage/ResourceDescriptorPagesTable.jsx
+++ b/src/main/cliapp/src/containers/resourceDescriptorPagePage/ResourceDescriptorPagesTable.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useMemo } from 'react';
+import { useMutation } from '@tanstack/react-query';
 import { GenericDataTable } from '../../components/GenericDataTable/GenericDataTable';
 import { Toast } from 'primereact/toast';
 import { getDefaultTableState } from '../../service/TableStateService';
@@ -6,9 +7,14 @@ import { FILTER_CONFIGS } from '../../constants/FilterFields';
 import { useGetTableData } from '../../service/useGetTableData';
 import { useGetUserSettings } from '../../service/useGetUserSettings';
 import { SearchService } from '../../service/SearchService';
+import { ResourceDescriptorPageService } from '../../service/ResourceDescriptorPageService';
 import { Endpoints } from '../../constants/Endpoints';
 
 import { StringTemplate } from '../../components/Templates/StringTemplate';
+import { InputTextEditor } from '../../components/InputTextEditor';
+import { AutocompleteEditor } from '../../components/Autocomplete/AutocompleteEditor';
+import { ErrorMessageComponent } from '../../components/Error/ErrorMessageComponent';
+import { buildAutocompleteFilter, autocompleteSearch, defaultAutocompleteOnChange } from '../../utils/utils';
 
 export const ResourceDescriptorPagesTable = () => {
 	const [isInEditMode, setIsInEditMode] = useState(false);
@@ -21,6 +27,63 @@ export const ResourceDescriptorPagesTable = () => {
 
 	const toast_topleft = useRef(null);
 	const toast_topright = useRef(null);
+	const errorMessagesRef = useRef();
+	errorMessagesRef.current = errorMessages;
+
+	let resourceDescriptorPageService = new ResourceDescriptorPageService();
+
+	const mutation = useMutation({
+		mutationFn: (updatedResourceDescriptorPage) => {
+			if (!resourceDescriptorPageService) {
+				resourceDescriptorPageService = new ResourceDescriptorPageService();
+			}
+			return resourceDescriptorPageService.saveResourceDescriptorPage(updatedResourceDescriptorPage);
+		},
+	});
+
+	const stringEditor = (props, field) => {
+		return (
+			<>
+				<InputTextEditor rowProps={props} fieldName={field} />
+				<ErrorMessageComponent errorMessages={errorMessagesRef.current[props.rowIndex]} errorField={field} />
+			</>
+		);
+	};
+
+	const resourceDescriptorSearch = (event, setFiltered, setQuery) => {
+		const autocompleteFields = ['prefix', 'name'];
+		const endpoint = Endpoints.Resource.DESCRIPTOR;
+		const filterName = 'resourceDescriptorFilter';
+		const filter = buildAutocompleteFilter(event, autocompleteFields);
+
+		setQuery(event.query);
+		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered);
+	};
+
+	const onResourceDescriptorValueChange = (event, setFieldValue, props) => {
+		defaultAutocompleteOnChange(props, event, 'resourceDescriptor', setFieldValue, 'prefix');
+	};
+
+	const resourceDescriptorEditorTemplate = (props) => {
+		return (
+			<>
+				<AutocompleteEditor
+					search={resourceDescriptorSearch}
+					initialValue={props.rowData.resourceDescriptor?.prefix}
+					rowProps={props}
+					fieldName="resourceDescriptor"
+					subField="prefix"
+					valueDisplay={(item, setAutocompleteHoverItem, op, query) => (
+						<div>
+							{item.prefix} ({item.name})
+						</div>
+					)}
+					onValueChangeHandler={onResourceDescriptorValueChange}
+				/>
+				<ErrorMessageComponent errorMessages={errorMessagesRef.current[props.rowIndex]} errorField="resourceDescriptor" />
+			</>
+		);
+	};
 
 	const columns = useMemo(
 		() => [
@@ -29,9 +92,10 @@ export const ResourceDescriptorPagesTable = () => {
 				header: 'Resource Descriptor',
 				sortable: true,
 				body: (rowData) => (
-					<StringTemplate string={`${rowData.resourceDescriptor?.prefix} (${rowData.resourceDescriptor.name})`} />
+					<StringTemplate string={`${rowData.resourceDescriptor?.prefix} (${rowData.resourceDescriptor?.name})`} />
 				),
 				filterConfig: FILTER_CONFIGS.resourceDescriptorFilterConfig,
+				editor: (props) => resourceDescriptorEditorTemplate(props),
 			},
 			{
 				field: 'name',
@@ -39,6 +103,7 @@ export const ResourceDescriptorPagesTable = () => {
 				sortable: true,
 				body: (rowData) => <StringTemplate string={rowData.name} />,
 				filterConfig: FILTER_CONFIGS.nameFilterConfig,
+				editor: (props) => stringEditor(props, 'name'),
 			},
 			{
 				field: 'urlTemplate',
@@ -46,6 +111,7 @@ export const ResourceDescriptorPagesTable = () => {
 				sortable: true,
 				body: (rowData) => <StringTemplate string={rowData.urlTemplate} />,
 				filterConfig: FILTER_CONFIGS.urlTemplateFilterConfig,
+				editor: (props) => stringEditor(props, 'urlTemplate'),
 			},
 			{
 				field: 'pageDescription',
@@ -53,6 +119,7 @@ export const ResourceDescriptorPagesTable = () => {
 				sortable: true,
 				body: (rowData) => <StringTemplate string={rowData.pageDescription} />,
 				filterConfig: FILTER_CONFIGS.pageDescriptionFilterConfig,
+				editor: (props) => stringEditor(props, 'pageDescription'),
 			},
 		],
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -96,7 +163,8 @@ export const ResourceDescriptorPagesTable = () => {
 				setTableState={setTableState}
 				tableName="Resource Descriptor Pages"
 				columns={columns}
-				isEditable={false}
+				isEditable={true}
+				mutation={mutation}
 				isInEditMode={isInEditMode}
 				setIsInEditMode={setIsInEditMode}
 				toasts={{ toast_topleft, toast_topright }}

--- a/src/main/cliapp/src/service/ResourceDescriptorPageService.js
+++ b/src/main/cliapp/src/service/ResourceDescriptorPageService.js
@@ -1,0 +1,7 @@
+import { BaseAuthService } from './BaseAuthService';
+
+export class ResourceDescriptorPageService extends BaseAuthService {
+	saveResourceDescriptorPage(updatedResourceDescriptorPage) {
+		return this.api.put(`/resourcedescriptorpage`, updatedResourceDescriptorPage);
+	}
+}

--- a/src/main/cliapp/src/service/ResourceDescriptorService.js
+++ b/src/main/cliapp/src/service/ResourceDescriptorService.js
@@ -1,0 +1,7 @@
+import { BaseAuthService } from './BaseAuthService';
+
+export class ResourceDescriptorService extends BaseAuthService {
+	saveResourceDescriptor(updatedResourceDescriptor) {
+		return this.api.put(`/resourcedescriptor`, updatedResourceDescriptor);
+	}
+}

--- a/src/main/java/org/alliancegenome/curation_api/controllers/crud/ResourceDescriptorCrudController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/crud/ResourceDescriptorCrudController.java
@@ -28,4 +28,9 @@ public class ResourceDescriptorCrudController extends BaseEntityCrudController<R
 		return resourceDescriptorService.getById(id);
 	}
 
+	@Override
+	public ObjectResponse<ResourceDescriptor> update(ResourceDescriptor entity) {
+		return resourceDescriptorService.update(entity);
+	}
+
 }

--- a/src/main/java/org/alliancegenome/curation_api/controllers/crud/ResourceDescriptorPageCrudController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/crud/ResourceDescriptorPageCrudController.java
@@ -28,4 +28,9 @@ public class ResourceDescriptorPageCrudController extends BaseEntityCrudControll
 		return resourceDescriptorPageService.getById(id);
 	}
 
+	@Override
+	public ObjectResponse<ResourceDescriptorPage> update(ResourceDescriptorPage entity) {
+		return resourceDescriptorPageService.update(entity);
+	}
+
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ResourceDescriptorCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ResourceDescriptorCrudInterface.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -26,5 +27,11 @@ public interface ResourceDescriptorCrudInterface extends BaseIdCrudInterface<Res
 	@Path("/{id}")
 	@JsonView(CurationView.ResourceDescriptorView.class)
 	ObjectResponse<ResourceDescriptor> getById(@PathParam("id") Long id);
+
+	@Override
+	@PUT
+	@Path("/")
+	@JsonView(CurationView.ResourceDescriptorView.class)
+	ObjectResponse<ResourceDescriptor> update(ResourceDescriptor entity);
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ResourceDescriptorPageCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ResourceDescriptorPageCrudInterface.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 
 import org.alliancegenome.curation_api.interfaces.base.BaseIdCrudInterface;
 import org.alliancegenome.curation_api.model.entities.ResourceDescriptorPage;
+import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -13,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
@@ -29,4 +31,10 @@ public interface ResourceDescriptorPageCrudInterface extends BaseIdCrudInterface
 	@JsonView(CurationView.ResourceDescriptorPageView.class)
 	@Tag(name = "Elastic Search Browsing Endpoints")
 	SearchResponse<ResourceDescriptorPage> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
+
+	@Override
+	@PUT
+	@Path("/")
+	@JsonView(CurationView.ResourceDescriptorPageView.class)
+	ObjectResponse<ResourceDescriptorPage> update(ResourceDescriptorPage entity);
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ResourceDescriptor.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ResourceDescriptor.java
@@ -60,7 +60,7 @@ public class ResourceDescriptor extends AuditedObject {
 	private String name;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
-	@KeywordField(name = "synoynyms_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES)
+	@KeywordField(name = "synonyms_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES)
 	@ElementCollection
 	@JoinTable(indexes = @Index(columnList = "resourcedescriptor_id"))
 	@Fetch(FetchMode.JOIN)

--- a/src/main/java/org/alliancegenome/curation_api/services/ResourceDescriptorPageService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ResourceDescriptorPageService.java
@@ -9,18 +9,21 @@ import org.alliancegenome.curation_api.model.entities.ResourceDescriptor;
 import org.alliancegenome.curation_api.model.entities.ResourceDescriptorPage;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.services.base.BaseEntityCrudService;
+import org.alliancegenome.curation_api.services.validation.ResourceDescriptorPageValidator;
 import org.apache.commons.collections.CollectionUtils;
 
 import io.quarkus.logging.Log;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 
 @RequestScoped
 public class ResourceDescriptorPageService extends BaseEntityCrudService<ResourceDescriptorPage, ResourceDescriptorPageDAO> {
 
 	@Inject ResourceDescriptorPageDAO resourceDescriptorPageDAO;
 	@Inject ResourceDescriptorService resourceDescriptorService;
+	@Inject ResourceDescriptorPageValidator resourceDescriptorPageValidator;
 
 	HashMap<String, Date> resourceRequestMap = new HashMap<>();
 	HashMap<String, HashMap<String, ResourceDescriptorPage>> resourcePageCacheMap = new HashMap<>();
@@ -29,6 +32,13 @@ public class ResourceDescriptorPageService extends BaseEntityCrudService<Resourc
 	@PostConstruct
 	protected void init() {
 		setSQLDao(resourceDescriptorPageDAO);
+	}
+
+	@Override
+	@Transactional
+	public ObjectResponse<ResourceDescriptorPage> update(ResourceDescriptorPage uiEntity) {
+		ResourceDescriptorPage dbEntity = resourceDescriptorPageValidator.validateResourceDescriptorPageUpdate(uiEntity);
+		return new ObjectResponse<>(resourceDescriptorPageDAO.persist(dbEntity));
 	}
 
 	public ResourceDescriptorPage getPageForResourceDescriptor(String resourceDescriptorPrefix, String pageName) {

--- a/src/main/java/org/alliancegenome/curation_api/services/ResourceDescriptorService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ResourceDescriptorService.java
@@ -12,6 +12,7 @@ import org.alliancegenome.curation_api.model.ingest.dto.ResourceDescriptorDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.base.BaseEntityCrudService;
+import org.alliancegenome.curation_api.services.validation.ResourceDescriptorValidator;
 import org.alliancegenome.curation_api.services.validation.dto.ResourceDescriptorDTOValidator;
 import org.apache.commons.collections4.ListUtils;
 
@@ -26,6 +27,7 @@ public class ResourceDescriptorService extends BaseEntityCrudService<ResourceDes
 
 	@Inject ResourceDescriptorDAO resourceDescriptorDAO;
 	@Inject ResourceDescriptorDTOValidator resourceDescriptorDtoValidator;
+	@Inject ResourceDescriptorValidator resourceDescriptorValidator;
 
 	Date prefixRequest;
 	HashMap<String, ResourceDescriptor> prefixCacheMap = new HashMap<>();
@@ -34,6 +36,13 @@ public class ResourceDescriptorService extends BaseEntityCrudService<ResourceDes
 	@PostConstruct
 	protected void init() {
 		setSQLDao(resourceDescriptorDAO);
+	}
+
+	@Override
+	@Transactional
+	public ObjectResponse<ResourceDescriptor> update(ResourceDescriptor uiEntity) {
+		ResourceDescriptor dbEntity = resourceDescriptorValidator.validateResourceDescriptorUpdate(uiEntity);
+		return new ObjectResponse<>(resourceDescriptorDAO.persist(dbEntity));
 	}
 
 	public List<String> getAllNames() {

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/ResourceDescriptorPageValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/ResourceDescriptorPageValidator.java
@@ -1,0 +1,76 @@
+package org.alliancegenome.curation_api.services.validation;
+
+import org.alliancegenome.curation_api.constants.ValidationConstants;
+import org.alliancegenome.curation_api.dao.ResourceDescriptorDAO;
+import org.alliancegenome.curation_api.dao.ResourceDescriptorPageDAO;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
+import org.alliancegenome.curation_api.model.entities.ResourceDescriptor;
+import org.alliancegenome.curation_api.model.entities.ResourceDescriptorPage;
+import org.alliancegenome.curation_api.response.ObjectResponse;
+import org.alliancegenome.curation_api.services.validation.base.AuditedObjectValidator;
+import org.apache.commons.lang3.StringUtils;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+
+@RequestScoped
+public class ResourceDescriptorPageValidator extends AuditedObjectValidator<ResourceDescriptorPage> {
+
+	@Inject ResourceDescriptorPageDAO resourceDescriptorPageDAO;
+	@Inject ResourceDescriptorDAO resourceDescriptorDAO;
+
+	private String errorMessage;
+
+	public ResourceDescriptorPage validateResourceDescriptorPageUpdate(ResourceDescriptorPage uiEntity) {
+		response = new ObjectResponse<>(uiEntity);
+		errorMessage = "Could not update Resource Descriptor Page: [" + uiEntity.getId() + "]";
+
+		Long id = uiEntity.getId();
+		if (id == null) {
+			addMessageResponse("No Resource Descriptor Page ID provided");
+			throw new ApiErrorException(response);
+		}
+		ResourceDescriptorPage dbEntity = resourceDescriptorPageDAO.find(id);
+		if (dbEntity == null) {
+			addMessageResponse("Could not find Resource Descriptor Page with ID: [" + id + "]");
+			throw new ApiErrorException(response);
+		}
+
+		dbEntity = (ResourceDescriptorPage) validateAuditedObjectFields(uiEntity, dbEntity, false);
+
+		return validateResourceDescriptorPage(uiEntity, dbEntity);
+	}
+
+	private ResourceDescriptorPage validateResourceDescriptorPage(ResourceDescriptorPage uiEntity, ResourceDescriptorPage dbEntity) {
+		if (uiEntity.getResourceDescriptor() == null || uiEntity.getResourceDescriptor().getId() == null) {
+			addMessageResponse("resourceDescriptor", ValidationConstants.REQUIRED_MESSAGE);
+		} else {
+			ResourceDescriptor resourceDescriptor = resourceDescriptorDAO.find(uiEntity.getResourceDescriptor().getId());
+			if (resourceDescriptor == null) {
+				addMessageResponse("resourceDescriptor", ValidationConstants.INVALID_MESSAGE);
+			} else {
+				dbEntity.setResourceDescriptor(resourceDescriptor);
+			}
+		}
+
+		if (StringUtils.isBlank(uiEntity.getName())) {
+			addMessageResponse("name", ValidationConstants.REQUIRED_MESSAGE);
+		} else {
+			dbEntity.setName(uiEntity.getName());
+		}
+
+		if (StringUtils.isBlank(uiEntity.getUrlTemplate())) {
+			addMessageResponse("urlTemplate", ValidationConstants.REQUIRED_MESSAGE);
+		} else {
+			dbEntity.setUrlTemplate(uiEntity.getUrlTemplate());
+		}
+		dbEntity.setPageDescription(uiEntity.getPageDescription());
+
+		if (response.hasErrors()) {
+			response.setErrorMessage(errorMessage);
+			throw new ApiErrorException(response);
+		}
+
+		return dbEntity;
+	}
+}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/ResourceDescriptorValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/ResourceDescriptorValidator.java
@@ -1,0 +1,77 @@
+package org.alliancegenome.curation_api.services.validation;
+
+import org.alliancegenome.curation_api.constants.ValidationConstants;
+import org.alliancegenome.curation_api.dao.ResourceDescriptorDAO;
+import org.alliancegenome.curation_api.exceptions.ApiErrorException;
+import org.alliancegenome.curation_api.model.entities.ResourceDescriptor;
+import org.alliancegenome.curation_api.response.ObjectResponse;
+import org.alliancegenome.curation_api.services.validation.base.AuditedObjectValidator;
+import org.apache.commons.lang3.StringUtils;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+
+@RequestScoped
+public class ResourceDescriptorValidator extends AuditedObjectValidator<ResourceDescriptor> {
+
+	@Inject ResourceDescriptorDAO resourceDescriptorDAO;
+
+	private String errorMessage;
+
+	public ResourceDescriptor validateResourceDescriptorUpdate(ResourceDescriptor uiEntity) {
+		response = new ObjectResponse<>(uiEntity);
+		errorMessage = "Could not update Resource Descriptor: [" + uiEntity.getId() + "]";
+
+		Long id = uiEntity.getId();
+		if (id == null) {
+			addMessageResponse("No Resource Descriptor ID provided");
+			throw new ApiErrorException(response);
+		}
+		ResourceDescriptor dbEntity = resourceDescriptorDAO.find(id);
+		if (dbEntity == null) {
+			addMessageResponse("Could not find Resource Descriptor with ID: [" + id + "]");
+			throw new ApiErrorException(response);
+		}
+
+		dbEntity = (ResourceDescriptor) validateAuditedObjectFields(uiEntity, dbEntity, false);
+
+		return validateResourceDescriptor(uiEntity, dbEntity);
+	}
+
+	private ResourceDescriptor validateResourceDescriptor(ResourceDescriptor uiEntity, ResourceDescriptor dbEntity) {
+		if (StringUtils.isBlank(uiEntity.getPrefix())) {
+			addMessageResponse("prefix", ValidationConstants.REQUIRED_MESSAGE);
+		} else {
+			dbEntity.setPrefix(uiEntity.getPrefix());
+		}
+
+		if (StringUtils.isBlank(uiEntity.getName())) {
+			addMessageResponse("name", ValidationConstants.REQUIRED_MESSAGE);
+		} else {
+			dbEntity.setName(uiEntity.getName());
+		}
+
+		dbEntity.setSynonyms(uiEntity.getSynonyms());
+
+		if (StringUtils.isBlank(uiEntity.getIdPattern())) {
+			addMessageResponse("idPattern", ValidationConstants.REQUIRED_MESSAGE);
+		} else {
+			dbEntity.setIdPattern(uiEntity.getIdPattern());
+		}
+
+		dbEntity.setIdExample(uiEntity.getIdExample());
+
+		if (StringUtils.isBlank(uiEntity.getDefaultUrlTemplate())) {
+			addMessageResponse("defaultUrlTemplate", ValidationConstants.REQUIRED_MESSAGE);
+		} else {
+			dbEntity.setDefaultUrlTemplate(uiEntity.getDefaultUrlTemplate());
+		}
+
+		if (response.hasErrors()) {
+			response.setErrorMessage(errorMessage);
+			throw new ApiErrorException(response);
+		}
+
+		return dbEntity;
+	}
+}


### PR DESCRIPTION
## Summary
- Enable inline row editing for the Resource Descriptors and Resource Descriptor Pages tables in the curation UI
- Add backend validators (`ResourceDescriptorValidator`, `ResourceDescriptorPageValidator`) to enforce required fields (prefix, name, idPattern, defaultUrlTemplate for descriptors; name, urlTemplate, resourceDescriptor for pages)
- Add autocomplete search editor for the Resource Descriptor column on the pages table, searchable by prefix and name
- Override update endpoints with correct `@JsonView` to include synonyms and parent references in PUT responses
- Fix `synoynyms_keyword` → `synonyms_keyword` typo in Hibernate Search index annotation

## Test plan
- [ ] Navigate to `#/resourcedescriptors`, click edit on a row, modify fields, save — verify changes persist
- [ ] Try saving with blank prefix or name — verify validation error is shown
- [ ] Verify synonyms persist in the UI after saving (no disappearing on save)
- [ ] Navigate to `#/resourcedescriptorpages`, edit a row, modify fields, save
- [ ] Use the autocomplete on the Resource Descriptor column to change the parent descriptor
- [ ] Try saving a page with blank urlTemplate — verify validation error
- [ ] Reindex both entities and verify search still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)