### PR TITLE
SCRUM-6051 Remove duplicate GCRP cross-references from gene cross-ref…

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/AlleleSummaryDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/AlleleSummaryDocument.java
@@ -59,6 +59,63 @@ public class AlleleSummaryDocument extends AVSParentDocument {
 		geneSynonyms = null;
 		geneSystematicName = null;
 		phenotypeStatements = null;
+		dereferenceGeneCrossReferences();
+		dereferenceVariantAssociationSubjectReferences();
+	}
+
+	private void dereferenceVariantAssociationSubjectReferences() {
+		if (variantList == null) {
+			return;
+		}
+		for (Variant variant : variantList) {
+			if (variant == null) {
+				continue;
+			}
+			variant.setReferences(null);
+			if (variant.getCuratedVariantGenomicLocations() == null) {
+				continue;
+			}
+			variant.getCuratedVariantGenomicLocations().forEach(cvgla -> {
+				if (cvgla == null) {
+					return;
+				}
+				Variant subject = cvgla.getVariantAssociationSubject();
+				if (subject != null) {
+					subject.setReferences(null);
+				}
+			});
+		}
+	}
+
+	private void dereferenceGeneCrossReferences() {
+		if (alleleOfGene != null) {
+			alleleOfGene.setCrossReferences(null);
+		}
+		if (variantList == null) {
+			return;
+		}
+		for (Variant variant : variantList) {
+			if (variant == null || variant.getCuratedVariantGenomicLocations() == null) {
+				continue;
+			}
+			variant.getCuratedVariantGenomicLocations().forEach(cvgla -> {
+				if (cvgla == null || cvgla.getPredictedVariantConsequences() == null) {
+					return;
+				}
+				cvgla.getPredictedVariantConsequences().forEach(pvc -> {
+					if (pvc == null || pvc.getVariantTranscript() == null
+							|| pvc.getVariantTranscript().getTranscriptGeneAssociations() == null) {
+						return;
+					}
+					pvc.getVariantTranscript().getTranscriptGeneAssociations().forEach(tga -> {
+						Gene gene = tga.getTranscriptGeneAssociationObject();
+						if (gene != null) {
+							gene.setCrossReferences(null);
+						}
+					});
+				});
+			});
+		}
 	}
 }
 

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/GeneValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/GeneValidator.java
@@ -26,6 +26,7 @@ import org.alliancegenome.curation_api.services.validation.dto.slotAnnotations.G
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
 
+import io.quarkus.logging.Log;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 
@@ -93,7 +94,19 @@ public class GeneValidator extends GenomicEntityValidator<Gene> {
 
 		if (gcrpCrossReference != null && CollectionUtils.isNotEmpty(dbEntity.getCrossReferences())) {
 			String gcrpUniqueId = crossReferenceService.getCrossReferenceUniqueId(gcrpCrossReference);
-			dbEntity.getCrossReferences().removeIf(xref -> gcrpUniqueId.equals(crossReferenceService.getCrossReferenceUniqueId(xref)));
+			List<CrossReference> xrefList = new ArrayList<>();
+			for (CrossReference xref : dbEntity.getCrossReferences()) {
+				if (gcrpUniqueId.equals(crossReferenceService.getCrossReferenceUniqueId(xref))) {
+					try {
+						crossReferenceService.deleteById(xref.getId());
+					} catch (Exception e) {
+						Log.error("Unable to delete CrossReference " + e.getMessage());
+					}
+				} else {
+					xrefList.add(xref);
+				}
+			}
+			dbEntity.setCrossReferences(xrefList);
 		}
 
 		response.convertErrorMessagesToMap();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/GeneValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/GeneValidator.java
@@ -106,7 +106,8 @@ public class GeneValidator extends GenomicEntityValidator<Gene> {
 					xrefList.add(xref);
 				}
 			}
-			dbEntity.setCrossReferences(xrefList);
+			dbEntity.getCrossReferences().clear();
+			dbEntity.getCrossReferences().addAll(xrefList);
 		}
 
 		response.convertErrorMessagesToMap();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/GeneValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/GeneValidator.java
