### PR TITLE
SCRUM-5419 enable CRUD on Resource Descriptors and Pages tables

### DIFF
--- a/src/main/cliapp/src/containers/resourceDescriptorPage/NewResourceDescriptorForm.jsx
+++ b/src/main/cliapp/src/containers/resourceDescriptorPage/NewResourceDescriptorForm.jsx
@@ -1,0 +1,242 @@
+import { useRef, useState } from 'react';
+import { Dialog } from 'primereact/dialog';
+import { InputText } from 'primereact/inputtext';
+import { InputTextarea } from 'primereact/inputtextarea';
+import { Dropdown } from 'primereact/dropdown';
+import { Button } from 'primereact/button';
+import { Toast } from 'primereact/toast';
+import { classNames } from 'primereact/utils';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ResourceDescriptorService } from '../../service/ResourceDescriptorService';
+import { useControlledVocabularyService } from '../../service/useControlledVocabularyService';
+import ErrorBoundary from '../../components/Error/ErrorBoundary';
+
+const emptyResourceDescriptor = {
+	prefix: '',
+	name: '',
+	synonyms: [],
+	idPattern: '',
+	idExample: '',
+	defaultUrlTemplate: '',
+	internal: false,
+};
+
+export const NewResourceDescriptorForm = ({
+	newResourceDescriptorDialog,
+	setNewResourceDescriptorDialog,
+	setNewResourceDescriptor,
+}) => {
+	const queryClient = useQueryClient();
+	const [resourceDescriptor, setResourceDescriptor] = useState({ ...emptyResourceDescriptor });
+	const [synonymsInput, setSynonymsInput] = useState('');
+	const [submitted, setSubmitted] = useState(false);
+	const toast_success = useRef(null);
+	const toast_error = useRef(null);
+
+	let resourceDescriptorService = null;
+
+	const booleanTerms = useControlledVocabularyService('generic_boolean_terms');
+
+	const getService = () => {
+		if (!resourceDescriptorService) {
+			resourceDescriptorService = new ResourceDescriptorService();
+		}
+		return resourceDescriptorService;
+	};
+
+	const mutation = useMutation({
+		mutationFn: (newResourceDescriptorPayload) => {
+			return getService().createResourceDescriptor(newResourceDescriptorPayload);
+		},
+	});
+
+	const onTextChange = (event, field) => {
+		const value = event.target?.value ?? '';
+		setResourceDescriptor((prev) => ({ ...prev, [field]: value }));
+	};
+
+	const onSynonymsChange = (event) => {
+		const raw = event.target?.value ?? '';
+		setSynonymsInput(raw);
+		const parsed = raw
+			? raw
+					.split(',')
+					.map((entry) => entry.trim())
+					.filter((entry) => entry.length > 0)
+			: [];
+		setResourceDescriptor((prev) => ({ ...prev, synonyms: parsed }));
+	};
+
+	const onInternalChange = (value) => {
+		if (value === undefined || value === null || value === '') return;
+		const parsed = typeof value === 'string' ? JSON.parse(value) : value;
+		setResourceDescriptor((prev) => ({ ...prev, internal: parsed }));
+	};
+
+	const hideDialog = () => {
+		setNewResourceDescriptorDialog(false);
+		setSubmitted(false);
+		setResourceDescriptor({ ...emptyResourceDescriptor });
+		setSynonymsInput('');
+	};
+
+	const saveResourceDescriptor = (event) => {
+		event.preventDefault();
+		setSubmitted(true);
+		if (
+			resourceDescriptor.prefix &&
+			resourceDescriptor.prefix.trim() &&
+			resourceDescriptor.name &&
+			resourceDescriptor.name.trim() &&
+			resourceDescriptor.defaultUrlTemplate &&
+			resourceDescriptor.defaultUrlTemplate.trim()
+		) {
+			mutation.mutate(resourceDescriptor, {
+				onSuccess: (data) => {
+					if (setNewResourceDescriptor) {
+						setNewResourceDescriptor(data.data.entity, queryClient);
+					} else {
+						queryClient.invalidateQueries({ queryKey: ['resourceDescriptors'] });
+					}
+					toast_success.current.show({
+						severity: 'success',
+						summary: 'Successful',
+						detail: 'New Resource Descriptor Added',
+					});
+					setSubmitted(false);
+					setNewResourceDescriptorDialog(false);
+					setResourceDescriptor({ ...emptyResourceDescriptor });
+					setSynonymsInput('');
+				},
+				onError: (error) => {
+					const fieldErrors = error.response?.data?.errorMessages;
+					const fieldDetail =
+						fieldErrors && Object.keys(fieldErrors).length > 0
+							? Object.entries(fieldErrors)
+									.map(([field, message]) => `${field}: ${message}`)
+									.join('; ')
+							: null;
+					const summary = error.response?.data?.errorMessage || 'Page error: ';
+					toast_error.current.show([
+						{
+							life: 7000,
+							severity: 'error',
+							summary,
+							detail: fieldDetail || error.message,
+							sticky: false,
+						},
+					]);
+				},
+			});
+		}
+	};
+
+	const dialogFooter = (
+		<>
+			<Button label="Cancel" icon="pi pi-times" className="p-button-text" onClick={hideDialog} />
+			<Button
+				label="Save"
+				icon="pi pi-check"
+				className="p-button-text"
+				onClick={saveResourceDescriptor}
+				disabled={mutation.isPending}
+			/>
+		</>
+	);
+
+	return (
+		<div>
+			<Toast ref={toast_error} position="top-left" />
+			<Toast ref={toast_success} position="top-right" />
+			<Dialog
+				visible={newResourceDescriptorDialog}
+				style={{ width: '450px' }}
+				header="New Resource Descriptor"
+				modal
+				className="p-fluid"
+				footer={dialogFooter}
+				onHide={hideDialog}
+			>
+				<ErrorBoundary>
+					<div className="field">
+						<label htmlFor="prefix">
+							<font color="red">*</font>Prefix
+						</label>
+						<InputText
+							id="prefix"
+							value={resourceDescriptor.prefix}
+							onChange={(e) => onTextChange(e, 'prefix')}
+							required
+							autoFocus
+							className={classNames({ 'p-invalid': submitted && !resourceDescriptor.prefix })}
+						/>
+						{submitted && !resourceDescriptor.prefix && <small className="p-error">Prefix is required.</small>}
+					</div>
+					<div className="field">
+						<label htmlFor="name">
+							<font color="red">*</font>Name
+						</label>
+						<InputText
+							id="name"
+							value={resourceDescriptor.name}
+							onChange={(e) => onTextChange(e, 'name')}
+							required
+							className={classNames({ 'p-invalid': submitted && !resourceDescriptor.name })}
+						/>
+						{submitted && !resourceDescriptor.name && <small className="p-error">Name is required.</small>}
+					</div>
+					<div className="field">
+						<label htmlFor="synonyms">Synonyms (comma-separated)</label>
+						<InputTextarea id="synonyms" value={synonymsInput} onChange={onSynonymsChange} rows={3} />
+					</div>
+					<div className="field">
+						<label htmlFor="idPattern">ID Pattern</label>
+						<InputText
+							id="idPattern"
+							value={resourceDescriptor.idPattern}
+							onChange={(e) => onTextChange(e, 'idPattern')}
+						/>
+					</div>
+					<div className="field">
+						<label htmlFor="idExample">ID Example</label>
+						<InputText
+							id="idExample"
+							value={resourceDescriptor.idExample}
+							onChange={(e) => onTextChange(e, 'idExample')}
+						/>
+					</div>
+					<div className="field">
+						<label htmlFor="defaultUrlTemplate">
+							<font color="red">*</font>Default URL Template
+						</label>
+						<InputText
+							id="defaultUrlTemplate"
+							value={resourceDescriptor.defaultUrlTemplate}
+							onChange={(e) => onTextChange(e, 'defaultUrlTemplate')}
+							required
+							className={classNames({ 'p-invalid': submitted && !resourceDescriptor.defaultUrlTemplate })}
+						/>
+						{submitted && !resourceDescriptor.defaultUrlTemplate && (
+							<small className="p-error">Default URL Template is required.</small>
+						)}
+					</div>
+					<div className="field">
+						<label htmlFor="internal">Internal</label>
+						<Dropdown
+							id="internal"
+							value={
+								resourceDescriptor.internal === null || resourceDescriptor.internal === undefined
+									? null
+									: String(resourceDescriptor.internal)
+							}
+							options={booleanTerms?.terms || []}
+							optionLabel="text"
+							optionValue="name"
+							onChange={(e) => onInternalChange(e.target?.value)}
+						/>
+					</div>
+				</ErrorBoundary>
+			</Dialog>
+		</div>
+	);
+};

