### PR TITLE
SCRUM-6022 Fix multi-autocomplete allowing only one entry after clearing

### DIFF
--- a/src/main/cliapp/src/utils/utils.js
+++ b/src/main/cliapp/src/utils/utils.js
@@ -362,7 +362,7 @@ export function defaultAutocompleteOnChange(rowProps, event, fieldName, setField
 
 export function multipleAutocompleteOnChange(rowProps, event, fieldName, setFieldValue) {
 	if (!event.target.value) {
-		rowProps.editorCallback(null);
+		rowProps.editorCallback([]);
 		setFieldValue([]);
 		return;
 	}
@@ -380,7 +380,9 @@ const isPropValuesEqual = (subject, target, propName) => {
 
 export function getUniqueItemsByProperty(items, propName) {
 	return items.filter(
-		(item, index, array) => index === array.findIndex((foundItem) => isPropValuesEqual(foundItem, item, propName))
+		(item, index, array) =>
+			item[propName] == null ||
+			index === array.findIndex((foundItem) => isPropValuesEqual(foundItem, item, propName))
 	);
 }
 

--- a/src/main/cliapp/src/utils/utils.js
+++ b/src/main/cliapp/src/utils/utils.js
@@ -381,8 +381,7 @@ const isPropValuesEqual = (subject, target, propName) => {
 export function getUniqueItemsByProperty(items, propName) {
 	return items.filter(
 		(item, index, array) =>
-			item[propName] == null ||
-			index === array.findIndex((foundItem) => isPropValuesEqual(foundItem, item, propName))
+			item[propName] == null || index === array.findIndex((foundItem) => isPropValuesEqual(foundItem, item, propName))
 	);
 }
 


### PR DESCRIPTION
## Summary
- Fix `getUniqueItemsByProperty` to skip deduplication when the property (`id`) is `null`/`undefined` — search API results (e.g. literature references) don't have an `id` field, so `undefined === undefined` was treating every item after the first as a duplicate
- Fix `multipleAutocompleteOnChange` to call `editorCallback([])` instead of `editorCallback(null)` when clearing, for type consistency

## Root Cause
The `getUniqueItemsByProperty(items, 'id')` function in `multipleAutocompleteOnChange` filters items by unique `id`. Literature reference search results from the API don't include an `id` property, so all items have `id: undefined`. Since `undefined === undefined` is `true`, every item after the first was filtered out as a "duplicate", limiting the field to one entry.

## Test plan
- [ ] Open Alleles table, edit a row with multiple references
- [ ] Delete all existing references
- [ ] Search and add a reference — verify it appears as a chip
- [ ] Search and add a second reference — verify both chips are present
- [ ] Verify the same works for other multi-autocomplete editors (DA evidence codes, allele mutation types, functional impacts)
- [ ] Verify that actual duplicate prevention still works for entities that have valid `id` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)