### PR TITLE
SCRUM-6006 add gene systematic name to gene, allele, and variant search documents

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
@@ -472,6 +472,29 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 			}
 		}
 
+		// Gene systematic name per allele (via allele -> gene association)
+		String geneSystematicNameQueryString = """
+			SELECT DISTINCT aga.alleleassociationsubject_id AS allele_id, sa.displaytext AS systematic_name
+			FROM allelegeneassociation aga
+			JOIN vocabularyterm v ON v.id = aga.relation_id AND v.name = 'is_allele_of'
+			JOIN slotannotation sa ON sa.singlegene_id = aga.allelegeneassociationobject_id
+				AND sa.slotannotationtype = 'GeneSystematicNameSlotAnnotation'
+			WHERE aga.alleleassociationsubject_id IN :alleleIds
+			AND aga.internal = false AND aga.obsolete = false
+			""";
+		Query geneSystematicNameQuery = entityManager.createNativeQuery(geneSystematicNameQueryString);
+		geneSystematicNameQuery.setParameter("alleleIds", alleleIds);
+		List<Object[]> geneSystematicNameResults = geneSystematicNameQuery.getResultList();
+
+		Map<Long, String> alleleGeneSystematicNameMap = new HashMap<>();
+		for (Object[] row : geneSystematicNameResults) {
+			Long alleleId = (Long) row[0];
+			String systematicName = (String) row[1];
+			if (systematicName != null) {
+				alleleGeneSystematicNameMap.put(alleleId, systematicName);
+			}
+		}
+
 		// Gene cross references per allele (via allele -> gene association)
 		String geneCrossRefsQueryString = """
 			SELECT DISTINCT aga.alleleassociationsubject_id AS allele_id, cr.referencedcurie AS xref
@@ -1202,6 +1225,7 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 			doc.setConstructKnockdownComponents(alleleConstructKnockdownComponentsMap.get(allele.getId()));
 			doc.setGeneCrossReferences(alleleGeneCrossRefsMap.get(allele.getId()));
 			doc.setGeneSynonyms(alleleGeneSynonymsMap.get(allele.getId()));
+			doc.setGeneSystematicName(alleleGeneSystematicNameMap.get(allele.getId()));
 			doc.setPhenotypeStatements(allelePhenotypeStatementsMap.get(allele.getId()));
 			docs.add(doc);
 		}

--- a/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/GeneDAO.java
@@ -255,6 +255,27 @@ public class GeneDAO extends BaseSQLDAO<Gene> {
 			""", geneIds);
 	}
 
+	public Map<Long, String> getGeneSystematicNames(List<Long> geneIds) {
+		if (CollectionUtils.isEmpty(geneIds)) {
+			return new HashMap<>();
+		}
+		Query query = entityManager.createNativeQuery("""
+			SELECT singlegene_id, displaytext FROM slotannotation
+			WHERE slotannotationtype = 'GeneSystematicNameSlotAnnotation' AND singlegene_id IN :geneIds
+			""");
+		query.setParameter("geneIds", geneIds);
+		List<Object[]> rows = query.getResultList();
+		Map<Long, String> result = new HashMap<>();
+		for (Object[] row : rows) {
+			Long id = ((Number) row[0]).longValue();
+			String name = (String) row[1];
+			if (name != null) {
+				result.put(id, name);
+			}
+		}
+		return result;
+	}
+
 	public Map<Long, Set<String>> getGeneSecondaryIds(List<Long> geneIds) {
 		if (CollectionUtils.isEmpty(geneIds)) {
 			return new HashMap<>();

--- a/src/main/java/org/alliancegenome/curation_api/model/document/builders/VariantDocumentBuilder.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/builders/VariantDocumentBuilder.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.alliancegenome.curation_api.model.document.es.VariantSummaryDocument;
 import org.alliancegenome.curation_api.model.entities.Allele;
+import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.Variant;
 
 import lombok.extern.slf4j.Slf4j;
@@ -25,10 +26,16 @@ public class VariantDocumentBuilder {
 						Allele alleleAssociationSubject = alleleVariantAssociation.getAlleleAssociationSubject();
 						dto.setAllele(alleleAssociationSubject);
 						HashSet<String> geneIds = new HashSet<>();
+						HashSet<String> geneSystematicNames = new HashSet<>();
 						alleleAssociationSubject.getAlleleGeneAssociations().forEach(association -> {
-							geneIds.add(association.getAlleleGeneAssociationObject().getPrimaryExternalId());
+							Gene gene = association.getAlleleGeneAssociationObject();
+							geneIds.add(gene.getPrimaryExternalId());
+							if (gene.getGeneSystematicName() != null && gene.getGeneSystematicName().getDisplayText() != null) {
+								geneSystematicNames.add(gene.getGeneSystematicName().getDisplayText());
+							}
 						});
 						dto.setGeneIds(geneIds);
+						dto.setGeneSystematicNames(geneSystematicNames);
 						dtos.add(dto);
 					});
 					return dtos;

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/AlleleSummaryDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/AlleleSummaryDocument.java
@@ -36,6 +36,7 @@ public class AlleleSummaryDocument extends AVSParentDocument {
 	private Set<String> constructKnockdownComponents;
 	private Set<String> geneCrossReferences;
 	private Set<String> geneSynonyms;
+	private String geneSystematicName;
 	private Set<String> phenotypeStatements;
 
 	public void setAlleleOfGene(Gene alleleOfGene) {
@@ -56,6 +57,7 @@ public class AlleleSummaryDocument extends AVSParentDocument {
 		constructKnockdownComponents = null;
 		geneCrossReferences = null;
 		geneSynonyms = null;
+		geneSystematicName = null;
 		phenotypeStatements = null;
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneSearchResultDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneSearchResultDocument.java
@@ -26,6 +26,7 @@ public class GeneSearchResultDocument extends ESDocument {
 	private String symbol;
 	private String soTermId;
 	private String soTermName;
+	private String systematicName;
 	
 	private Set<String> chromosomes;
 	private Set<String> crossReferences;

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/VariantSummaryDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/VariantSummaryDocument.java
@@ -24,4 +24,5 @@ public class VariantSummaryDocument extends AVSParentDocument {
 	private List<Variant> variantList;
 	private HashSet<String> geneSynonyms;
 	private HashSet<String> geneCrossReferences;
+	private HashSet<String> geneSystematicNames;
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
@@ -368,6 +368,7 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 		CompletableFuture<List<Object[]>> baseInfoFuture = CompletableFuture.supplyAsync(() -> geneDAO.getBaseGeneInfo(geneIds), executor);
 		CompletableFuture<Map<Long, Set<String>>> soAncestorsFuture = CompletableFuture.supplyAsync(() -> geneDAO.getSoTermAncestors(geneIds), executor);
 		CompletableFuture<Map<Long, Set<String>>> synonymsFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneSynonyms(geneIds), executor);
+		CompletableFuture<Map<Long, String>> systematicNamesFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneSystematicNames(geneIds), executor);
 		CompletableFuture<Map<Long, Set<String>>> secondaryIdsFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneSecondaryIds(geneIds), executor);
 		CompletableFuture<Map<Long, Set<String>>> crossRefsFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneCrossReferences(geneIds), executor);
 		CompletableFuture<Map<Long, Set<String>>> chromosomesFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneChromosomes(geneIds), executor);
@@ -385,7 +386,7 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 		CompletableFuture<Map<Long, Set<String>>> modelsFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneModels(geneIds), executor);
 		CompletableFuture<Map<Long, Set<String>>> diseaseAgrSlimFuture = CompletableFuture.supplyAsync(() -> geneDAO.getGeneDiseaseAgrSlim(geneIds), executor);
 
