### PR TITLE
SCRUM-5126 add OntologyTermClosure bulk endpoints

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/controllers/document/OntologyTermClosureDocumentController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/document/OntologyTermClosureDocumentController.java
@@ -1,0 +1,39 @@
+package org.alliancegenome.curation_api.controllers.document;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.alliancegenome.curation_api.interfaces.document.OntologyTermClosureDocumentInterface;
+import org.alliancegenome.curation_api.model.entities.ontology.OntologyTermClosure;
+import org.alliancegenome.curation_api.response.SearchResponse;
+import org.alliancegenome.curation_api.services.ontology.OntologyTermClosureService;
+
+import jakarta.inject.Inject;
+
+public class OntologyTermClosureDocumentController implements OntologyTermClosureDocumentInterface {
+
+	@Inject
+	OntologyTermClosureService ontologyTermClosureService;
+
+	@Override
+	public SearchResponse<Long> getAllIds(String ontologyTermType, String relationTypes) {
+		Set<String> parsedRelationTypes = relationTypes == null || relationTypes.isBlank()
+			? new HashSet<>()
+			: Arrays.stream(relationTypes.split(",")).map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toCollection(HashSet::new));
+		List<Long> ids = ontologyTermClosureService.getAllIds(ontologyTermType, parsedRelationTypes);
+		SearchResponse<Long> response = new SearchResponse<>(ids);
+		response.setTotalResults((long) ids.size());
+		return response;
+	}
+
+	@Override
+	public SearchResponse<OntologyTermClosure> findByIds(List<Long> ids) {
+		List<OntologyTermClosure> entities = ontologyTermClosureService.findByIds(ids);
+		SearchResponse<OntologyTermClosure> response = new SearchResponse<>(entities);
+		response.setTotalResults((long) entities.size());
+		return response;
+	}
+}

--- a/src/main/java/org/alliancegenome/curation_api/dao/ontology/OntologyTermClosureDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ontology/OntologyTermClosureDAO.java
@@ -1,15 +1,74 @@
 package org.alliancegenome.curation_api.dao.ontology;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
+import org.alliancegenome.curation_api.model.entities.ontology.OntologyTerm;
 import org.alliancegenome.curation_api.model.entities.ontology.OntologyTermClosure;
