### PR TITLE
SCRUM-6050 do not require idPattern when updating Resource Descriptors

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/validation/ResourceDescriptorValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/ResourceDescriptorValidator.java
@@ -53,11 +53,7 @@ public class ResourceDescriptorValidator extends AuditedObjectValidator<Resource
 
 		dbEntity.setSynonyms(uiEntity.getSynonyms());
 
-		if (StringUtils.isBlank(uiEntity.getIdPattern())) {
-			addMessageResponse("idPattern", ValidationConstants.REQUIRED_MESSAGE);
-		} else {
-			dbEntity.setIdPattern(uiEntity.getIdPattern());
-		}
+		dbEntity.setIdPattern(uiEntity.getIdPattern());
 
 		dbEntity.setIdExample(uiEntity.getIdExample());
 


### PR DESCRIPTION
## Summary
- The Resource Descriptor table at `/#/resourcedescriptors` rejected edits on rows with no `idPattern` (4 existing rows). `ResourceDescriptorValidator.validateResourceDescriptor` was flagging `idPattern` as required, while the entity column has no NOT NULL constraint and the bulk-load DTO validator already treats it as optional.
- Drop the required check; assign `idPattern` unconditionally, matching how `idExample` and `synonyms` are already handled in the same method. `prefix`, `name`, and `defaultUrlTemplate` remain required.

## Test plan
- [ ] On alpha after deploy: edit one of the 4 existing rows that lacks an ID Pattern, save without filling it in — should succeed.
- [ ] Edit a row and clear an existing ID Pattern — should also save.
- [ ] Confirm `prefix`, `name`, and `defaultUrlTemplate` still produce required-field errors when blanked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)