-		CompletableFuture.allOf(baseInfoFuture, soAncestorsFuture, synonymsFuture, secondaryIdsFuture,
+		CompletableFuture.allOf(baseInfoFuture, soAncestorsFuture, synonymsFuture, systematicNamesFuture, secondaryIdsFuture,
 			crossRefsFuture, chromosomesFuture, allelesFuture, phenotypesFuture, directDiseaseFuture,
 			strictOrthoFuture, orthoDiseaseFuture, goFuture, subcellularFuture, anatomicalFuture,
 			anatomicalSlimFuture, whereExpressedFuture, descriptionFuture, modelsFuture, diseaseAgrSlimFuture).join();
@@ -394,6 +395,7 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 		List<Object[]> baseInfoRows = baseInfoFuture.join();
 		Map<Long, Set<String>> soAncestors = soAncestorsFuture.join();
 		Map<Long, Set<String>> synonyms = synonymsFuture.join();
+		Map<Long, String> systematicNames = systematicNamesFuture.join();
 		Map<Long, Set<String>> secondaryIds = secondaryIdsFuture.join();
 		Map<Long, Set<String>> crossRefs = crossRefsFuture.join();
 		Map<Long, Set<String>> chromosomes = chromosomesFuture.join();
@@ -476,6 +478,7 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 				geneSynonyms.add(doc.getSymbol());
 			}
 			doc.setSynonyms(geneSynonyms);
+			doc.setSystematicName(systematicNames.get(id));
 			doc.setSecondaryIds(secondaryIds.getOrDefault(id, new HashSet<>()));
 			doc.setCrossReferences(crossRefs.getOrDefault(id, new HashSet<>()));
 			doc.setChromosomes(chromosomes.getOrDefault(id, new HashSet<>()));


### PR DESCRIPTION
## Summary
Exposes gene systematic name (e.g. WB `W02C12.3`, FB `CG5102`, SGD `YBR160W`) via dedicated fields on the three search/summary documents:

- `GeneSearchResultDocument.systematicName` (String) — populated in `GeneService.buildSearchResultDocuments` via new `GeneDAO.getGeneSystematicNames` batch SQL (mirrors the existing `getGeneSynonyms` pattern).
- `AlleleSummaryDocument.geneSystematicName` (String) — populated in `AlleleDAO` alongside the existing `alleleGeneSynonymsMap` block.
- `VariantSummaryDocument.geneSystematicNames` (Set) — populated in `VariantDocumentBuilder` via entity traversal (variant → alleleVariantAssociations → allele → alleleGeneAssociations → gene → `getGeneSystematicName().getDisplayText()`).

Source: `slotannotation.slotannotationtype = 'GeneSystematicNameSlotAnnotation'` (281,491 rows in alpha; spot-checked the four example systematic names from SCRUM-6006 and they resolve to the expected genes).

Context: in 9.0.0 the curation team split systematic name out of gene synonyms into its own dedicated field. On production these names were indexed as synonyms, so on stage they need a dedicated path into the public search index. This PR is the upstream half — the downstream consumer in `agr_java_software` will bump `agr_curation_api` to the next release and wire the new fields into `AlleleSearchResultDocument` / `VariantSearchResultDocument` / the indexer.

## Test plan
- [ ] `mvn compile` passes (verified locally)
- [ ] Unit/integration tests pass in CI
- [ ] Manual spot check after release: fetch an allele summary for a WB allele of `hlh-30` and confirm `geneSystematicName = "W02C12.3"`
- [ ] Manual spot check: fetch a `GeneSearchResultDocument` for `SGD:S000000364` and confirm `systematicName = "YBR160W"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)