### PR TITLE
 SCRUM-6039 remove idFields from Vocabulary Term Sets table

### DIFF
--- a/src/main/cliapp/src/containers/vocabularyTermSetPage/VocabularyTermSetTable.jsx
+++ b/src/main/cliapp/src/containers/vocabularyTermSetPage/VocabularyTermSetTable.jsx
@@ -163,7 +163,6 @@ export const VocabularyTermSetTable = () => {
 				setTableState={setTableState}
 				columns={columns}
 				isEditable={true}
-				idFields={['vocabularyTermSetVocabulary', 'memberTerms']}
 				mutation={mutation}
 				isInEditMode={isInEditMode}
 				setIsInEditMode={setIsInEditMode}


### PR DESCRIPTION
idFields stripped memberTerms (a List) down to {id: ...}, which the backend couldn't deserialize as a list — every save failed with "Not able to deserialize data provided". Same fix as SCRUM-6023.