### PR TITLE
SCRUM-6042 strip transcriptGeneAssociations crossReferences in Varian…

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/VariantSummaryDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/VariantSummaryDocument.java
@@ -3,6 +3,7 @@ package org.alliancegenome.curation_api.model.document.es;
 import java.util.HashSet;
 import java.util.List;
 
+import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.Variant;
 import org.alliancegenome.curation_api.view.CurationView;
 
@@ -25,4 +26,39 @@ public class VariantSummaryDocument extends AVSParentDocument {
 	private HashSet<String> geneSynonyms;
 	private HashSet<String> geneCrossReferences;
 	private HashSet<String> geneSystematicNames;
+
+	public void removeTransportFields() {
+		geneSynonyms = null;
+		geneCrossReferences = null;
+		geneSystematicNames = null;
+		dereferenceGeneCrossReferences();
+	}
+
+	private void dereferenceGeneCrossReferences() {
+		if (variantList == null) {
+			return;
+		}
+		for (Variant variant : variantList) {
+			if (variant == null || variant.getCuratedVariantGenomicLocations() == null) {
+				continue;
+			}
+			variant.getCuratedVariantGenomicLocations().forEach(cvgla -> {
+				if (cvgla == null || cvgla.getPredictedVariantConsequences() == null) {
+					return;
+				}
+				cvgla.getPredictedVariantConsequences().forEach(pvc -> {
+					if (pvc == null || pvc.getVariantTranscript() == null
+							|| pvc.getVariantTranscript().getTranscriptGeneAssociations() == null) {
+						return;
+					}
+					pvc.getVariantTranscript().getTranscriptGeneAssociations().forEach(tga -> {
+						Gene gene = tga.getTranscriptGeneAssociationObject();
+						if (gene != null) {
+							gene.setCrossReferences(null);
+						}
+					});
+				});
+			});
+		}
+	}
 }


### PR DESCRIPTION
…tSummaryDocument.removeTransportFields()

Mirrors the AlleleSummaryDocument pattern: nulls geneSynonyms/geneCrossReferences/geneSystematicNames transport fields and walks variantList graph to dereference gene crossReferences under each transcriptGeneAssociation.

Indexer call sites still need wiring in agr_java_software.