+import org.apache.commons.collections.CollectionUtils;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.BadRequestException;
 
 @ApplicationScoped
 public class OntologyTermClosureDAO extends BaseSQLDAO<OntologyTermClosure> {
-	
+
 	protected OntologyTermClosureDAO() {
 		super(OntologyTermClosure.class);
 	}
-	
+
+	// Returns closure-row IDs for the given ontology term type whose closureTypes equal the requested set
+	// and whose ancestor (closureObject) is non-obsolete. Both ends of the row must be of the requested type.
+	// closureTypes is JSONB; equality is filtered in-memory after fetching candidate rows for the type.
+	public List<Long> getAllIds(String ontologyTermType, Set<String> relationTypes) {
+		Class<?> termClass = entityManager.getMetamodel().getEntities().stream()
+			.filter(t -> OntologyTerm.class.isAssignableFrom(t.getJavaType()))
+			.filter(t -> t.getJavaType().getSimpleName().equals(ontologyTermType))
+			.map(t -> t.getJavaType())
+			.findFirst()
+			.orElseThrow(() -> new BadRequestException("Unknown ontology term type: " + ontologyTermType));
+
+		String jpql = """
+				SELECT c.id, c.closureTypes FROM OntologyTermClosure c
+				JOIN c.closureSubject sub
+				JOIN c.closureObject obj
+				WHERE TYPE(sub) = :termType
+				AND TYPE(obj) = :termType
+				AND (obj.obsolete = false OR obj.obsolete IS NULL)
+				""";
+
+		List<Object[]> rows = entityManager
+			.createQuery(jpql, Object[].class)
+			.setParameter("termType", termClass)
+			.getResultList();
+
+		List<Long> ids = new ArrayList<>(rows.size());
+		for (Object[] row : rows) {
+			@SuppressWarnings("unchecked")
+			Set<String> rowTypes = (Set<String>) row[1];
+			if (rowTypes != null && rowTypes.equals(relationTypes)) {
+				ids.add((Long) row[0]);
+			}
+		}
+		return ids;
+	}
+
+	public List<OntologyTermClosure> findByIds(List<Long> ids) {
+		if (CollectionUtils.isEmpty(ids)) {
+			return new ArrayList<>();
+		}
+		String jpql = """
+				SELECT c FROM OntologyTermClosure c
+				JOIN FETCH c.closureSubject
+				JOIN FETCH c.closureObject
+				WHERE c.id IN :ids
+				""";
+		return entityManager
+			.createQuery(jpql, OntologyTermClosure.class)
+			.setParameter("ids", ids)
+			.getResultList();
+	}
+
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/document/OntologyTermClosureDocumentInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/document/OntologyTermClosureDocumentInterface.java
@@ -1,0 +1,37 @@
+package org.alliancegenome.curation_api.interfaces.document;
+
+import java.util.List;
+
+import org.alliancegenome.curation_api.model.entities.ontology.OntologyTermClosure;
+import org.alliancegenome.curation_api.response.SearchResponse;
+import org.alliancegenome.curation_api.view.CurationView;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/ontologytermclosure/document")
+@Tag(name = "Public Document Endpoints")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface OntologyTermClosureDocumentInterface {
+
+	@POST
+	@Path("/ids")
+	SearchResponse<Long> getAllIds(
+		@Parameter(description = "Ontology term type discriminator on both ends of the closure (e.g. DOTerm)") @QueryParam("ontologyTermType") String ontologyTermType,
+		@Parameter(description = "Comma-separated relation types the closure must equal (e.g. is_a,part_of)") @QueryParam("relationTypes") String relationTypes);
+
+	@POST
+	@Path("/byids")
+	@JsonView(CurationView.ForPublic.class)
+	SearchResponse<OntologyTermClosure> findByIds(@RequestBody List<Long> ids);
+}

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/document/OntologyTermClosureDocumentInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/document/OntologyTermClosureDocumentInterface.java
@@ -32,6 +32,6 @@ public interface OntologyTermClosureDocumentInterface {
 
 	@POST
 	@Path("/byids")
-	@JsonView(CurationView.ForPublic.class)
+	@JsonView(CurationView.OntologyTermClosureView.class)
 	SearchResponse<OntologyTermClosure> findByIds(@RequestBody List<Long> ids);
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/base/CurieObject.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/base/CurieObject.java
@@ -28,7 +28,7 @@ public class CurieObject extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "curie_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.DiseaseSummaryDocument.class, CurationView.ModelDocument.class, CurationView.GeneExpressionDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.DiseaseSummaryDocument.class, CurationView.ModelDocument.class, CurationView.GeneExpressionDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.OntologyTermClosureView.class })
 	@Column(nullable = false)
 	protected String curie;
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTermClosure.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTermClosure.java
@@ -31,18 +31,16 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 	@Index(name = "ontologyclosure_updatedby_index", columnList = "updatedBy_id") })
 public class OntologyTermClosure extends AuditedObject {
 
-	@JsonView(CurationView.ForPublic.class)
 	private Integer distance;
 
-	@JsonView(CurationView.ForPublic.class)
 	@JdbcTypeCode(SqlTypes.JSON)
 	private Set<String> closureTypes = new HashSet<>();
 
-	@JsonView(CurationView.ForPublic.class)
+	@JsonView(CurationView.OntologyTermClosureView.class)
 	@ManyToOne
 	private OntologyTerm closureSubject;
 
-	@JsonView(CurationView.ForPublic.class)
+	@JsonView(CurationView.OntologyTermClosureView.class)
 	@ManyToOne
 	private OntologyTerm closureObject;
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTermClosure.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTermClosure.java
@@ -5,8 +5,11 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
+import org.alliancegenome.curation_api.view.CurationView;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
+
+import com.fasterxml.jackson.annotation.JsonView;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
@@ -28,14 +31,18 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 	@Index(name = "ontologyclosure_updatedby_index", columnList = "updatedBy_id") })
 public class OntologyTermClosure extends AuditedObject {
 
+	@JsonView(CurationView.ForPublic.class)
 	private Integer distance;
 
+	@JsonView(CurationView.ForPublic.class)
 	@JdbcTypeCode(SqlTypes.JSON)
 	private Set<String> closureTypes = new HashSet<>();
 
+	@JsonView(CurationView.ForPublic.class)
 	@ManyToOne
 	private OntologyTerm closureSubject;
 
+	@JsonView(CurationView.ForPublic.class)
 	@ManyToOne
 	private OntologyTerm closureObject;
 

--- a/src/main/java/org/alliancegenome/curation_api/response/SearchResponse.java
+++ b/src/main/java/org/alliancegenome/curation_api/response/SearchResponse.java
@@ -32,7 +32,8 @@ import lombok.Data;
 	CurationView.SequenceSummaryDocument.class,
 	CurationView.HTPDatasetSearchResultDocument.class,
 	CurationView.GeneExpressionDocument.class,
-	CurationView.TransgenicAllelesDocument.class
+	CurationView.TransgenicAllelesDocument.class,
+	CurationView.OntologyTermClosureView.class
 })
 public class SearchResponse<E> extends APIResponse {
 

--- a/src/main/java/org/alliancegenome/curation_api/services/ontology/OntologyTermClosureService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ontology/OntologyTermClosureService.java
@@ -1,5 +1,8 @@
 package org.alliancegenome.curation_api.services.ontology;
 
+import java.util.List;
+import java.util.Set;
+
 import org.alliancegenome.curation_api.dao.ontology.OntologyTermClosureDAO;
 import org.alliancegenome.curation_api.model.entities.ontology.OntologyTermClosure;
 import org.alliancegenome.curation_api.services.base.BaseEntityCrudService;
@@ -18,6 +21,14 @@ public class OntologyTermClosureService extends BaseEntityCrudService<OntologyTe
 	@PostConstruct
 	protected void init() {
 		setSQLDao(ontologyTermClosureDAO);
+	}
+
+	public List<Long> getAllIds(String ontologyTermType, Set<String> relationTypes) {
+		return ontologyTermClosureDAO.getAllIds(ontologyTermType, relationTypes);
+	}
+
+	public List<OntologyTermClosure> findByIds(List<Long> ids) {
+		return ontologyTermClosureDAO.findByIds(ids);
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/view/CurationView.java
+++ b/src/main/java/org/alliancegenome/curation_api/view/CurationView.java
@@ -10,6 +10,9 @@ public class CurationView {
 	public static class FieldsAndLists extends FieldsOnly {
 	}
 
+	public static class OntologyTermClosureView {
+	}
+
 	public static class ConditionRelationView extends FieldsOnly {
 	}
 


### PR DESCRIPTION
Add /ontologytermclosure/document/ids and /byids following the existing indexer document-interface pattern. getAllIds returns closure-row IDs filtered by ontology term type, relation types, and non-obsolete ancestor; findByIds resolves batches under the ForPublic view.

Tag OntologyTermClosure fields with @JsonView(ForPublic.class) so they serialize under the new endpoint. Enables retiring the last Neo4j-backed closure call in the disease annotation indexer.