@@ -91,6 +91,11 @@ public class GeneValidator extends GenomicEntityValidator<Gene> {
 		CrossReference gcrpCrossReference = validateGcrpCrossReference(uiEntity.getGcrpCrossReference(), dbEntity.getGcrpCrossReference());
 		dbEntity.setGcrpCrossReference(gcrpCrossReference);
 
+		if (gcrpCrossReference != null && CollectionUtils.isNotEmpty(dbEntity.getCrossReferences())) {
+			String gcrpUniqueId = crossReferenceService.getCrossReferenceUniqueId(gcrpCrossReference);
+			dbEntity.getCrossReferences().removeIf(xref -> gcrpUniqueId.equals(crossReferenceService.getCrossReferenceUniqueId(xref)));
+		}
+
 		response.convertErrorMessagesToMap();
 
 		if (response.hasErrors()) {

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDTOValidator.java
@@ -34,6 +34,7 @@ import org.alliancegenome.curation_api.services.validation.dto.slotAnnotations.G
 import org.alliancegenome.curation_api.services.validation.dto.slotAnnotations.GeneSystematicNameSlotAnnotationDTOValidator;
 import org.apache.commons.collections.CollectionUtils;
 
+import io.quarkus.logging.Log;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -110,7 +111,19 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 
 		if (gcrpCrossReference != null && CollectionUtils.isNotEmpty(gene.getCrossReferences())) {
 			String gcrpUniqueId = crossReferenceService.getCrossReferenceUniqueId(gcrpCrossReference);
-			gene.getCrossReferences().removeIf(xref -> gcrpUniqueId.equals(crossReferenceService.getCrossReferenceUniqueId(xref)));
+			List<CrossReference> xrefList = new ArrayList<>();
+			for (CrossReference xref : gene.getCrossReferences()) {
+				if (gcrpUniqueId.equals(crossReferenceService.getCrossReferenceUniqueId(xref))) {
+					try {
+						crossReferenceService.deleteById(xref.getId());
+					} catch (Exception e) {
+						Log.error("Unable to delete CrossReference " + e.getMessage());
+					}
+				} else {
+					xrefList.add(xref);
+				}
+			}
+			gene.setCrossReferences(xrefList);
 		}
 
 		response.convertWarningMessagesToMap();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDTOValidator.java
@@ -123,7 +123,8 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 					xrefList.add(xref);
 				}
 			}
-			gene.setCrossReferences(xrefList);
+			gene.getCrossReferences().clear();
+			gene.getCrossReferences().addAll(xrefList);
 		}
 
 		response.convertWarningMessagesToMap();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDTOValidator.java
@@ -105,7 +105,12 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 			}
 		}
 		gene.setGcrpCrossReference(gcrpCrossReference);
-		
+
+		if (gcrpCrossReference != null && CollectionUtils.isNotEmpty(gene.getCrossReferences())) {
+			String gcrpUniqueId = crossReferenceService.getCrossReferenceUniqueId(gcrpCrossReference);
+			gene.getCrossReferences().removeIf(xref -> gcrpUniqueId.equals(crossReferenceService.getCrossReferenceUniqueId(xref)));
+		}
+
 		response.convertWarningMessagesToMap();
 		response.convertErrorMessagesToMap();
 

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDTOValidator.java
@@ -23,6 +23,7 @@ import org.alliancegenome.curation_api.model.ingest.dto.GeneDTO;
 import org.alliancegenome.curation_api.model.ingest.dto.slotAnnotions.NameSlotAnnotationDTO;
 import org.alliancegenome.curation_api.model.ingest.dto.slotAnnotions.SecondaryIdSlotAnnotationDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
+import org.alliancegenome.curation_api.services.CrossReferenceService;
 import org.alliancegenome.curation_api.services.helpers.SlotAnnotationIdentityHelper;
 import org.alliancegenome.curation_api.services.ontology.SoTermService;
 import org.alliancegenome.curation_api.services.validation.dto.base.GenomicEntityDTOValidator;
@@ -47,6 +48,7 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 	@Inject GeneSynonymSlotAnnotationDTOValidator geneSynonymDtoValidator;
 	@Inject GeneSecondaryIdSlotAnnotationDTOValidator geneSecondaryIdDtoValidator;
 	@Inject CrossReferenceDTOValidator crossReferenceDtoValidator;
+	@Inject CrossReferenceService crossReferenceService;
 	@Inject SlotAnnotationIdentityHelper identityHelper;
 	@Inject SoTermService soTermService;
 


### PR DESCRIPTION
…erence list

Filter out any cross-reference from the general crossReferences list that matches the dedicated gcrpCrossReference during gene validation, preventing duplicate GCRP IDs from appearing in the cross-reference section of gene pages.