### PR TITLE
SCRUM-5935: Add audit columns and expandable synonyms editor

### DIFF
--- a/src/main/cliapp/src/components/Editors/StringListTextAreaEditor.jsx
+++ b/src/main/cliapp/src/components/Editors/StringListTextAreaEditor.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { InputTextarea } from 'primereact/inputtextarea';
+
+export function StringListTextAreaEditor({ rowProps, fieldName, rows = 5 }) {
+	const initialValue = Array.isArray(rowProps.rowData[fieldName]) ? rowProps.rowData[fieldName].join(', ') : '';
+	const [fieldValue, setFieldValue] = useState(initialValue);
+
+	const onChange = (e) => {
+		const value = e.target.value;
+		setFieldValue(value);
+		let updatedEntities = [...rowProps.props.value];
+		updatedEntities[rowProps.rowIndex][fieldName] = value
+			? value
+					.split(',')
+					.map((s) => s.trim())
+					.filter((s) => s.length > 0)
+			: [];
+	};
+
+	return (
+		<>
+			<InputTextarea
+				aria-label={fieldName}
+				value={fieldValue}
+				onChange={onChange}
+				style={{ width: '100%' }}
+				rows={rows}
+				autoResize
+			/>
+		</>
+	);
+}

--- a/src/main/cliapp/src/containers/resourceDescriptorPage/ResourceDescriptorsTable.jsx
+++ b/src/main/cliapp/src/containers/resourceDescriptorPage/ResourceDescriptorsTable.jsx
@@ -13,7 +13,7 @@ import { Endpoints } from '../../constants/Endpoints';
 import { StringTemplate } from '../../components/Templates/StringTemplate';
 import { CommaSeparatedArrayTemplate } from '../../components/Templates/CommaSeparatedArrayTemplate';
 import { InputTextEditor } from '../../components/InputTextEditor';
-import { StringListEditor } from '../../components/Editors/StringListEditor';
+import { StringListTextAreaEditor } from '../../components/Editors/StringListTextAreaEditor';
 import { ErrorMessageComponent } from '../../components/Error/ErrorMessageComponent';
 
 export const ResourceDescriptorsTable = () => {
@@ -75,7 +75,7 @@ export const ResourceDescriptorsTable = () => {
 				filterConfig: FILTER_CONFIGS.synonymsFilterConfig,
 				editor: (props) => (
 					<>
-						<StringListEditor rowProps={props} fieldName="synonyms" />
+						<StringListTextAreaEditor rowProps={props} fieldName="synonyms" rows={5} />
 						<ErrorMessageComponent errorMessages={errorMessagesRef.current[props.rowIndex]} errorField="synonyms" />
 					</>
 				),
@@ -103,6 +103,21 @@ export const ResourceDescriptorsTable = () => {
 				body: (rowData) => <StringTemplate string={rowData.defaultUrlTemplate} />,
 				filterConfig: FILTER_CONFIGS.defaultUrlTemplateFilterConfig,
 				editor: (props) => stringEditor(props, 'defaultUrlTemplate'),
+			},
+			{
+				field: 'updatedBy.uniqueId',
+				header: 'Updated By',
+				sortable: true,
+				body: (rowData) => <StringTemplate string={rowData.updatedBy?.uniqueId} />,
+				filterConfig: FILTER_CONFIGS.updatedByFilterConfig,
+			},
+			{
+				field: 'dateUpdated',
+				header: 'Date Updated',
+				sortable: true,
+				filter: true,
+				body: (rowData) => <StringTemplate string={rowData.dateUpdated} />,
+				filterConfig: FILTER_CONFIGS.dateUpdatedFilterConfig,
 			},
 		],
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/main/cliapp/src/containers/resourceDescriptorPagePage/ResourceDescriptorPagesTable.jsx
+++ b/src/main/cliapp/src/containers/resourceDescriptorPagePage/ResourceDescriptorPagesTable.jsx
@@ -124,6 +124,21 @@ export const ResourceDescriptorPagesTable = () => {
 				filterConfig: FILTER_CONFIGS.pageDescriptionFilterConfig,
 				editor: (props) => stringEditor(props, 'pageDescription'),
 			},
+			{
+				field: 'updatedBy.uniqueId',
+				header: 'Updated By',
+				sortable: true,
+				body: (rowData) => <StringTemplate string={rowData.updatedBy?.uniqueId} />,
+				filterConfig: FILTER_CONFIGS.updatedByFilterConfig,
+			},
+			{
+				field: 'dateUpdated',
+				header: 'Date Updated',
+				sortable: true,
+				filter: true,
+				body: (rowData) => <StringTemplate string={rowData.dateUpdated} />,
+				filterConfig: FILTER_CONFIGS.dateUpdatedFilterConfig,
+			},
 		],
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[]


### PR DESCRIPTION
## Summary
- Add **Date Updated** and **Updated By** columns to both Resource Descriptors and Resource Descriptor Pages tables (read-only, sortable, filterable)
- Replace single-line `StringListEditor` with a new **`StringListTextAreaEditor`** for synonyms editing — uses an auto-resizing textarea (5 rows default) to make it easier to read and edit entries with many synonyms (e.g., SNOMED)

## Test plan
- [ ] Navigate to `#/resourcedescriptors` — verify Date Updated and Updated By columns appear
- [ ] Navigate to `#/resourcedescriptorpages` — verify Date Updated and Updated By columns appear
- [ ] Edit a Resource Descriptor row — verify synonyms field shows a multi-line textarea instead of a single-line input
- [ ] Check SNOMED prefix synonyms — verify all synonyms are readable without excessive horizontal scrolling
- [ ] Verify the textarea auto-resizes as content grows

🤖 Generated with [Claude Code](https://claude.com/claude-code)