--- a/src/main/cliapp/src/containers/resourceDescriptorPage/ResourceDescriptorsTable.jsx
+++ b/src/main/cliapp/src/containers/resourceDescriptorPage/ResourceDescriptorsTable.jsx
@@ -2,6 +2,7 @@ import React, { useRef, useState, useMemo } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { GenericDataTable } from '../../components/GenericDataTable/GenericDataTable';
 import { Toast } from 'primereact/toast';
+import { Button } from 'primereact/button';
 import { getDefaultTableState } from '../../service/TableStateService';
 import { FILTER_CONFIGS } from '../../constants/FilterFields';
 import { useGetTableData } from '../../service/useGetTableData';
@@ -9,11 +10,16 @@ import { useGetUserSettings } from '../../service/useGetUserSettings';
 import { SearchService } from '../../service/SearchService';
 import { ResourceDescriptorService } from '../../service/ResourceDescriptorService';
 import { Endpoints } from '../../constants/Endpoints';
+import { setNewEntity } from '../../utils/utils';
 
 import { StringTemplate } from '../../components/Templates/StringTemplate';
+import { BooleanTemplate } from '../../components/Templates/BooleanTemplate';
 import { CommaSeparatedArrayTemplate } from '../../components/Templates/CommaSeparatedArrayTemplate';
 import { InputTextTableEditor } from '../../components/Editors/text/InputTextTableEditor';
 import { StringListTextAreaTableEditor } from '../../components/Editors/text/StringListTextAreaTableEditor';
