### PR TITLE
Release/v0.49.2

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/document/builders/DiseaseSummaryDocumentBuilder.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/builders/DiseaseSummaryDocumentBuilder.java
@@ -46,6 +46,13 @@ public class DiseaseSummaryDocumentBuilder {
 			doc.getCrossReferenceLinkUrls().add(map);
 		}
 
+		Set<String> closureIDs = doTerm.getAncestors().stream()
+			.filter(closure -> closure.getClosureTypes().contains("is_a") || closure.getClosureTypes().contains("part_of"))
+			.map(closure -> closure.getClosureObject().getCurie())
+			.collect(Collectors.toSet());
+		closureIDs.add(doTerm.getCurie());
+		doc.setParentClosureIDs(closureIDs);
+
 		return doc;
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSummaryDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/DiseaseSummaryDocument.java
@@ -26,4 +26,5 @@ public class DiseaseSummaryDocument extends ESDocument {
 	private Set<OntologyTerm> children;
 	private List<Map<String, String>> crossReferenceLinkUrls;
 	private List<Map<String, String>> sourceReferenceLinkUrls;
+	private Set<String> parentClosureIDs;
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/OntologyTerm.java
@@ -89,7 +89,7 @@ public class OntologyTerm extends CurieObject {
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "subsets_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
 	@ElementCollection
-	@JsonView({ CurationView.FieldsAndLists.class })
+	@JsonView({ CurationView.FieldsAndLists.class, CurationView.DiseaseSummaryDocument.class })
 	@JoinTable(indexes = @Index(name = "ontologyterm_subsets_ontologyterm_index", columnList = "ontologyterm_id"))
 	private List<String> subsets;
 


### PR DESCRIPTION
## Summary
Adds `CurationView.DiseaseSummaryDocument.class` to the `@JsonView` annotation on `OntologyTerm.subsets` so disease_summary documents expose the term's subset memberships (e.g. `DO_AGR_slim`).

This is the curation-side piece of SCRUM-6057 (removing the remaining Neo4j dependencies from the public REST API). It lets the agr_indexer identify AGR DO slim disease terms directly from the disease_summary doc, without needing a separate Neo4j call (`DiseaseRepository.getAgrDoSlim`).

## Test plan
- [ ] Merge triggers v0.49.2 release workflow (tag + Docker build + EBS deploy)
- [ ] After deploy, verify alpha: POST `/api/disease/document/summary` returns `doTerm.subsets` populated for slim terms (e.g. DOID:14566 should include `"DO_AGR_slim"`)
- [ ] After site_index reindex, verify ES `disease_summary` docs include `doTerm.subsets`