### PR TITLE
fix: silence duplicate junit-platform.properties warning

### DIFF
--- a/src/main/resources/application.properties.defaults
+++ b/src/main/resources/application.properties.defaults
@@ -88,6 +88,7 @@ quarkus.oidc.enabled=true
 quarkus.oidc.authentication.user-info-required=false
 %dev.quarkus.oidc.enabled=false
 %test.quarkus.oidc.enabled=false
+%test.quarkus.test.class-orderer=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
 
 cognito.domain =
 cognito.user-pool-id=

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,3 +1,3 @@
 junit.jupiter.testinstance.lifecycle.default = per_class
-
-junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$OrderAnnotation
+junit.jupiter.testclass.order.default = io.quarkus.test.config.QuarkusClassOrderer
+junit.jupiter.extensions.autodetection.enabled = true


### PR DESCRIPTION
## Summary
- Quarkus 3.27 ships a `junit-platform.properties` inside `quarkus-junit5-config`, which the project's own `junit-platform.properties` shadows. JUnit emits a "Discovered 2 'junit-platform.properties'" warning and the Quarkus defaults are silently dropped.
- Adopt the Quarkus orderer (`io.quarkus.test.config.QuarkusClassOrderer`) and configure it to delegate to `ClassOrderer.OrderAnnotation` via `%test.quarkus.test.class-orderer`, so the existing `@Order(N)` annotations on `IT_*` classes continue to control execution order.
- Also re-enable `junit.jupiter.extensions.autodetection.enabled=true` (a Quarkus default that was being silently lost).

## Test plan
- [ ] CI green — confirm the duplicate-properties warning no longer appears in the GitHub Actions build log
- [ ] Confirm IT classes still run in `@Order(N)` order (e.g. `IT_0101_*` before `IT_0102_*` before `IT_0201_*` ...)