+import { BooleanTableEditor } from '../../components/Editors/dropdown/boolean/BooleanTableEditor';
+
+import { NewResourceDescriptorForm } from './NewResourceDescriptorForm';
 
 export const ResourceDescriptorsTable = () => {
 	const [isInEditMode, setIsInEditMode] = useState(false);
@@ -21,6 +27,7 @@ export const ResourceDescriptorsTable = () => {
 	const [totalRecords, setTotalRecords] = useState(0);
 
 	const [resourceDescriptors, setResourceDescriptors] = useState();
+	const [newResourceDescriptorDialog, setNewResourceDescriptorDialog] = useState(false);
 
 	const searchService = new SearchService();
 
@@ -111,6 +118,41 @@ export const ResourceDescriptorsTable = () => {
 				),
 			},
 			{
+				field: 'internal',
+				header: 'Internal',
+				sortable: true,
+				body: (rowData) => <BooleanTemplate value={rowData.internal} />,
+				filterConfig: FILTER_CONFIGS.internalFilterConfig,
+				editor: (editorOptions) => (
+					<BooleanTableEditor editorOptions={editorOptions} errorMessagesRef={errorMessagesRef} field="internal" />
+				),
+			},
+			{
+				field: 'obsolete',
+				header: 'Obsolete',
+				sortable: true,
+				body: (rowData) => <BooleanTemplate value={rowData.obsolete} />,
+				filterConfig: FILTER_CONFIGS.obsoleteFilterConfig,
+				editor: (editorOptions) => (
+					<BooleanTableEditor editorOptions={editorOptions} errorMessagesRef={errorMessagesRef} field="obsolete" />
+				),
+			},
+			{
+				field: 'createdBy.uniqueId',
+				header: 'Created By',
+				sortable: true,
+				body: (rowData) => <StringTemplate string={rowData.createdBy?.uniqueId} />,
+				filterConfig: FILTER_CONFIGS.createdByFilterConfig,
+			},
+			{
+				field: 'dateCreated',
+				header: 'Date Created',
+				sortable: true,
+				filter: true,
+				body: (rowData) => <StringTemplate string={rowData.dateCreated} />,
+				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+			},
+			{
 				field: 'updatedBy.uniqueId',
 				header: 'Updated By',
 				sortable: true,
@@ -153,6 +195,24 @@ export const ResourceDescriptorsTable = () => {
 		searchService,
 	});
 
+	const handleOpenNewResourceDescriptor = () => {
+		setNewResourceDescriptorDialog(true);
+	};
+
+	const headerButtons = (disabled = false) => {
+		return (
+			<>
+				<Button
+					label="New Resource Descriptor"
+					icon="pi pi-plus"
+					onClick={handleOpenNewResourceDescriptor}
+					disabled={disabled}
+				/>
+				&nbsp;&nbsp;
+			</>
+		);
+	};
+
 	return (
 		<div className="card">
 			<Toast ref={toast_topleft} position="top-left" />
@@ -171,10 +231,21 @@ export const ResourceDescriptorsTable = () => {
 				mutation={mutation}
 				isInEditMode={isInEditMode}
 				setIsInEditMode={setIsInEditMode}
+				headerButtons={headerButtons}
 				toasts={{ toast_topleft, toast_topright }}
 				errorObject={{ errorMessages, setErrorMessages }}
+				deletionEnabled={true}
+				deletionMethod={resourceDescriptorService.deleteResourceDescriptor}
+				deprecateOption={true}
 				defaultColumnWidth={DEFAULT_COLUMN_WIDTH}
 				fetching={isFetching || isLoading}
+			/>
+			<NewResourceDescriptorForm
+				newResourceDescriptorDialog={newResourceDescriptorDialog}
+				setNewResourceDescriptorDialog={setNewResourceDescriptorDialog}
+				setNewResourceDescriptor={(newResourceDescriptor, queryClient) =>
+					setNewEntity(tableState, setResourceDescriptors, newResourceDescriptor, queryClient)
+				}
 			/>
 		</div>
 	);

--- a/src/main/cliapp/src/containers/resourceDescriptorPagePage/NewResourceDescriptorPageForm.jsx
+++ b/src/main/cliapp/src/containers/resourceDescriptorPagePage/NewResourceDescriptorPageForm.jsx
@@ -1,0 +1,231 @@
+import { useRef, useState } from 'react';
+import { Dialog } from 'primereact/dialog';
+import { InputText } from 'primereact/inputtext';
+import { InputTextarea } from 'primereact/inputtextarea';
+import { Dropdown } from 'primereact/dropdown';
+import { Button } from 'primereact/button';
+import { Toast } from 'primereact/toast';
+import { classNames } from 'primereact/utils';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ResourceDescriptorPageService } from '../../service/ResourceDescriptorPageService';
+import { useControlledVocabularyService } from '../../service/useControlledVocabularyService';
+import { AutocompleteFormEditor } from '../../components/Editors/autocomplete/base/AutocompleteFormEditor';
+import { resourceDescriptorSearch } from '../../components/Editors/autocomplete/resourceDescriptor/utils';
+import ErrorBoundary from '../../components/Error/ErrorBoundary';
+
+const emptyResourceDescriptorPage = {
+	resourceDescriptor: null,
+	name: '',
+	urlTemplate: '',
+	pageDescription: '',
+	internal: false,
+};
+
+export const NewResourceDescriptorPageForm = ({
+	newResourceDescriptorPageDialog,
+	setNewResourceDescriptorPageDialog,
+	setNewResourceDescriptorPage,
+}) => {
+	const queryClient = useQueryClient();
+	const [resourceDescriptorPage, setResourceDescriptorPage] = useState({ ...emptyResourceDescriptorPage });
+	const [submitted, setSubmitted] = useState(false);
+	const toast_success = useRef(null);
+	const toast_error = useRef(null);
+
+	let resourceDescriptorPageService = null;
+
+	const booleanTerms = useControlledVocabularyService('generic_boolean_terms');
+
+	const getService = () => {
+		if (!resourceDescriptorPageService) {
+			resourceDescriptorPageService = new ResourceDescriptorPageService();
+		}
+		return resourceDescriptorPageService;
+	};
+
+	const mutation = useMutation({
+		mutationFn: (newResourceDescriptorPagePayload) => {
+			return getService().createResourceDescriptorPage(newResourceDescriptorPagePayload);
+		},
+	});
+
+	const onTextChange = (event, field) => {
+		const value = event.target?.value ?? '';
+		setResourceDescriptorPage((prev) => ({ ...prev, [field]: value }));
+	};
+
+	const onResourceDescriptorChange = (event) => {
+		const value = event.target?.value;
+		const resolved = value && typeof value === 'object' ? value : null;
+		setResourceDescriptorPage((prev) => ({ ...prev, resourceDescriptor: resolved }));
+	};
+
+	const onInternalChange = (value) => {
+		if (value === undefined || value === null || value === '') return;
+		const parsed = typeof value === 'string' ? JSON.parse(value) : value;
+		setResourceDescriptorPage((prev) => ({ ...prev, internal: parsed }));
+	};
+
+	const hideDialog = () => {
+		setNewResourceDescriptorPageDialog(false);
+		setSubmitted(false);
+		setResourceDescriptorPage({ ...emptyResourceDescriptorPage });
+	};
+
+	const saveResourceDescriptorPage = (event) => {
+		event.preventDefault();
+		setSubmitted(true);
+		if (
+			resourceDescriptorPage.resourceDescriptor?.id &&
+			resourceDescriptorPage.name &&
+			resourceDescriptorPage.name.trim() &&
+			resourceDescriptorPage.urlTemplate &&
+			resourceDescriptorPage.urlTemplate.trim()
+		) {
+			mutation.mutate(resourceDescriptorPage, {
+				onSuccess: (data) => {
+					if (setNewResourceDescriptorPage) {
+						setNewResourceDescriptorPage(data.data.entity, queryClient);
+					} else {
+						queryClient.invalidateQueries({ queryKey: ['resourceDescriptorPages'] });
+					}
+					toast_success.current.show({
+						severity: 'success',
+						summary: 'Successful',
+						detail: 'New Resource Descriptor Page Added',
+					});
+					setSubmitted(false);
+					setNewResourceDescriptorPageDialog(false);
+					setResourceDescriptorPage({ ...emptyResourceDescriptorPage });
+				},
+				onError: (error) => {
+					const fieldErrors = error.response?.data?.errorMessages;
+					const fieldDetail =
+						fieldErrors && Object.keys(fieldErrors).length > 0
+							? Object.entries(fieldErrors)
+									.map(([field, message]) => `${field}: ${message}`)
+									.join('; ')
+							: null;
+					const summary = error.response?.data?.errorMessage || 'Page error: ';
+					toast_error.current.show([
+						{
+							life: 7000,
+							severity: 'error',
+							summary,
+							detail: fieldDetail || error.message,
+							sticky: false,
+						},
+					]);
+				},
+			});
+		}
+	};
+
+	const dialogFooter = (
+		<>
+			<Button label="Cancel" icon="pi pi-times" className="p-button-text" onClick={hideDialog} />
+			<Button
+				label="Save"
+				icon="pi pi-check"
+				className="p-button-text"
+				onClick={saveResourceDescriptorPage}
+				disabled={mutation.isPending}
+			/>
+		</>
+	);
+
+	return (
+		<div>
+			<Toast ref={toast_error} position="top-left" />
+			<Toast ref={toast_success} position="top-right" />
+			<Dialog
+				visible={newResourceDescriptorPageDialog}
+				style={{ width: '450px' }}
+				header="New Resource Descriptor Page"
+				modal
+				className="p-fluid"
+				footer={dialogFooter}
+				onHide={hideDialog}
+			>
+				<ErrorBoundary>
+					<div className="field">
+						<label htmlFor="resourceDescriptor">
+							<font color="red">*</font>Resource Descriptor
+						</label>
+						<AutocompleteFormEditor
+							name="resourceDescriptor"
+							fieldName="resourceDescriptor"
+							subField="prefix"
+							initialValue={resourceDescriptorPage.resourceDescriptor}
+							search={resourceDescriptorSearch}
+							onValueChangeHandler={onResourceDescriptorChange}
+							valueDisplay={(item) => (
+								<div>
+									{item.prefix} ({item.name})
+								</div>
+							)}
+							classNames={classNames({
+								'p-invalid': submitted && !resourceDescriptorPage.resourceDescriptor?.id,
+							})}
+						/>
+						{submitted && !resourceDescriptorPage.resourceDescriptor?.id && (
+							<small className="p-error">Resource Descriptor is required.</small>
+						)}
+					</div>
+					<div className="field">
+						<label htmlFor="name">
+							<font color="red">*</font>Name
+						</label>
+						<InputText
+							id="name"
+							value={resourceDescriptorPage.name}
+							onChange={(e) => onTextChange(e, 'name')}
+							required
+							className={classNames({ 'p-invalid': submitted && !resourceDescriptorPage.name })}
+						/>
+						{submitted && !resourceDescriptorPage.name && <small className="p-error">Name is required.</small>}
+					</div>
+					<div className="field">
+						<label htmlFor="urlTemplate">
+							<font color="red">*</font>URL Template
+						</label>
+						<InputText
+							id="urlTemplate"
+							value={resourceDescriptorPage.urlTemplate}
+							onChange={(e) => onTextChange(e, 'urlTemplate')}
+							required
+							className={classNames({ 'p-invalid': submitted && !resourceDescriptorPage.urlTemplate })}
+						/>
+						{submitted && !resourceDescriptorPage.urlTemplate && (
+							<small className="p-error">URL Template is required.</small>
+						)}
+					</div>
+					<div className="field">
+						<label htmlFor="pageDescription">Page Description</label>
+						<InputTextarea
+							id="pageDescription"
+							value={resourceDescriptorPage.pageDescription}
+							onChange={(e) => onTextChange(e, 'pageDescription')}
+							rows={3}
+						/>
+					</div>
+					<div className="field">
+						<label htmlFor="internal">Internal</label>
+						<Dropdown
+							id="internal"
+							value={
+								resourceDescriptorPage.internal === null || resourceDescriptorPage.internal === undefined
+									? null
+									: String(resourceDescriptorPage.internal)
+							}
+							options={booleanTerms?.terms || []}
+							optionLabel="text"
+							optionValue="name"
+							onChange={(e) => onInternalChange(e.target?.value)}
+						/>
+					</div>
+				</ErrorBoundary>
+			</Dialog>
+		</div>
+	);
+};

--- a/src/main/cliapp/src/containers/resourceDescriptorPagePage/ResourceDescriptorPagesTable.jsx
+++ b/src/main/cliapp/src/containers/resourceDescriptorPagePage/ResourceDescriptorPagesTable.jsx
@@ -2,6 +2,7 @@ import React, { useRef, useState, useMemo } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { GenericDataTable } from '../../components/GenericDataTable/GenericDataTable';
 import { Toast } from 'primereact/toast';
+import { Button } from 'primereact/button';
 import { getDefaultTableState } from '../../service/TableStateService';
 import { FILTER_CONFIGS } from '../../constants/FilterFields';
 import { useGetTableData } from '../../service/useGetTableData';
@@ -9,10 +10,15 @@ import { useGetUserSettings } from '../../service/useGetUserSettings';
 import { SearchService } from '../../service/SearchService';
 import { ResourceDescriptorPageService } from '../../service/ResourceDescriptorPageService';
 import { Endpoints } from '../../constants/Endpoints';
+import { setNewEntity } from '../../utils/utils';
 
 import { StringTemplate } from '../../components/Templates/StringTemplate';
+import { BooleanTemplate } from '../../components/Templates/BooleanTemplate';
 import { InputTextTableEditor } from '../../components/Editors/text/InputTextTableEditor';
+import { BooleanTableEditor } from '../../components/Editors/dropdown/boolean/BooleanTableEditor';
 import { ResourceDescriptorTableEditor } from '../../components/Editors/autocomplete/resourceDescriptor/ResourceDescriptorTableEditor';
+
+import { NewResourceDescriptorPageForm } from './NewResourceDescriptorPageForm';
 
 export const ResourceDescriptorPagesTable = () => {
 	const [isInEditMode, setIsInEditMode] = useState(false);
@@ -20,6 +26,7 @@ export const ResourceDescriptorPagesTable = () => {
 	const [totalRecords, setTotalRecords] = useState(0);
 
 	const [resourceDescriptorPages, setResourceDescriptorPages] = useState();
+	const [newResourceDescriptorPageDialog, setNewResourceDescriptorPageDialog] = useState(false);
 
 	const searchService = new SearchService();
 
@@ -89,6 +96,41 @@ export const ResourceDescriptorPagesTable = () => {
 				),
 			},
 			{
+				field: 'internal',
+				header: 'Internal',
+				sortable: true,
+				body: (rowData) => <BooleanTemplate value={rowData.internal} />,
+				filterConfig: FILTER_CONFIGS.internalFilterConfig,
+				editor: (editorOptions) => (
+					<BooleanTableEditor editorOptions={editorOptions} errorMessagesRef={errorMessagesRef} field="internal" />
+				),
+			},
+			{
+				field: 'obsolete',
+				header: 'Obsolete',
+				sortable: true,
+				body: (rowData) => <BooleanTemplate value={rowData.obsolete} />,
+				filterConfig: FILTER_CONFIGS.obsoleteFilterConfig,
+				editor: (editorOptions) => (
+					<BooleanTableEditor editorOptions={editorOptions} errorMessagesRef={errorMessagesRef} field="obsolete" />
+				),
+			},
+			{
+				field: 'createdBy.uniqueId',
+				header: 'Created By',
+				sortable: true,
+				body: (rowData) => <StringTemplate string={rowData.createdBy?.uniqueId} />,
+				filterConfig: FILTER_CONFIGS.createdByFilterConfig,
+			},
+			{
+				field: 'dateCreated',
+				header: 'Date Created',
+				sortable: true,
+				filter: true,
+				body: (rowData) => <StringTemplate string={rowData.dateCreated} />,
+				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+			},
+			{
 				field: 'updatedBy.uniqueId',
 				header: 'Updated By',
 				sortable: true,
@@ -131,6 +173,24 @@ export const ResourceDescriptorPagesTable = () => {
 		searchService,
 	});
 
+	const handleOpenNewResourceDescriptorPage = () => {
+		setNewResourceDescriptorPageDialog(true);
+	};
+
+	const headerButtons = (disabled = false) => {
+		return (
+			<>
+				<Button
+					label="New Resource Descriptor Page"
+					icon="pi pi-plus"
+					onClick={handleOpenNewResourceDescriptorPage}
+					disabled={disabled}
+				/>
+				&nbsp;&nbsp;
+			</>
+		);
+	};
+
 	return (
 		<div className="card">
 			<Toast ref={toast_topleft} position="top-left" />
@@ -149,10 +209,21 @@ export const ResourceDescriptorPagesTable = () => {
 				mutation={mutation}
 				isInEditMode={isInEditMode}
 				setIsInEditMode={setIsInEditMode}
+				headerButtons={headerButtons}
 				toasts={{ toast_topleft, toast_topright }}
 				errorObject={{ errorMessages, setErrorMessages }}
+				deletionEnabled={true}
+				deletionMethod={resourceDescriptorPageService.deleteResourceDescriptorPage}
+				deprecateOption={true}
 				defaultColumnWidth={DEFAULT_COLUMN_WIDTH}
 				fetching={isFetching || isLoading}
+			/>
+			<NewResourceDescriptorPageForm
+				newResourceDescriptorPageDialog={newResourceDescriptorPageDialog}
+				setNewResourceDescriptorPageDialog={setNewResourceDescriptorPageDialog}
+				setNewResourceDescriptorPage={(newResourceDescriptorPage, queryClient) =>
+					setNewEntity(tableState, setResourceDescriptorPages, newResourceDescriptorPage, queryClient)
+				}
 			/>
 		</div>
 	);

--- a/src/main/cliapp/src/service/ResourceDescriptorPageService.js
+++ b/src/main/cliapp/src/service/ResourceDescriptorPageService.js
@@ -1,7 +1,18 @@
 import { BaseAuthService } from './BaseAuthService';
+import { DeletionService } from './DeletionService';
+import { Endpoints } from '../constants/Endpoints';
 
 export class ResourceDescriptorPageService extends BaseAuthService {
 	saveResourceDescriptorPage(updatedResourceDescriptorPage) {
 		return this.api.put(`/resourcedescriptorpage`, updatedResourceDescriptorPage);
+	}
+
+	createResourceDescriptorPage(resourceDescriptorPage) {
+		return this.api.post(`/resourcedescriptorpage`, resourceDescriptorPage);
+	}
+
+	async deleteResourceDescriptorPage(resourceDescriptorPage) {
+		const deletionService = new DeletionService();
+		return await deletionService.delete(Endpoints.Resource.DESCRIPTOR_PAGE, resourceDescriptorPage.id);
 	}
 }

--- a/src/main/cliapp/src/service/ResourceDescriptorService.js
+++ b/src/main/cliapp/src/service/ResourceDescriptorService.js
@@ -1,7 +1,18 @@
 import { BaseAuthService } from './BaseAuthService';
+import { DeletionService } from './DeletionService';
+import { Endpoints } from '../constants/Endpoints';
 
 export class ResourceDescriptorService extends BaseAuthService {
 	saveResourceDescriptor(updatedResourceDescriptor) {
 		return this.api.put(`/resourcedescriptor`, updatedResourceDescriptor);
+	}
+
+	createResourceDescriptor(resourceDescriptor) {
+		return this.api.post(`/resourcedescriptor`, resourceDescriptor);
+	}
+
+	async deleteResourceDescriptor(resourceDescriptor) {
+		const deletionService = new DeletionService();
+		return await deletionService.delete(Endpoints.Resource.DESCRIPTOR, resourceDescriptor.id);
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/controllers/crud/ResourceDescriptorCrudController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/crud/ResourceDescriptorCrudController.java
@@ -29,6 +29,11 @@ public class ResourceDescriptorCrudController extends BaseEntityCrudController<R
 	}
 
 	@Override
+	public ObjectResponse<ResourceDescriptor> create(ResourceDescriptor entity) {
+		return resourceDescriptorService.create(entity);
+	}
+
+	@Override
 	public ObjectResponse<ResourceDescriptor> update(ResourceDescriptor entity) {
 		return resourceDescriptorService.update(entity);
 	}

--- a/src/main/java/org/alliancegenome/curation_api/controllers/crud/ResourceDescriptorPageCrudController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/crud/ResourceDescriptorPageCrudController.java
@@ -29,6 +29,11 @@ public class ResourceDescriptorPageCrudController extends BaseEntityCrudControll
 	}
 
 	@Override
+	public ObjectResponse<ResourceDescriptorPage> create(ResourceDescriptorPage entity) {
+		return resourceDescriptorPageService.create(entity);
+	}
+
+	@Override
 	public ObjectResponse<ResourceDescriptorPage> update(ResourceDescriptorPage entity) {
 		return resourceDescriptorPageService.update(entity);
 	}

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ResourceDescriptorCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ResourceDescriptorCrudInterface.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -27,6 +28,12 @@ public interface ResourceDescriptorCrudInterface extends BaseIdCrudInterface<Res
 	@Path("/{id}")
 	@JsonView(CurationView.ResourceDescriptorView.class)
 	ObjectResponse<ResourceDescriptor> getById(@PathParam("id") Long id);
+
+	@Override
+	@POST
+	@Path("/")
+	@JsonView(CurationView.ResourceDescriptorView.class)
+	ObjectResponse<ResourceDescriptor> create(ResourceDescriptor entity);
 
 	@Override
 	@PUT

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ResourceDescriptorPageCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ResourceDescriptorPageCrudInterface.java
@@ -33,6 +33,12 @@ public interface ResourceDescriptorPageCrudInterface extends BaseIdCrudInterface
 	SearchResponse<ResourceDescriptorPage> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 	@Override
+	@POST
+	@Path("/")
+	@JsonView(CurationView.ResourceDescriptorPageView.class)
+	ObjectResponse<ResourceDescriptorPage> create(ResourceDescriptorPage entity);
+
+	@Override
 	@PUT
 	@Path("/")
 	@JsonView(CurationView.ResourceDescriptorPageView.class)

--- a/src/main/java/org/alliancegenome/curation_api/services/ResourceDescriptorPageService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ResourceDescriptorPageService.java
@@ -41,6 +41,13 @@ public class ResourceDescriptorPageService extends BaseEntityCrudService<Resourc
 		return new ObjectResponse<>(resourceDescriptorPageDAO.persist(dbEntity));
 	}
 
+	@Override
+	@Transactional
+	public ObjectResponse<ResourceDescriptorPage> create(ResourceDescriptorPage uiEntity) {
+		ResourceDescriptorPage dbEntity = resourceDescriptorPageValidator.validateResourceDescriptorPageCreate(uiEntity);
+		return new ObjectResponse<>(resourceDescriptorPageDAO.persist(dbEntity));
+	}
+
 	public ResourceDescriptorPage getPageForResourceDescriptor(String resourceDescriptorPrefix, String pageName) {
 
 		ResourceDescriptorPage page = null;

--- a/src/main/java/org/alliancegenome/curation_api/services/ResourceDescriptorService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ResourceDescriptorService.java
@@ -45,6 +45,13 @@ public class ResourceDescriptorService extends BaseEntityCrudService<ResourceDes
 		return new ObjectResponse<>(resourceDescriptorDAO.persist(dbEntity));
 	}
 
+	@Override
+	@Transactional
+	public ObjectResponse<ResourceDescriptor> create(ResourceDescriptor uiEntity) {
+		ResourceDescriptor dbEntity = resourceDescriptorValidator.validateResourceDescriptorCreate(uiEntity);
+		return new ObjectResponse<>(resourceDescriptorDAO.persist(dbEntity));
+	}
+
 	public List<String> getAllNames() {
 		List<String> names = resourceDescriptorDAO.findAllNames();
 		names.removeIf(Objects::isNull);

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/ResourceDescriptorPageValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/ResourceDescriptorPageValidator.java
@@ -41,6 +41,16 @@ public class ResourceDescriptorPageValidator extends AuditedObjectValidator<Reso
 		return validateResourceDescriptorPage(uiEntity, dbEntity);
 	}
 
+	public ResourceDescriptorPage validateResourceDescriptorPageCreate(ResourceDescriptorPage uiEntity) {
+		response = new ObjectResponse<>(uiEntity);
+		errorMessage = "Could not create Resource Descriptor Page";
+
+		ResourceDescriptorPage dbEntity = new ResourceDescriptorPage();
+		dbEntity = (ResourceDescriptorPage) validateAuditedObjectFields(uiEntity, dbEntity, true);
+
+		return validateResourceDescriptorPage(uiEntity, dbEntity);
+	}
+
 	private ResourceDescriptorPage validateResourceDescriptorPage(ResourceDescriptorPage uiEntity, ResourceDescriptorPage dbEntity) {
 		if (uiEntity.getResourceDescriptor() == null || uiEntity.getResourceDescriptor().getId() == null) {
 			addMessageResponse("resourceDescriptor", ValidationConstants.REQUIRED_MESSAGE);

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/ResourceDescriptorValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/ResourceDescriptorValidator.java
@@ -5,6 +5,7 @@ import org.alliancegenome.curation_api.dao.ResourceDescriptorDAO;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.ResourceDescriptor;
 import org.alliancegenome.curation_api.response.ObjectResponse;
+import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.validation.base.AuditedObjectValidator;
 import org.apache.commons.lang3.StringUtils;
 
@@ -38,11 +39,27 @@ public class ResourceDescriptorValidator extends AuditedObjectValidator<Resource
 		return validateResourceDescriptor(uiEntity, dbEntity);
 	}
 
+	public ResourceDescriptor validateResourceDescriptorCreate(ResourceDescriptor uiEntity) {
+		response = new ObjectResponse<>(uiEntity);
+		errorMessage = "Could not create Resource Descriptor";
+
+		ResourceDescriptor dbEntity = new ResourceDescriptor();
+		dbEntity = (ResourceDescriptor) validateAuditedObjectFields(uiEntity, dbEntity, true);
+
+		return validateResourceDescriptor(uiEntity, dbEntity);
+	}
+
 	private ResourceDescriptor validateResourceDescriptor(ResourceDescriptor uiEntity, ResourceDescriptor dbEntity) {
 		if (StringUtils.isBlank(uiEntity.getPrefix())) {
 			addMessageResponse("prefix", ValidationConstants.REQUIRED_MESSAGE);
 		} else {
-			dbEntity.setPrefix(uiEntity.getPrefix());
+			SearchResponse<ResourceDescriptor> existing = resourceDescriptorDAO.findByField("prefix", uiEntity.getPrefix());
+			ResourceDescriptor existingMatch = existing == null ? null : existing.getSingleResult();
+			if (existingMatch != null && !existingMatch.getId().equals(uiEntity.getId())) {
+				addMessageResponse("prefix", "A Resource Descriptor with this prefix already exists");
+			} else {
+				dbEntity.setPrefix(uiEntity.getPrefix());
+			}
 		}
 
 		if (StringUtils.isBlank(uiEntity.getName())) {

--- a/src/test/java/org/alliancegenome/curation_api/base/BaseITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/base/BaseITCase.java
@@ -785,6 +785,8 @@ public class BaseITCase {
 	public ResourceDescriptor createResourceDescriptor(String prefix) {
 		ResourceDescriptor rd = new ResourceDescriptor();
 		rd.setPrefix(prefix);
+		rd.setName(prefix);
+		rd.setDefaultUrlTemplate("http://example.com/" + prefix + "/[%s]");
 
 		ObjectResponse<ResourceDescriptor> response = RestAssured.given().
 			contentType("application/json").


### PR DESCRIPTION
  - Add "New Resource Descriptor" and "New Resource Descriptor Page" dialogs with required-field validation per ticket
  - Wire delete-or-deprecate action via GenericDataTable; deprecate reuses the existing PUT mutation with obsolete=true
  - Add Internal/Obsolete (editable) and Created By/Date Created columns to both tables
  - Surface backend field-level errors (errorMessages map) in the create-dialog toast instead of axios's generic message
  - Override service create() on both entities so POST runs through new validateResourceDescriptor[Page]Create methods, closing a gap where the inherited base create() persisted unvalidated entities
  - Pre-check prefix uniqueness in ResourceDescriptorValidator so duplicates return a field-level error instead of a 500 from the DB unique constraint
  - Widen POST JsonView on both CRUD interfaces so create responses include synonyms / resourceDescriptor parent ref