### PR TITLE
SCRUM-5967 Add GeneCacheDocument view and cache endpoint

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/controllers/document/GeneDocumentController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/document/GeneDocumentController.java
@@ -91,6 +91,22 @@ public class GeneDocumentController implements GeneDocumentInterface {
 	}
 
 	@Override
+	public SearchResponse<GeneSummaryDocument> findCacheByIds(List<Long> ids) {
+		List<Gene> genes = geneService.findByIds(ids);
+		ArrayList<GeneSummaryDocument> list = new ArrayList<>();
+		if (genes != null) {
+			for (Gene gene : genes) {
+				GeneSummaryDocument doc = new GeneSummaryDocument();
+				doc.setGene(gene);
+				list.add(doc);
+			}
+		}
+		SearchResponse<GeneSummaryDocument> ret = new SearchResponse<>(list);
+		ret.setTotalResults((long) list.size());
+		return ret;
+	}
+
+	@Override
 	public SearchResponse<GeneSearchResultDocument> findSearchResultByIds(List<Long> ids) {
 		List<GeneSearchResultDocument> list = geneService.buildSearchResultDocuments(ids);
 		SearchResponse<GeneSearchResultDocument> ret = new SearchResponse<>(list);

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/document/GeneDocumentInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/document/GeneDocumentInterface.java
@@ -47,6 +47,11 @@ public interface GeneDocumentInterface {
 	SearchResponse<GeneSummaryDocument> findByIds(@RequestBody List<Long> ids);
 
 	@POST
+	@Path("/cache/byids")
+	@JsonView(CurationView.GeneCacheDocument.class)
+	SearchResponse<GeneSummaryDocument> findCacheByIds(@RequestBody List<Long> ids);
+
+	@POST
 	@Path("/searchresult/byids")
 	@JsonView(CurationView.GeneSearchResultDocument.class)
 	SearchResponse<GeneSearchResultDocument> findSearchResultByIds(@RequestBody List<Long> ids);

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneSummaryDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneSummaryDocument.java
@@ -8,12 +8,12 @@ import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Data;
 
 @Data
-@JsonView(CurationView.GeneSummaryDocument.class)
+@JsonView({ CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class })
 public class GeneSummaryDocument extends ESDocument {
 
 	{
 		category = "gene_summary";
 	}
-	
+
 	private Gene gene;
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/SequenceSummaryDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/SequenceSummaryDocument.java
@@ -1,7 +1,5 @@
 package org.alliancegenome.curation_api.model.document.es;
 
-import java.util.HashSet;
-
 import org.alliancegenome.curation_api.model.entities.PredictedVariantConsequence;
 import org.alliancegenome.curation_api.model.entities.Variant;
 import org.alliancegenome.curation_api.view.CurationView;
@@ -22,7 +20,5 @@ public class SequenceSummaryDocument extends AVSParentDocument {
 
 	private Variant variant;
 	private PredictedVariantConsequence consequence;
-	private HashSet<String> geneSynonyms;
-	private HashSet<String> geneCrossReferences;
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/SequenceSummaryDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/SequenceSummaryDocument.java
@@ -1,5 +1,7 @@
 package org.alliancegenome.curation_api.model.document.es;
 
+import java.util.HashSet;
+
 import org.alliancegenome.curation_api.model.entities.PredictedVariantConsequence;
 import org.alliancegenome.curation_api.model.entities.Variant;
 import org.alliancegenome.curation_api.view.CurationView;
@@ -20,5 +22,7 @@ public class SequenceSummaryDocument extends AVSParentDocument {
 
 	private Variant variant;
 	private PredictedVariantConsequence consequence;
+	private HashSet<String> geneSynonyms;
+	private HashSet<String> geneCrossReferences;
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/VariantSummaryDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/VariantSummaryDocument.java
@@ -1,5 +1,6 @@
 package org.alliancegenome.curation_api.model.document.es;
 
+import java.util.HashSet;
 import java.util.List;
 
 import org.alliancegenome.curation_api.model.entities.Variant;
@@ -21,4 +22,6 @@ public class VariantSummaryDocument extends AVSParentDocument {
 		alterationTypeSortOrder = 4;
 	}
 	private List<Variant> variantList;
+	private HashSet<String> geneSynonyms;
+	private HashSet<String> geneCrossReferences;
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AssemblyComponent.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AssemblyComponent.java
@@ -33,7 +33,7 @@ import lombok.ToString;
 	}
 )
 public class AssemblyComponent extends GenomicEntity {
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
 	private String name;
 
 	@IndexedEmbedded(includePaths = {"name", "name_keyword", "curie", "curie_keyword", "primaryExternalId", "primaryExternalId_keyword", "modInternalId", "modInternalId_keyword"})

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/BiologicalEntity.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/BiologicalEntity.java
@@ -70,7 +70,7 @@ public class BiologicalEntity extends SubmittedObject {
 	@IndexedEmbedded(includePaths = {"name", "curie", "name_keyword", "curie_keyword"})
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.TransgenicAllelesDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.TransgenicAllelesDocument.class })
 	private NCBITaxonTerm taxon;
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/CrossReference.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/CrossReference.java
@@ -43,20 +43,20 @@ public class CrossReference extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "referencedCurie_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.ModelDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.TransgenicAllelesDocument.class})
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.ModelDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.TransgenicAllelesDocument.class})
 	@EqualsAndHashCode.Include
 	private String referencedCurie;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "displayName_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.TransgenicAllelesDocument.class})
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.TransgenicAllelesDocument.class})
 	@EqualsAndHashCode.Include
 	private String displayName;
 
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.DiseaseSummaryDocument.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.ModelDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.TransgenicAllelesDocument.class})
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.DiseaseSummaryDocument.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.ModelDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.TransgenicAllelesDocument.class})
 	@Fetch(FetchMode.SELECT)
 	private ResourceDescriptorPage resourceDescriptorPage;
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Gene.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Gene.java
@@ -113,7 +113,7 @@ public class Gene extends GenomicEntity {
 	@IndexedEmbedded(includePaths = { "displayText", "formatText", "nameType.name", "synonymScope.name", "evidence.curie", "displayText_keyword", "formatText_keyword", "nameType.name_keyword", "synonymScope.name_keyword", "evidence.curie_keyword"})
 	@OneToOne(mappedBy = "singleGene", cascade = CascadeType.ALL, orphanRemoval = true)
 	@JsonManagedReference
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.ModelDocument.class, CurationView.TransgenicAllelesDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.ModelDocument.class, CurationView.TransgenicAllelesDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
 	private GeneSymbolSlotAnnotation geneSymbol;
 
 	@IndexedEmbedded(includePaths = { "displayText", "formatText", "nameType.name", "synonymScope.name", "evidence.curie", "displayText_keyword", "formatText_keyword", "nameType.name_keyword", "synonymScope.name_keyword", "evidence.curie_keyword"})
@@ -131,7 +131,7 @@ public class Gene extends GenomicEntity {
 	@IndexedEmbedded(includePaths = { "displayText", "formatText", "nameType.name", "synonymScope.name", "evidence.curie", "displayText_keyword", "formatText_keyword", "nameType.name_keyword", "synonymScope.name_keyword", "evidence.curie_keyword"})
 	@OneToMany(mappedBy = "singleGene", cascade = CascadeType.ALL, orphanRemoval = true)
 	@JsonManagedReference
-	@JsonView({ CurationView.FieldsAndLists.class, CurationView.GeneView.class, CurationView.GeneSummaryDocument.class })
+	@JsonView({ CurationView.FieldsAndLists.class, CurationView.GeneView.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class })
 	private List<GeneSynonymSlotAnnotation> geneSynonyms;
 
 	@IndexedEmbedded(includePaths = { "secondaryId", "evidence.curie", "secondaryId_keyword", "evidence.curie_keyword"})
@@ -162,7 +162,7 @@ public class Gene extends GenomicEntity {
 	)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@OneToMany(mappedBy = "geneAssociationSubject", cascade = CascadeType.ALL, orphanRemoval = true)
-	@JsonView({ CurationView.FieldsAndLists.class, CurationView.GeneDetailView.class, CurationView.GeneSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
+	@JsonView({ CurationView.FieldsAndLists.class, CurationView.GeneDetailView.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
 	private List<GeneGenomicLocationAssociation> geneGenomicLocationAssociations;
 
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/GenomicEntity.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/GenomicEntity.java
@@ -37,6 +37,6 @@ public class GenomicEntity extends BiologicalEntity {
 		@Index(columnList = "crossreferences_id", name = "genomicentity_crossreference_crossreferences_index")
 	})
 	@EqualsAndHashCode.Include
-	@JsonView({CurationView.FieldsAndLists.class, CurationView.AlleleView.class, CurationView.GeneView.class, CurationView.AffectedGenomicModelView.class, CurationView.VariantView.class, CurationView.GeneSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class})
+	@JsonView({CurationView.FieldsAndLists.class, CurationView.AlleleView.class, CurationView.GeneView.class, CurationView.AffectedGenomicModelView.class, CurationView.VariantView.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class})
 	private List<CrossReference> crossReferences;
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/LocationAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/LocationAssociation.java
@@ -34,12 +34,12 @@ public abstract class LocationAssociation extends EvidenceAssociation {
 
 	@GenericField(projectable = Projectable.YES, sortable = Sortable.YES)
 	@Column(name = "`start`")
-	@JsonView({CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class})
+	@JsonView({CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class})
 	private Integer start;
 
 	@GenericField(projectable = Projectable.YES, sortable = Sortable.YES)
 	@Column(name = "`end`")
-	@JsonView({CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class})
+	@JsonView({CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class})
 	private Integer end;
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
@@ -62,17 +62,17 @@ public class Species extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "fullName_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class })
 	private String fullName;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "abbreviation_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class })
 	private String abbreviation;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "displayName_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class })
 	private String displayName;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/GeneGenomicLocationAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/GeneGenomicLocationAssociation.java
@@ -69,14 +69,14 @@ public class GeneGenomicLocationAssociation extends LocationAssociation {
 		"modInternalId", "modInternalId_keyword", "name", "name_keyword"
 	})
 	@ManyToOne
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class })
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@Fetch(FetchMode.JOIN)
 	private AssemblyComponent geneGenomicLocationAssociationObject;
 	
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "strand_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class })
 	@Column(length = 1)
 	private String strand;
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/base/CurieObject.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/base/CurieObject.java
@@ -28,7 +28,7 @@ public class CurieObject extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "curie_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.DiseaseSummaryDocument.class, CurationView.ModelDocument.class, CurationView.GeneExpressionDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.DiseaseSummaryDocument.class, CurationView.ModelDocument.class, CurationView.GeneExpressionDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
 	@Column(nullable = false)
 	protected String curie;
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/base/SubmittedObject.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/base/SubmittedObject.java
@@ -51,6 +51,7 @@ public class SubmittedObject extends CurieObject {
 			CurationView.ForPublic.class,
 			CurationView.GeneToGeneOrthologyDocument.class,
 			CurationView.GeneSummaryDocument.class,
+			CurationView.GeneCacheDocument.class,
 			CurationView.ModelDocument.class,
 			CurationView.TransgenicAllelesDocument.class,
 			CurationView.AlleleSummaryDocument.class,

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java
@@ -26,7 +26,7 @@ import lombok.ToString;
 public class NCBITaxonTerm extends OntologyTerm {
 
 	@OneToOne(mappedBy = "taxon", cascade = CascadeType.ALL, orphanRemoval = true)
-	@JsonView({CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class})
+	@JsonView({CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class})
 	private Species species;
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
@@ -57,7 +57,7 @@ public class OntologyTerm extends CurieObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "name_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.DiseaseSummaryDocument.class, CurationView.ModelDocument.class, CurationView.AlleleSummaryDocument.class,
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.DiseaseSummaryDocument.class, CurationView.ModelDocument.class, CurationView.AlleleSummaryDocument.class,
 		CurationView.GeneExpressionDocument.class, CurationView.GeneExpressionDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
 	@Column(length = 2000)
 	protected String name;

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/NameSlotAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/slotAnnotations/NameSlotAnnotation.java
@@ -42,14 +42,14 @@ public abstract class NameSlotAnnotation extends SlotAnnotation {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "formatText_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneSummaryDocument.class, CurationView.ModelDocument.class, CurationView.TransgenicAllelesDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.ModelDocument.class, CurationView.TransgenicAllelesDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
 	@EqualsAndHashCode.Include
 	@Column(columnDefinition = "TEXT")
 	protected String formatText;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "displayText_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.ModelDocument.class, CurationView.TransgenicAllelesDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.ModelDocument.class, CurationView.TransgenicAllelesDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
 	@EqualsAndHashCode.Include
 	@Column(columnDefinition = "TEXT")
 	protected String displayText;

--- a/src/main/java/org/alliancegenome/curation_api/response/SearchResponse.java
+++ b/src/main/java/org/alliancegenome/curation_api/response/SearchResponse.java
@@ -23,6 +23,7 @@ import lombok.Data;
 	CurationView.GOSearchResultDocument.class,
 	CurationView.GeneSummaryDocument.class,
 	CurationView.GeneSearchResultDocument.class,
+	CurationView.GeneCacheDocument.class,
 	CurationView.DiseaseSummaryDocument.class,
 	CurationView.DiseaseSearchResultDocument.class,
 	CurationView.AlleleSummaryDocument.class,

--- a/src/main/java/org/alliancegenome/curation_api/view/CurationView.java
+++ b/src/main/java/org/alliancegenome/curation_api/view/CurationView.java
@@ -152,6 +152,7 @@ public class CurationView {
 	public static class VariantSummaryDocument { }
 	public static class VariantSearchResultDocument { }
 	public static class SequenceSummaryDocument { }
+	public static class GeneCacheDocument { }
 
 	// View for Table Documents
 	public static class GeneToGeneOrthologyDocument { }


### PR DESCRIPTION
## Summary
- Add `GeneCacheDocument` JsonView with slim gene fields for variant indexer cache (curie, primaryExternalId, taxon, geneSymbol, geneSynonyms, crossReferences, geneGenomicLocationAssociations + nested)
- Add `POST /gene/document/cache/byids` endpoint returning `GeneSummaryDocument` with the slim view
- Add `geneSynonyms` and `geneCrossReferences` `HashSet<String>` fields to `VariantSummaryDocument` and `SequenceSummaryDocument` for variant search support
- Add `GeneCacheDocument` to `SearchResponse` and `GeneSummaryDocument` class-level views

## Test plan
- [ ] Call `POST /api/gene/document/cache/byids` with a batch of gene IDs, verify slim response
- [ ] Verify existing `findByIds` endpoint still returns full `GeneSummaryDocument` payload
- [ ] Verify no regression on gene summary indexing