### PR TITLE
Release/v0.48.18 — SCRUM-6020 + SCRUM-6007 FMS Expression/VariantsAlleles fixes

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/AlleleSummaryDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/AlleleSummaryDocument.java
@@ -71,7 +71,6 @@ public class AlleleSummaryDocument extends AVSParentDocument {
 			if (variant == null) {
 				continue;
 			}
-			variant.setReferences(null);
 			if (variant.getCuratedVariantGenomicLocations() == null) {
 				continue;
 			}

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/AnatomicalSite.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/AnatomicalSite.java
@@ -48,19 +48,19 @@ public class AnatomicalSite extends AuditedObject {
 	@IndexedEmbedded(includePaths = {"name", "name_keyword"})
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class})
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class})
 	private AnatomicalTerm anatomicalStructure;
 
 	@IndexedEmbedded(includePaths = {"name", "name_keyword"})
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class})
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class})
 	private AnatomicalTerm anatomicalSubstructure;
 
 	@IndexedEmbedded(includePaths = {"name", "name_keyword"})
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class})
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class})
 	private GOTerm cellularComponentTerm;
 
 	//celullar compoent ribbon -- slim
@@ -97,7 +97,7 @@ public class AnatomicalSite extends AuditedObject {
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "anatomicalstructurequalifiers_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
 	@ManyToMany
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class})
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class})
 	@JoinTable(
 		name = "anatomicalsite_anatomicalstructurequalifiers",
 		indexes = {
@@ -109,7 +109,7 @@ public class AnatomicalSite extends AuditedObject {
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "anatomicalsubstructurequalifiers_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
 	@ManyToMany
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class})
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class})
 	@JoinTable(
 		name = "anatomicalsite_anatomicalsubstructurequalifiers",
 		indexes = {
@@ -121,7 +121,7 @@ public class AnatomicalSite extends AuditedObject {
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "cellularcomponentqualifiers_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
 	@ManyToMany
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class})
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class})
 	@JoinTable(
 		name = "anatomicalsite_cellularcomponentqualifiers",
 		indexes = {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ExpressionPattern.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ExpressionPattern.java
@@ -39,6 +39,6 @@ public class ExpressionPattern extends AuditedObject {
 
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class })
 	private AnatomicalSite whereExpressed;
 }


### PR DESCRIPTION
## Summary
- **SCRUM-6020**: keep `variant.references` on `AlleleSummaryDocument` so the FMS VARIANT-ALLELE generator can populate the `VariantInformationReference` column
- **SCRUM-6007**: expose `ExpressionPattern.whereExpressed` on `CurationView.GeneExpressionDocument` so the FMS Expression generator can populate the 12 currently-blank anatomy / sub-structure / cellular-component columns

## Context

### SCRUM-6020
`AlleleSummaryDocument.removeTransportFields()` was nulling the top-level `variant.references` on every variant in `variantList[]` before the doc reached ES. The agr_file_generator VARIANT-ALLELE TSV/JSON outputs need those references to fill the `VariantInformationReference` column (currently a known gap). Removing the single `variant.setReferences(null)` line lets references serialize through Jackson as part of the indexed `allele_summary` doc. The redundant subject-level dereference (`subject.setReferences(null)`) inside `curatedVariantGenomicLocations[]` is left in place to avoid duplicate data.

### SCRUM-6007
`ExpressionPattern.whereExpressed` was only on `CurationView.FieldsOnly` / `ForPublic`, so the entire `whereExpressed` subtree was dropped before the `gene_expression_annotation` site_index doc was serialized. As a result the agr_file_generator Expression TSV had 12 blank columns (`CellularComponent*`, `SubStructure*`, `AnatomyTerm*` and their qualifier pairs). This adds `CurationView.GeneExpressionDocument` to:
- `ExpressionPattern.whereExpressed`
- `AnatomicalSite.{anatomicalStructure, anatomicalSubstructure, cellularComponentTerm, anatomicalStructureQualifiers, anatomicalSubstructureQualifiers, cellularComponentQualifiers}`

`OntologyTerm.curie` and `OntologyTerm.name` are already on the `GeneExpressionDocument` view, so the leaf fields the file generator needs come along for free. No changes to `GeneExpressionDocumentBuilder` — its `whereExpressed` traversal works on the in-memory entity (uberon / GO ribbon term collections), not on the serialized JsonView.

## Test plan
- [ ] Build passes
- [ ] After deploy + reindex, verify `allele_summary` docs in ES contain `variantList[*].references[*].curie` (or equivalent)
- [ ] After deploy + reindex, verify `gene_expression_annotation` docs in ES contain `geneExpressionAnnotation.expressionPattern.whereExpressed.{anatomicalStructure, anatomicalSubstructure, cellularComponentTerm}.{curie, name}` and the three `*Qualifiers` lists where present
- [ ] Run agr_file_generator VariantsAlleles and confirm `VariantInformationReference` column populates for FB / MGI / WB / ZFIN
- [ ] Run agr_file_generator Expression and confirm the 12 anatomy / sub-structure / cellular-component columns populate