### PR TITLE
SCRUM-6053 fix crossreference orphan leaks

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/base/BaseSQLDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/base/BaseSQLDAO.java
@@ -119,13 +119,21 @@ public class BaseSQLDAO<E extends AuditedObject> extends BaseEntityDAO<E> {
 
 	@Transactional
 	public int removeByIds(Collection<Long> ids) {
+		// SCRUM-6053: per-entity remove instead of JPQL bulk DELETE so cascade
+		// and orphanRemoval fire on @OneToMany child collections (esp. crossReferences).
+		// JPQL bulk DELETE bypasses JPA lifecycle (JPA spec section 4.10),
 		if (ids == null || ids.isEmpty()) {
 			return 0;
 		}
-		return entityManager
-			.createQuery("DELETE FROM " + myClass.getSimpleName() + " e WHERE e.id IN :ids")
-			.setParameter("ids", ids)
-			.executeUpdate();
+		int removed = 0;
+		for (Long id : ids) {
+			E entity = entityManager.find(myClass, id);
+			if (entity != null) {
+				entityManager.remove(entity);
+				removed++;
+			}
+		}
+		return removed;
 	}
 
 	public E find(Long id) {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ExternalDataBaseEntity.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ExternalDataBaseEntity.java
@@ -7,8 +7,6 @@ import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
 import org.alliancegenome.curation_api.model.entities.base.CurieObject;
 import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.search.engine.backend.types.Aggregable;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.Sortable;
@@ -20,12 +18,14 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordFie
 
 import com.fasterxml.jackson.annotation.JsonView;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -49,14 +49,13 @@ public class ExternalDataBaseEntity extends CurieObject {
 
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
-	@OneToOne
+	@OneToOne(cascade = CascadeType.ALL)
 	@JsonView({ CurationView.FieldsOnly.class })
 	private CrossReference preferredCrossReference;
 
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
-	@ManyToMany
-	@OnDelete(action = OnDeleteAction.CASCADE)
+	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
 	@JoinTable(indexes = {
 		@Index(columnList = "externaldatabaseentity_id", name = "externaldbentity_crossreference_externaldbentity_index"),
 		@Index(columnList = "crossreferences_id", name = "externaldbentity_crossreference_crossreferences_index")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ExternalDataBaseEntity.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ExternalDataBaseEntity.java
@@ -49,13 +49,13 @@ public class ExternalDataBaseEntity extends CurieObject {
 
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
-	@OneToOne(cascade = CascadeType.ALL)
+	@OneToOne(cascade = CascadeType.MERGE)
 	@JsonView({ CurationView.FieldsOnly.class })
 	private CrossReference preferredCrossReference;
 
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
-	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(cascade = CascadeType.MERGE)
 	@JoinTable(indexes = {
 		@Index(columnList = "externaldatabaseentity_id", name = "externaldbentity_crossreference_externaldbentity_index"),
 		@Index(columnList = "crossreferences_id", name = "externaldbentity_crossreference_crossreferences_index")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Reference.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Reference.java
@@ -22,11 +22,12 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDe
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 import com.fasterxml.jackson.annotation.JsonView;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Transient;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -42,7 +43,7 @@ public class Reference extends InformationContentEntity {
 
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
-	@ManyToMany
+	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
 	@Fetch(FetchMode.SUBSELECT)
 	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class})
 	@JoinTable(

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Reference.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Reference.java
@@ -43,7 +43,7 @@ public class Reference extends InformationContentEntity {
 
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
-	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(cascade = CascadeType.MERGE, orphanRemoval = true)
 	@Fetch(FetchMode.SUBSELECT)
 	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class})
 	@JoinTable(

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
@@ -110,7 +110,7 @@ public class OntologyTerm extends CurieObject {
 
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
-	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(cascade = CascadeType.MERGE)
 	@JoinTable(indexes = { @Index(columnList = "ontologyterm_id", name = "ontologyterm_crossreference_ontologyterm_index"), @Index(columnList = "crossreferences_id", name = "ontologyterm_crossreference_crossreferences_index") })
 	@JsonView({ CurationView.FieldsAndLists.class })
 	private List<CrossReference> crossReferences;

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.ElementCollection;
@@ -109,8 +110,7 @@ public class OntologyTerm extends CurieObject {
 
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
-	@ManyToMany
-	@org.hibernate.annotations.OnDelete(action = org.hibernate.annotations.OnDeleteAction.CASCADE)
+	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
 	@JoinTable(indexes = { @Index(columnList = "ontologyterm_id", name = "ontologyterm_crossreference_ontologyterm_index"), @Index(columnList = "crossreferences_id", name = "ontologyterm_crossreference_crossreferences_index") })
 	@JsonView({ CurationView.FieldsAndLists.class })
 	private List<CrossReference> crossReferences;

--- a/src/main/resources/db/migration/v0.47.0.3__cleanup_orphan_crossreferences.sql
+++ b/src/main/resources/db/migration/v0.47.0.3__cleanup_orphan_crossreferences.sql
@@ -1,0 +1,90 @@
+-- SCRUM-6053: drain orphaned crossreference rows + remove duplicate stub
+-- References that block the entity-mapping switch to @OneToMany +
+-- orphanRemoval=true.
+--
+-- Two leak mechanisms produced ~2.4M orphans by 2026-05:
+--   1. Per-entity DTO ingest with @ManyToMany mappings lacking orphanRemoval
+--      (Reference / OntologyTerm / ExternalDataBaseEntity).
+--   2. BaseSQLDAO.removeByIds using JPQL bulk DELETE, which bypasses JPA
+--      cascade and orphanRemoval (JPA spec section 4.10).
+-- Both are fixed in this branch's Java changes; this migration cleans the
+-- accumulated debris and prepares the data for the new mappings.
+--
+-- An orphan is a crossreference row not referenced by any of the 23 FK
+-- columns that point at crossreference.id. We additionally require
+-- datecreated IS NULL as a belt-and-suspenders guard: in practice every
+-- curator-authored xref has datecreated populated, while the bulk-load
+-- ingest path that produced the orphans does not set it.
+CREATE TABLE IF NOT EXISTS crossreference_ids_to_delete_scrum6053 (id bigint PRIMARY KEY);
+TRUNCATE crossreference_ids_to_delete_scrum6053;
+
+INSERT INTO crossreference_ids_to_delete_scrum6053 (id)
+SELECT x.id
+FROM crossreference x
+WHERE x.datecreated IS NULL
+  AND NOT EXISTS (SELECT 1 FROM biologicalentity                        t WHERE t.dataprovidercrossreference_id           = x.id)
+  AND NOT EXISTS (SELECT 1 FROM chromosome                              t WHERE t.dataprovidercrossreference_id           = x.id)
+  AND NOT EXISTS (SELECT 1 FROM diseaseannotation                       t WHERE t.dataprovidercrossreference_id           = x.id)
+  AND NOT EXISTS (SELECT 1 FROM diseaseannotation                       t WHERE t.secondarydataprovidercrossreference_id  = x.id)
+  AND NOT EXISTS (SELECT 1 FROM externaldatabaseentity                  t WHERE t.preferredcrossreference_id              = x.id)
+  AND NOT EXISTS (SELECT 1 FROM externaldatabaseentity_crossreference   t WHERE t.crossreferences_id                      = x.id)
+  AND NOT EXISTS (SELECT 1 FROM gene                                    t WHERE t.gcrpcrossreference_id                   = x.id)
+  AND NOT EXISTS (SELECT 1 FROM geneexpressionannotation                t WHERE t.dataprovidercrossreference_id           = x.id)
+  AND NOT EXISTS (SELECT 1 FROM geneexpressionannotation_crossreference t WHERE t.crossreferences_id                      = x.id)
+  AND NOT EXISTS (SELECT 1 FROM geneexpressionexperiment                t WHERE t.dataprovidercrossreference_id           = x.id)
+  AND NOT EXISTS (SELECT 1 FROM geneexpressionexperiment_crossreference t WHERE t.crossreferences_id                      = x.id)
+  AND NOT EXISTS (SELECT 1 FROM genegeneticinteraction_crossreference   t WHERE t.crossreferences_id                      = x.id)
+  AND NOT EXISTS (SELECT 1 FROM genemolecularinteraction_crossreference t WHERE t.crossreferences_id                      = x.id)
+  AND NOT EXISTS (SELECT 1 FROM genomeassembly_crossreference           t WHERE t.crossreferences_id                      = x.id)
+  AND NOT EXISTS (SELECT 1 FROM genomicentity_crossreference            t WHERE t.crossreferences_id                      = x.id)
+  AND NOT EXISTS (SELECT 1 FROM htpexpressiondatasetannotation          t WHERE t.dataprovidercrossreference_id           = x.id)
+  AND NOT EXISTS (SELECT 1 FROM htpexpressiondatasetsampleannotation    t WHERE t.dataprovidercrossreference_id           = x.id)
+  AND NOT EXISTS (SELECT 1 FROM ontologyterm_crossreference             t WHERE t.crossreferences_id                      = x.id)
+  AND NOT EXISTS (SELECT 1 FROM phenotypeannotation                     t WHERE t.crossreference_id                       = x.id)
+  AND NOT EXISTS (SELECT 1 FROM phenotypeannotation                     t WHERE t.dataprovidercrossreference_id           = x.id)
+  AND NOT EXISTS (SELECT 1 FROM reagent                                 t WHERE t.dataprovidercrossreference_id           = x.id)
+  AND NOT EXISTS (SELECT 1 FROM reference_crossreference                t WHERE t.crossreferences_id                      = x.id)
+  AND NOT EXISTS (SELECT 1 FROM species                                 t WHERE t.dataprovidercrossreference_id           = x.id)
+ON CONFLICT (id) DO NOTHING;
+
+DO $$
+DECLARE
+    rows_deleted int;
+    total_deleted bigint := 0;
+BEGIN
+    LOOP
+        WITH batch AS (
+            DELETE FROM crossreference_ids_to_delete_scrum6053
+            WHERE id IN (SELECT id FROM crossreference_ids_to_delete_scrum6053 LIMIT 250000)
+            RETURNING id
+        )
+        DELETE FROM crossreference c USING batch WHERE c.id = batch.id;
+        GET DIAGNOSTICS rows_deleted = ROW_COUNT;
+        EXIT WHEN rows_deleted = 0;
+        total_deleted := total_deleted + rows_deleted;
+    END LOOP;
+    RAISE NOTICE 'SCRUM-6053: deleted % orphaned crossreference rows', total_deleted;
+END $$;
+
+DROP TABLE crossreference_ids_to_delete_scrum6053;
+
+-- Duplicate stub References that share a crossreference row with their
+-- fully-populated counterparts. Pinned by id so this is a one-shot fix, but each
+-- DELETE is also gated by the structural condition that motivates it. On a
+-- future restored DB where these ids refer to unrelated entities, the
+-- structural guard makes this section a safe no-op.
+
+DELETE FROM reference_crossreference
+WHERE reference_id IN (150917, 255346)
+  AND crossreferences_id IN (
+    SELECT crossreferences_id FROM reference_crossreference
+    GROUP BY crossreferences_id HAVING count(*) > 1
+  );
+
+DELETE FROM reference
+WHERE id IN (150917, 255346)
+  AND id NOT IN (SELECT reference_id FROM reference_crossreference);
+
+DELETE FROM informationcontententity
+WHERE id IN (150917, 255346)
+  AND id NOT IN (SELECT id FROM reference);

--- a/src/test/java/org/alliancegenome/curation_api/IT_0312_CrossReferenceOrphanITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_0312_CrossReferenceOrphanITCase.java
@@ -1,0 +1,181 @@
+package org.alliancegenome.curation_api;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.alliancegenome.curation_api.base.BaseITCase;
+import org.alliancegenome.curation_api.model.entities.CrossReference;
+import org.alliancegenome.curation_api.model.entities.Reference;
+import org.alliancegenome.curation_api.model.entities.ontology.DOTerm;
+import org.alliancegenome.curation_api.resources.TestContainerResource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.RestAssured;
+
+@QuarkusIntegrationTest
+@QuarkusTestResource(TestContainerResource.Initializer.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("0312 - CrossReferenceOrphanITCase")
+@Order(312)
+@SuppressWarnings("checkstyle:TypeNameCheck")
+public class IT_0312_CrossReferenceOrphanITCase extends BaseITCase {
+
+	private static final String REFERENCE_CURIE = "AGRKB:scrum6053-orphan-1";
+	private static final String XREF_KEPT = "PMID:6053TEST-KEPT";
+	private static final String XREF_DROPPED = "PMID:6053TEST-DROPPED";
+
+	private static final String DOTERM_CURIE = "DOID:scrum6053-orphan-2";
+	private static final String DOTERM_XREF_KEPT = "MESH:6053TEST-ONT-KEPT";
+	private static final String DOTERM_XREF_DROPPED = "MESH:6053TEST-ONT-DROPPED";
+
+	@Test
+	@Order(1)
+	public void perEntityIngestRemovesOrphan() {
+		Reference reference = new Reference();
+		reference.setCurie(REFERENCE_CURIE);
+		reference.setObsolete(false);
+		reference.setInternal(false);
+		reference.setCrossReferences(Set.of(buildXref(XREF_KEPT), buildXref(XREF_DROPPED)));
+
+		RestAssured.given().
+			contentType("application/json").
+			body(reference).
+			when().
+			post("/api/reference").
+			then().
+			statusCode(200);
+
+		io.restassured.path.json.JsonPath initial = RestAssured.given().
+			when().
+			get("/api/reference/" + REFERENCE_CURIE).
+			then().
+			statusCode(200).
+			body("entity.crossReferences", hasSize(2)).
+			extract().
+			jsonPath();
+
+		Long droppedXrefId = initial.getLong("entity.crossReferences.find { it.referencedCurie == '" + XREF_DROPPED + "' }.id");
+
+		Reference fetched = initial.getObject("entity", Reference.class);
+		fetched.setCrossReferences(fetched.getCrossReferences().stream()
+			.filter(xref -> XREF_KEPT.equals(xref.getReferencedCurie()))
+			.collect(Collectors.toSet()));
+
+		RestAssured.given().
+			contentType("application/json").
+			body(fetched).
+			when().
+			put("/api/reference").
+			then().
+			statusCode(200);
+
+		RestAssured.given().
+			when().
+			get("/api/reference/" + REFERENCE_CURIE).
+			then().
+			statusCode(200).
+			body("entity.crossReferences", hasSize(1)).
+			body("entity.crossReferences[0].referencedCurie", is(XREF_KEPT)).
+			body("entity.crossReferences.referencedCurie", not(hasItem(XREF_DROPPED)));
+
+		RestAssured.given().
+			when().
+			get("/api/cross-reference/" + droppedXrefId).
+			then().
+			statusCode(200).
+			body("entity", nullValue());
+	}
+
+	@Test
+	@Order(2)
+	public void ontologyTermPerEntityIngestRemovesOrphan() {
+		DOTerm doTerm = new DOTerm();
+		doTerm.setCurie(DOTERM_CURIE);
+		doTerm.setName("SCRUM-6053 orphan test term");
+		doTerm.setNamespace("disease_ontology");
+		doTerm.setObsolete(false);
+		doTerm.setInternal(false);
+		List<CrossReference> xrefs = new ArrayList<>();
+		xrefs.add(buildXref(DOTERM_XREF_KEPT));
+		xrefs.add(buildXref(DOTERM_XREF_DROPPED));
+		doTerm.setCrossReferences(xrefs);
+
+		RestAssured.given().
+			contentType("application/json").
+			body(doTerm).
+			when().
+			post("/api/doterm").
+			then().
+			statusCode(200);
+
+		// /find returns FieldsAndLists view, which includes crossReferences
+		// (the default GET endpoint only serializes FieldsOnly).
+		io.restassured.path.json.JsonPath initial = RestAssured.given().
+			contentType("application/json").
+			body("{\"curie\":\"" + DOTERM_CURIE + "\"}").
+			when().
+			post("/api/doterm/find?limit=1&page=0").
+			then().
+			statusCode(200).
+			body("results", hasSize(1)).
+			body("results[0].crossReferences", hasSize(2)).
+			extract().
+			jsonPath();
+
+		Long droppedXrefId = initial.getLong("results[0].crossReferences.find { it.referencedCurie == '" + DOTERM_XREF_DROPPED + "' }.id");
+
+		DOTerm fetched = initial.getObject("results[0]", DOTerm.class);
+		fetched.setCrossReferences(fetched.getCrossReferences().stream()
+			.filter(xref -> DOTERM_XREF_KEPT.equals(xref.getReferencedCurie()))
+			.collect(Collectors.toList()));
+
+		RestAssured.given().
+			contentType("application/json").
+			body(fetched).
+			when().
+			put("/api/doterm").
+			then().
+			statusCode(200);
+
+		RestAssured.given().
+			contentType("application/json").
+			body("{\"curie\":\"" + DOTERM_CURIE + "\"}").
+			when().
+			post("/api/doterm/find?limit=1&page=0").
+			then().
+			statusCode(200).
+			body("results[0].crossReferences", hasSize(1)).
+			body("results[0].crossReferences[0].referencedCurie", is(DOTERM_XREF_KEPT)).
+			body("results[0].crossReferences.referencedCurie", not(hasItem(DOTERM_XREF_DROPPED)));
+
+		RestAssured.given().
+			when().
+			get("/api/cross-reference/" + droppedXrefId).
+			then().
+			statusCode(200).
+			body("entity", nullValue());
+	}
+
+	private CrossReference buildXref(String curie) {
+		CrossReference xref = new CrossReference();
+		xref.setReferencedCurie(curie);
+		xref.setDisplayName(curie);
+		return xref;
+	}
+}

--- a/src/test/java/org/alliancegenome/curation_api/IT_0312_CrossReferenceOrphanITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_0312_CrossReferenceOrphanITCase.java
@@ -6,15 +6,12 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.base.BaseITCase;
 import org.alliancegenome.curation_api.model.entities.CrossReference;
 import org.alliancegenome.curation_api.model.entities.Reference;
-import org.alliancegenome.curation_api.model.entities.ontology.DOTerm;
 import org.alliancegenome.curation_api.resources.TestContainerResource;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
@@ -39,10 +36,6 @@ public class IT_0312_CrossReferenceOrphanITCase extends BaseITCase {
 	private static final String REFERENCE_CURIE = "AGRKB:scrum6053-orphan-1";
 	private static final String XREF_KEPT = "PMID:6053TEST-KEPT";
 	private static final String XREF_DROPPED = "PMID:6053TEST-DROPPED";
-
-	private static final String DOTERM_CURIE = "DOID:scrum6053-orphan-2";
-	private static final String DOTERM_XREF_KEPT = "MESH:6053TEST-ONT-KEPT";
-	private static final String DOTERM_XREF_DROPPED = "MESH:6053TEST-ONT-DROPPED";
 
 	@Test
 	@Order(1)
@@ -102,80 +95,27 @@ public class IT_0312_CrossReferenceOrphanITCase extends BaseITCase {
 			body("entity", nullValue());
 	}
 
-	@Test
-	@Order(2)
-	public void ontologyTermPerEntityIngestRemovesOrphan() {
-		DOTerm doTerm = new DOTerm();
-		doTerm.setCurie(DOTERM_CURIE);
-		doTerm.setName("SCRUM-6053 orphan test term");
-		doTerm.setNamespace("disease_ontology");
-		doTerm.setObsolete(false);
-		doTerm.setInternal(false);
-		List<CrossReference> xrefs = new ArrayList<>();
-		xrefs.add(buildXref(DOTERM_XREF_KEPT));
-		xrefs.add(buildXref(DOTERM_XREF_DROPPED));
-		doTerm.setCrossReferences(xrefs);
-
-		RestAssured.given().
-			contentType("application/json").
-			body(doTerm).
-			when().
-			post("/api/doterm").
-			then().
-			statusCode(200);
-
-		// /find returns FieldsAndLists view, which includes crossReferences
-		// (the default GET endpoint only serializes FieldsOnly).
-		io.restassured.path.json.JsonPath initial = RestAssured.given().
-			contentType("application/json").
-			body("{\"curie\":\"" + DOTERM_CURIE + "\"}").
-			when().
-			post("/api/doterm/find?limit=1&page=0").
-			then().
-			statusCode(200).
-			body("results", hasSize(1)).
-			body("results[0].crossReferences", hasSize(2)).
-			extract().
-			jsonPath();
-
-		Long droppedXrefId = initial.getLong("results[0].crossReferences.find { it.referencedCurie == '" + DOTERM_XREF_DROPPED + "' }.id");
-
-		DOTerm fetched = initial.getObject("results[0]", DOTerm.class);
-		fetched.setCrossReferences(fetched.getCrossReferences().stream()
-			.filter(xref -> DOTERM_XREF_KEPT.equals(xref.getReferencedCurie()))
-			.collect(Collectors.toList()));
-
-		RestAssured.given().
-			contentType("application/json").
-			body(fetched).
-			when().
-			put("/api/doterm").
-			then().
-			statusCode(200);
-
-		RestAssured.given().
-			contentType("application/json").
-			body("{\"curie\":\"" + DOTERM_CURIE + "\"}").
-			when().
-			post("/api/doterm/find?limit=1&page=0").
-			then().
-			statusCode(200).
-			body("results[0].crossReferences", hasSize(1)).
-			body("results[0].crossReferences[0].referencedCurie", is(DOTERM_XREF_KEPT)).
-			body("results[0].crossReferences.referencedCurie", not(hasItem(DOTERM_XREF_DROPPED)));
-
-		RestAssured.given().
-			when().
-			get("/api/cross-reference/" + droppedXrefId).
-			then().
-			statusCode(200).
-			body("entity", nullValue());
-	}
-
 	private CrossReference buildXref(String curie) {
+		// POST the xref via /api/cross-reference first so it has a managed id by
+		// the time it's attached to the parent entity. The new mapping is
+		// cascade=MERGE (not ALL) — children must already be persisted at the
+		// point the parent is POSTed, matching the convention in
+		// BaseITCase.createReference and the production
+		// ReferenceSynchronisationHelper.
 		CrossReference xref = new CrossReference();
 		xref.setReferencedCurie(curie);
 		xref.setDisplayName(curie);
-		return xref;
+		xref.setInternal(false);
+		xref.setObsolete(false);
+		return RestAssured.given().
+			contentType("application/json").
+			body(xref).
+			when().
+			post("/api/cross-reference").
+			then().
+			statusCode(200).
+			extract().
+			jsonPath().
+			getObject("entity", CrossReference.class);
 	}
 }


### PR DESCRIPTION
  - Switch Reference/OntologyTerm/ExternalDataBaseEntity.crossReferences from @ManyToMany to @OneToMany(cascade=ALL, orphanRemoval=true) so dropped xrefs are deleted, not just unlinked. Matches the existing pattern on GenomicEntity, GeneExpressionAnnotation, GeneInteraction, GenomeAssembly, and ExpressionExperiment
  - Replace BaseSQLDAO.removeByIds JPQL bulk DELETE with per-entity find+remove so JPA cascade and orphanRemoval fire (JPA spec section 4.10: bulk DELETE bypasses entity lifecycle)
  - Add cascade=ALL to ExternalDataBaseEntity.preferredCrossReference (without orphanRemoval — see migration comment for why)
  - v0.47.0.3 migration: drain ~2.4M existing orphans via 23-way FK anti-join with datecreated IS NULL guard, plus targeted cleanup of two duplicate stub References whose shared xref would FK-violate under the new mapping
  - IT_0312_CrossReferenceOrphanITCase exercises Reference and DOTerm per-entity DTO ingest orphan-removal