### PR TITLE
Centralize autocomplete fields via AUTOCOMPLETE_CONFIGS registry

### DIFF
--- a/src/main/cliapp/src/components/ConditionRelationsEditDialog.jsx
+++ b/src/main/cliapp/src/components/ConditionRelationsEditDialog.jsx
@@ -16,6 +16,7 @@ import { SearchService } from '../service/SearchService';
 import { autocompleteSearch, buildAutocompleteFilter, multipleAutocompleteOnChange } from '../utils/utils';
 import { AutocompleteMultiEditor } from './Editors/autocomplete/base/AutocompleteMultiEditor';
 import { Endpoints } from '../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../constants/FilterFields';
 
 export const ConditionRelationsEditDialog = ({
 	originalConditionRelationsData,
@@ -94,15 +95,9 @@ export const ConditionRelationsEditDialog = ({
 	};
 
 	const conditionSearch = (event, setFiltered, setInputValue) => {
-		const autocompleteFields = [
-			'conditionSummary',
-			'conditionId.curie',
-			'conditionClass.curie',
-			'conditionTaxon.curie',
-			'conditionGeneOntology.curie',
-			'conditionChemical.curie',
-			'conditionAnatomy.curie',
-		];
+		const autocompleteFields = getAutocompleteFields(
+			AUTOCOMPLETE_CONFIGS.experimentalConditionDetailedAutocompleteConfig
+		);
 		const endpoint = Endpoints.Annotation.EXPERIMENTAL_CONDITION;
 		const filterName = 'conditionSummaryFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);

--- a/src/main/cliapp/src/components/Editors/autocomplete/agm/utils.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/agm/utils.jsx
@@ -2,6 +2,7 @@ import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/u
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
 import { SubjectAutocompleteTemplate } from '../base/templates/SubjectAutocompleteTemplate';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
 
 const agmValueDisplay = (item, setAutocompleteHoverItem, op, query) => (
 	<SubjectAutocompleteTemplate item={item} setAutocompleteHoverItem={setAutocompleteHoverItem} op={op} query={query} />
@@ -9,7 +10,7 @@ const agmValueDisplay = (item, setAutocompleteHoverItem, op, query) => (
 
 export const sgdStrainBackgroundSearchConfig = {
 	endpoint: Endpoints.Entity.AGM,
-	autocompleteFields: ['name', 'curie', 'primaryExternalId', 'modInternalId', 'crossReferences.referencedCurie'],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig),
 	filterName: 'sgdStrainBackgroundFilter',
 	otherFilters: { taxonFilter: { 'taxon.name': { queryString: 'Saccharomyces cerevisiae' } } },
 	valueDisplay: agmValueDisplay,
@@ -17,17 +18,7 @@ export const sgdStrainBackgroundSearchConfig = {
 
 export const diseaseGeneticModifierAgmsSearchConfig = {
 	endpoint: Endpoints.Entity.AGM,
-	autocompleteFields: [
-		'agmFullName.formatText',
-		'agmSynonyms.formatText',
-		'agmFullName.displayText',
-		'agmSynonyms.displayText',
-		'agmSecondaryIds.secondaryId',
-		'curie',
-		'primaryExternalId',
-		'modInternalId',
-		'crossReferences.referencedCurie',
-	],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig),
 	filterName: 'geneticModifierAgmsFilter',
 	valueDisplay: agmValueDisplay,
 };

--- a/src/main/cliapp/src/components/Editors/autocomplete/allele/utils.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/allele/utils.jsx
@@ -2,6 +2,7 @@ import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/u
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
 import { SubjectAutocompleteTemplate } from '../base/templates/SubjectAutocompleteTemplate';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
 
 const alleleValueDisplay = (item, setAutocompleteHoverItem, op, query) => (
 	<SubjectAutocompleteTemplate item={item} setAutocompleteHoverItem={setAutocompleteHoverItem} op={op} query={query} />
@@ -9,38 +10,14 @@ const alleleValueDisplay = (item, setAutocompleteHoverItem, op, query) => (
 
 export const assertedAllelesSearchConfig = {
 	endpoint: Endpoints.Entity.ALLELE,
-	autocompleteFields: [
-		'alleleSymbol.formatText',
-		'alleleSymbol.displayText',
-		'alleleFullName.formatText',
-		'alleleFullName.displayText',
-		'curie',
-		'primaryExternalId',
-		'modInternalId',
-		'crossReferences.referencedCurie',
-		'alleleSecondaryIds.secondaryId',
-		'alleleSynonyms.formatText',
-		'alleleSynonyms.displayText',
-	],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig),
 	filterName: 'assertedAllelesFilter',
 	valueDisplay: alleleValueDisplay,
 };
 
 export const diseaseGeneticModifierAllelesSearchConfig = {
 	endpoint: Endpoints.Entity.ALLELE,
-	// Modifier variant intentionally omits alleleSymbol.displayText (matches legacy behavior).
-	autocompleteFields: [
-		'alleleSymbol.formatText',
-		'alleleFullName.formatText',
-		'alleleFullName.displayText',
-		'alleleSynonyms.formatText',
-		'alleleSynonyms.displayText',
-		'curie',
-		'primaryExternalId',
-		'modInternalId',
-		'crossReferences.referencedCurie',
-		'alleleSecondaryIds.secondaryId',
-	],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig),
 	filterName: 'geneticModifierAllelesFilter',
 	valueDisplay: alleleValueDisplay,
 };

--- a/src/main/cliapp/src/components/Editors/autocomplete/biologicalEntity/BiologicalEntityTableEditor.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/biologicalEntity/BiologicalEntityTableEditor.jsx
@@ -1,10 +1,7 @@
 import { AutocompleteSingleTableEditor } from '../base/AutocompleteSingleTableEditor';
 import { getIdentifier } from '../../../../utils/utils';
-import {
-	getBiologicalEntityEndpoint,
-	getBiologicalEntityAutocompleteFields,
-	biologicalEntityValueDisplay,
-} from './utils';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
+import { getBiologicalEntityEndpoint, biologicalEntityValueDisplay } from './utils';
 
 export const BiologicalEntityTableEditor = ({ editorOptions, errorMessagesRef, uiErrorMessagesRef }) => (
 	<AutocompleteSingleTableEditor
@@ -12,7 +9,7 @@ export const BiologicalEntityTableEditor = ({ editorOptions, errorMessagesRef, u
 		field="diseaseAnnotationSubject"
 		subField="primaryExternalId"
 		endpoint={getBiologicalEntityEndpoint(editorOptions.rowData)}
-		autocompleteFields={getBiologicalEntityAutocompleteFields(editorOptions.rowData)}
+		autocompleteFields={getAutocompleteFields(AUTOCOMPLETE_CONFIGS.diseaseAnnotationSubjectAutocompleteConfig)}
 		filterName="diseaseAnnotationSubjectFilter"
 		initialValue={getIdentifier(editorOptions.rowData.diseaseAnnotationSubject)}
 		valueDisplay={biologicalEntityValueDisplay}

--- a/src/main/cliapp/src/components/Editors/autocomplete/biologicalEntity/utils.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/biologicalEntity/utils.jsx
@@ -1,51 +1,15 @@
 import { SubjectAutocompleteTemplate } from '../base/templates/SubjectAutocompleteTemplate';
 import { Endpoints } from '../../../../constants/Endpoints';
 
-// Biological entities (Gene/Allele/AGM) are searched via a row-type-aware
-// endpoint + autocompleteFields pair. Reused across multi-subject annotation
-// tables (e.g. disease annotations), hence the generic "biologicalEntity" name.
+// Biological entity disease annotations route to a per-type search endpoint
+// based on the row's annotation type. The autocomplete field set is shared
+// across all row types and lives in AUTOCOMPLETE_CONFIGS.
 
 export const getBiologicalEntityEndpoint = (rowData) => {
 	if (rowData?.type === 'GeneDiseaseAnnotation') return Endpoints.Entity.GENE;
 	if (rowData?.type === 'AlleleDiseaseAnnotation') return Endpoints.Entity.ALLELE;
 	if (rowData?.type === 'AGMDiseaseAnnotation') return Endpoints.Entity.AGM;
 	return Endpoints.Entity.BIOLOGICAL_ENTITY;
-};
-
-export const getBiologicalEntityAutocompleteFields = (rowData) => {
-	const fields = ['curie', 'primaryExternalId', 'modInternalId', 'crossReferences.referencedCurie'];
-	if (rowData?.type === 'AGMDiseaseAnnotation') {
-		fields.push(
-			'agmFullName.formatText',
-			'agmFullName.displayText',
-			'agmSynonyms.formatText',
-			'agmSynonyms.displayText',
-			'agmSecondaryIds.secondaryId'
-		);
-	} else if (rowData?.type === 'AlleleDiseaseAnnotation') {
-		fields.push(
-			'alleleFullName.formatText',
-			'alleleFullName.displayText',
-			'alleleSymbol.formatText',
-			'alleleSymbol.displayText',
-			'alleleSynonyms.formatText',
-			'alleleSynonyms.displayText',
-			'alleleSecondaryIds.secondaryId'
-		);
-	} else if (rowData?.type === 'GeneDiseaseAnnotation') {
-		fields.push(
-			'geneFullName.formatText',
-			'geneFullName.displayText',
-			'geneSymbol.formatText',
-			'geneSymbol.displayText',
-			'geneSynonyms.formatText',
-			'geneSynonyms.displayText',
-			'geneSystematicName.formatText',
-			'geneSystematicName.displayText',
-			'geneSecondaryIds.secondaryId'
-		);
-	}
-	return fields;
 };
 
 export const biologicalEntityValueDisplay = (item, setAutocompleteHoverItem, op, query) => (

--- a/src/main/cliapp/src/components/Editors/autocomplete/experimentalCondition/utils.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/experimentalCondition/utils.jsx
@@ -2,10 +2,11 @@ import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/u
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
 import { ExConAutocompleteTemplate } from '../base/templates/ExConAutocompleteTemplate';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
 
 export const conditionsSearchConfig = {
 	endpoint: Endpoints.Annotation.EXPERIMENTAL_CONDITION,
-	autocompleteFields: ['conditionSummary'],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.experimentalConditionAutocompleteConfig),
 	filterName: 'experimentalConditionFilter',
 	valueDisplay: (item, setAutocompleteHoverItem, op, query) => (
 		<ExConAutocompleteTemplate item={item} setAutocompleteHoverItem={setAutocompleteHoverItem} op={op} query={query} />

--- a/src/main/cliapp/src/components/Editors/autocomplete/gene/utils.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/gene/utils.jsx
@@ -2,22 +2,7 @@ import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/u
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
 import { SubjectAutocompleteTemplate } from '../base/templates/SubjectAutocompleteTemplate';
-
-const baseGeneAutocompleteFields = [
-	'geneSymbol.formatText',
-	'geneSymbol.displayText',
-	'geneFullName.formatText',
-	'geneFullName.displayText',
-	'geneSynonyms.formatText',
-	'geneSynonyms.displayText',
-	'geneSystematicName.formatText',
-	'geneSystematicName.displayText',
-	'geneSecondaryIds.secondaryId',
-	'curie',
-	'primaryExternalId',
-	'modInternalId',
-	'crossReferences.referencedCurie',
-];
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
 
 const geneValueDisplay = (item, setAutocompleteHoverItem, op, query) => (
 	<SubjectAutocompleteTemplate item={item} setAutocompleteHoverItem={setAutocompleteHoverItem} op={op} query={query} />
@@ -25,7 +10,7 @@ const geneValueDisplay = (item, setAutocompleteHoverItem, op, query) => (
 
 export const withSearchConfig = {
 	endpoint: Endpoints.Entity.GENE,
-	autocompleteFields: baseGeneAutocompleteFields,
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig),
 	filterName: 'withFilter',
 	otherFilters: { taxonFilter: { 'taxon.curie': { queryString: 'NCBITaxon:9606' } } },
 	valueDisplay: geneValueDisplay,
@@ -33,28 +18,14 @@ export const withSearchConfig = {
 
 export const assertedGenesSearchConfig = {
 	endpoint: Endpoints.Entity.GENE,
-	// assertedGenes intentionally omits geneSecondaryIds.secondaryId (matches legacy filter behavior).
-	autocompleteFields: [
-		'geneSymbol.formatText',
-		'geneSymbol.displayText',
-		'geneFullName.formatText',
-		'geneFullName.displayText',
-		'curie',
-		'primaryExternalId',
-		'modInternalId',
-		'crossReferences.referencedCurie',
-		'geneSynonyms.formatText',
-		'geneSynonyms.displayText',
-		'geneSystematicName.formatText',
-		'geneSystematicName.displayText',
-	],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.assertedGenesAutocompleteConfig),
 	filterName: 'assertedGenesFilter',
 	valueDisplay: geneValueDisplay,
 };
 
 export const diseaseGeneticModifierGenesSearchConfig = {
 	endpoint: Endpoints.Entity.GENE,
-	autocompleteFields: baseGeneAutocompleteFields,
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig),
 	filterName: 'geneticModifierGenesFilter',
 	valueDisplay: geneValueDisplay,
 };

--- a/src/main/cliapp/src/components/Editors/autocomplete/inCollection/utils.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/inCollection/utils.jsx
@@ -2,10 +2,11 @@ import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/u
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
 import { VocabTermAutocompleteTemplate } from '../base/templates/VocabTermAutocompleteTemplate';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
 
 export const inCollectionSearchConfig = {
 	endpoint: Endpoints.Vocabulary.TERM,
-	autocompleteFields: ['name'],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.nameOnlyAutocompleteConfig),
 	filterName: 'inCollectionFilter',
 	otherFilters: {
 		vocabularyFilter: {

--- a/src/main/cliapp/src/components/Editors/autocomplete/ontology/utils.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/ontology/utils.jsx
@@ -2,25 +2,22 @@ import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/u
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
 import { EvidenceAutocompleteTemplate } from '../base/templates/EvidenceAutocompleteTemplate';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
 
-export const curieAutocompleteFields = [
-	'curie',
-	'name',
-	'crossReferences.referencedCurie',
-	'secondaryIdentifiers',
-	'synonyms.name',
-];
+export const ontologyTermAutocompleteFields = getAutocompleteFields(
+	AUTOCOMPLETE_CONFIGS.ontologyTermAutocompleteConfig
+);
 
 export const diseaseSearchConfig = {
 	endpoint: Endpoints.Ontology.DO,
-	autocompleteFields: curieAutocompleteFields,
+	autocompleteFields: ontologyTermAutocompleteFields,
 	filterName: 'diseaseFilter',
 	otherFilters: { obsoleteFilter: { obsolete: { queryString: false } } },
 };
 
 export const evidenceCodesSearchConfig = {
 	endpoint: Endpoints.Ontology.ECO,
-	autocompleteFields: ['curie', 'name', 'abbreviation'],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.evidenceCodeAutocompleteConfig),
 	filterName: 'evidenceFilter',
 	otherFilters: {
 		obsoleteFilter: { obsolete: { queryString: false } },
@@ -38,38 +35,38 @@ export const evidenceCodesSearchConfig = {
 
 export const conditionClassSearchConfig = {
 	endpoint: Endpoints.Ontology.ZECO,
-	autocompleteFields: curieAutocompleteFields,
+	autocompleteFields: ontologyTermAutocompleteFields,
 	filterName: 'conditionClassFilter',
 	otherFilters: { subsetFilter: { subsets: { queryString: 'ZECO_0000267' } } },
 };
 
 export const conditionIdSearchConfig = {
 	endpoint: Endpoints.Ontology.EXPERIMENTAL_CONDITION,
-	autocompleteFields: curieAutocompleteFields,
+	autocompleteFields: ontologyTermAutocompleteFields,
 	filterName: 'conditionIdFilter',
 };
 
 export const conditionGeneOntologySearchConfig = {
 	endpoint: Endpoints.Ontology.GO,
-	autocompleteFields: curieAutocompleteFields,
+	autocompleteFields: ontologyTermAutocompleteFields,
 	filterName: 'conditionGeneOntologyFilter',
 };
 
 export const conditionChemicalSearchConfig = {
 	endpoint: Endpoints.Ontology.CHEMICAL,
-	autocompleteFields: curieAutocompleteFields,
+	autocompleteFields: ontologyTermAutocompleteFields,
 	filterName: 'conditionChemicalFilter',
 };
 
 export const conditionAnatomySearchConfig = {
 	endpoint: Endpoints.Ontology.ANATOMICAL,
-	autocompleteFields: curieAutocompleteFields,
+	autocompleteFields: ontologyTermAutocompleteFields,
 	filterName: 'conditionAnatomyFilter',
 };
 
 export const conditionTaxonSearchConfig = {
 	endpoint: Endpoints.Ontology.NCBI_TAXON,
-	autocompleteFields: curieAutocompleteFields,
+	autocompleteFields: ontologyTermAutocompleteFields,
 	filterName: 'conditionTaxonFilter',
 };
 

--- a/src/main/cliapp/src/components/Editors/autocomplete/references/utils.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/references/utils.jsx
@@ -2,10 +2,11 @@ import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/u
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
 import { LiteratureAutocompleteTemplate } from '../base/templates/LiteratureAutocompleteTemplate';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
 
 const referenceSearchConfig = {
 	endpoint: Endpoints.Document.LITERATURE_REFERENCE,
-	autocompleteFields: ['curie', 'cross_references.curie'],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.referenceAutocompleteConfig),
 	valueDisplay: (item, setAutocompleteHoverItem, op, query) => (
 		<LiteratureAutocompleteTemplate
 			item={item}

--- a/src/main/cliapp/src/components/Editors/autocomplete/resourceDescriptor/utils.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/resourceDescriptor/utils.jsx
@@ -1,10 +1,11 @@
 import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/utils';
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
 
 export const resourceDescriptorSearchConfig = {
 	endpoint: Endpoints.Resource.DESCRIPTOR,
-	autocompleteFields: ['prefix', 'name'],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.resourceDescriptorAutocompleteConfig),
 	filterName: 'resourceDescriptorFilter',
 	valueDisplay: (item) => (
 		<div>

--- a/src/main/cliapp/src/components/Editors/autocomplete/sourceGeneralConsequence/utils.js
+++ b/src/main/cliapp/src/components/Editors/autocomplete/sourceGeneralConsequence/utils.js
@@ -1,10 +1,11 @@
 import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/utils';
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
 
 export const sourceGeneralConsequenceSearchConfig = {
 	endpoint: Endpoints.Ontology.SO,
-	autocompleteFields: ['curie', 'name', 'secondaryIdentifiers', 'synonyms.name'],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.ontologyTermAutocompleteConfig),
 	filterName: 'sourceGeneralConsequenceFilter',
 };
 

--- a/src/main/cliapp/src/components/Editors/autocomplete/taxon/utils.js
+++ b/src/main/cliapp/src/components/Editors/autocomplete/taxon/utils.js
@@ -1,10 +1,11 @@
 import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/utils';
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
 
 export const taxonSearchConfig = {
 	endpoint: Endpoints.Ontology.NCBI_TAXON,
-	autocompleteFields: ['curie', 'name', 'crossReferences.referencedCurie', 'secondaryIdentifiers', 'synonyms.name'],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.ontologyTermAutocompleteConfig),
 	filterName: 'taxonFilter',
 };
 

--- a/src/main/cliapp/src/components/Editors/autocomplete/variantType/utils.js
+++ b/src/main/cliapp/src/components/Editors/autocomplete/variantType/utils.js
@@ -1,10 +1,11 @@
 import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/utils';
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
 
 export const variantTypeSearchConfig = {
 	endpoint: Endpoints.Ontology.SO,
-	autocompleteFields: ['curie', 'name', 'secondaryIdentifiers', 'synonyms.name'],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.ontologyTermAutocompleteConfig),
 	filterName: 'variantTypeFilter',
 };
 

--- a/src/main/cliapp/src/components/Editors/autocomplete/vocabulary/utils.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/vocabulary/utils.jsx
@@ -2,10 +2,11 @@ import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/u
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
 import { VocabTermAutocompleteTemplate } from '../base/templates/VocabTermAutocompleteTemplate';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
 
 export const vocabularySearchConfig = {
 	endpoint: Endpoints.Vocabulary.VOCABULARY,
-	autocompleteFields: ['name'],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.nameOnlyAutocompleteConfig),
 	filterName: 'vocabularyFilter',
 	valueDisplay: (item, setAutocompleteSelectedItem, op, query) => (
 		<VocabTermAutocompleteTemplate

--- a/src/main/cliapp/src/components/Editors/autocomplete/vocabularyTerm/utils.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/vocabularyTerm/utils.jsx
@@ -2,10 +2,11 @@ import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/u
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
 import { VocabTermAutocompleteTemplate } from '../base/templates/VocabTermAutocompleteTemplate';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
 
 export const memberTermsSearchConfig = {
 	endpoint: Endpoints.Vocabulary.TERM,
-	autocompleteFields: ['name'],
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.nameOnlyAutocompleteConfig),
 	filterName: 'memberTermsFilter',
 	valueDisplay: (item, setAutocompleteSelectedItem, op, query) => (
 		<VocabTermAutocompleteTemplate

--- a/src/main/cliapp/src/components/Editors/legacyForm/EvidenceCodeEditor.jsx
+++ b/src/main/cliapp/src/components/Editors/legacyForm/EvidenceCodeEditor.jsx
@@ -4,10 +4,11 @@ import { SearchService } from '../../../service/SearchService';
 import { EvidenceAutocompleteTemplate } from '../autocomplete/base/templates/EvidenceAutocompleteTemplate';
 import { ErrorMessageComponent } from '../../Error/ErrorMessageComponent';
 import { Endpoints } from '../../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../constants/FilterFields';
 
 const evidenceSearch = (event, setFiltered, setInputValue) => {
 	const searchService = new SearchService();
-	const autocompleteFields = ['curie', 'name', 'abbreviation'];
+	const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.evidenceCodeAutocompleteConfig);
 	const endpoint = Endpoints.Ontology.ECO;
 	const filterName = 'evidenceFilter';
 	const filter = buildAutocompleteFilter(event, autocompleteFields);

--- a/src/main/cliapp/src/components/Editors/legacyForm/EvidenceEditor.jsx
+++ b/src/main/cliapp/src/components/Editors/legacyForm/EvidenceEditor.jsx
@@ -4,10 +4,11 @@ import { autocompleteSearch, buildAutocompleteFilter } from '../../../utils/util
 import { LiteratureAutocompleteTemplate } from '../autocomplete/base/templates/LiteratureAutocompleteTemplate';
 import { DialogErrorMessageComponent } from '../../Error/DialogErrorMessageComponent';
 import { Endpoints } from '../../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../constants/FilterFields';
 
 const evidenceSearch = (event, setFiltered, setInputValue) => {
 	const searchService = new SearchService();
-	const autocompleteFields = ['curie', 'cross_references.curie'];
+	const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.referenceAutocompleteConfig);
 	const endpoint = Endpoints.Document.LITERATURE_REFERENCE;
 	const filterName = 'evidenceFilter';
 	const filter = buildAutocompleteFilter(event, autocompleteFields);

--- a/src/main/cliapp/src/components/Editors/legacyForm/FunctionalImpactsEditor.jsx
+++ b/src/main/cliapp/src/components/Editors/legacyForm/FunctionalImpactsEditor.jsx
@@ -4,10 +4,11 @@ import { autocompleteSearch, buildAutocompleteFilter } from '../../../utils/util
 import { VocabTermAutocompleteTemplate } from '../autocomplete/base/templates/VocabTermAutocompleteTemplate';
 import { DialogErrorMessageComponent } from '../../Error/DialogErrorMessageComponent';
 import { Endpoints } from '../../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../constants/FilterFields';
 
 const functionalImpactSearch = (event, setFiltered, setQuery) => {
 	const searchService = new SearchService();
-	const autocompleteFields = ['name'];
+	const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.nameOnlyAutocompleteConfig);
 	const endpoint = Endpoints.Vocabulary.TERM;
 	const filterName = 'functionalImpactFilter';
 	const otherFilters = {

--- a/src/main/cliapp/src/components/Editors/legacyForm/GeneEditor.jsx
+++ b/src/main/cliapp/src/components/Editors/legacyForm/GeneEditor.jsx
@@ -5,23 +5,11 @@ import { SubjectAutocompleteTemplate } from '../autocomplete/base/templates/Subj
 import { DialogErrorMessageComponent } from '../../Error/DialogErrorMessageComponent';
 import { getIdentifier } from '../../../utils/utils';
 import { Endpoints } from '../../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../constants/FilterFields';
 
 const geneSearch = (event, setFiltered, setInputValue) => {
 	const searchService = new SearchService();
-	const autocompleteFields = [
-		'curie',
-		'primaryExternalId',
-		'crossReferences.referencedCurie',
-		'geneFullName.formatText',
-		'geneFullName.displayText',
-		'geneSymbol.formatText',
-		'geneSymbol.displayText',
-		'geneSynonyms.formatText',
-		'geneSynonyms.displayText',
-		'geneSystematicName.formatText',
-		'geneSystematicName.displayText',
-		'geneSecondaryIds.secondaryId',
-	];
+	const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig);
 	const endpoint = Endpoints.Entity.GENE;
 	const filterName = 'objectFilter';
 	const filter = buildAutocompleteFilter(event, autocompleteFields);

--- a/src/main/cliapp/src/components/Editors/legacyForm/MutationTypesEditor.jsx
+++ b/src/main/cliapp/src/components/Editors/legacyForm/MutationTypesEditor.jsx
@@ -4,10 +4,11 @@ import { autocompleteSearch, buildAutocompleteFilter } from '../../../utils/util
 import { SubjectAutocompleteTemplate } from '../autocomplete/base/templates/SubjectAutocompleteTemplate';
 import { DialogErrorMessageComponent } from '../../Error/DialogErrorMessageComponent';
 import { Endpoints } from '../../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../constants/FilterFields';
 
 const mutationTypeSearch = (event, setFiltered, setInputValue) => {
 	const searchService = new SearchService();
-	const autocompleteFields = ['name', 'curie'];
+	const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.ontologyTermAutocompleteConfig);
 	const endpoint = Endpoints.Ontology.SO;
 	const filterName = 'mutationTypeFilter';
 	const filter = buildAutocompleteFilter(event, autocompleteFields);

--- a/src/main/cliapp/src/components/Editors/legacyForm/PhenotypeTermEditor.jsx
+++ b/src/main/cliapp/src/components/Editors/legacyForm/PhenotypeTermEditor.jsx
@@ -3,10 +3,11 @@ import { SearchService } from '../../../service/SearchService';
 import { autocompleteSearch, buildAutocompleteFilter } from '../../../utils/utils';
 import { DialogErrorMessageComponent } from '../../Error/DialogErrorMessageComponent';
 import { Endpoints } from '../../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../constants/FilterFields';
 
 const phenotypeTermSearch = (event, setFiltered, setInputValue) => {
 	const searchService = new SearchService();
-	const autocompleteFields = ['name', 'curie'];
+	const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.ontologyTermAutocompleteConfig);
 	const endpoint = Endpoints.Ontology.PHENOTYPE;
 	const filterName = 'phenotypeTermFilter';
 	const filter = buildAutocompleteFilter(event, autocompleteFields);

--- a/src/main/cliapp/src/components/Editors/legacyForm/ReferencesEditor.jsx
+++ b/src/main/cliapp/src/components/Editors/legacyForm/ReferencesEditor.jsx
@@ -4,10 +4,11 @@ import { autocompleteSearch, buildAutocompleteFilter } from '../../../utils/util
 import { DialogErrorMessageComponent } from '../../Error/DialogErrorMessageComponent';
 import { LiteratureAutocompleteTemplate } from '../autocomplete/base/templates/LiteratureAutocompleteTemplate';
 import { Endpoints } from '../../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../constants/FilterFields';
 
 const referenceSearch = (event, setFiltered, setInputValue) => {
 	const searchService = new SearchService();
-	const autocompleteFields = ['curie', 'cross_references.curie'];
+	const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.referenceAutocompleteConfig);
 	const endpoint = Endpoints.Document.LITERATURE_REFERENCE;
 	const filterName = 'referencesFilter';
 	const filter = buildAutocompleteFilter(event, autocompleteFields);

--- a/src/main/cliapp/src/components/EvidenceComponent.jsx
+++ b/src/main/cliapp/src/components/EvidenceComponent.jsx
@@ -12,6 +12,7 @@ import {
 } from '../utils/utils';
 import { LiteratureAutocompleteTemplate } from './Editors/autocomplete/base/templates/LiteratureAutocompleteTemplate';
 import { Endpoints } from '../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../constants/FilterFields';
 
 export const evidenceTemplate = (rowData) => {
 	if (rowData && rowData.evidence) {
@@ -53,7 +54,7 @@ export const onEvidenceValueChange = (event, setFieldValue, props) => {
 
 export const evidenceSearch = (event, setFiltered, setInputValue) => {
 	const searchService = new SearchService();
-	const autocompleteFields = ['curie', 'cross_references.curie'];
+	const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.referenceAutocompleteConfig);
 	const endpoint = Endpoints.Document.LITERATURE_REFERENCE;
 	const filterName = 'evidenceFilter';
 	const filter = buildAutocompleteFilter(event, autocompleteFields);

--- a/src/main/cliapp/src/constants/FilterFields.js
+++ b/src/main/cliapp/src/constants/FilterFields.js
@@ -143,7 +143,7 @@ export const FIELD_SETS = Object.freeze({
 		fields: ['conditionGeneOntology.curie', 'conditionGeneOntology.name'],
 	},
 	conditionIdFieldSet: {
-		filterName: 'conditionIdFieldSet',
+		filterName: 'conditionIdFilter',
 		fields: ['conditionId.curie', 'conditionId.name'],
 	},
 	conditionQuantityFieldSet: {
@@ -165,10 +165,6 @@ export const FIELD_SETS = Object.freeze({
 	conditionTaxonFieldSet: {
 		filterName: 'conditionTaxonFilter',
 		fields: ['conditionTaxon.curie', 'conditionTaxon.name'],
-	},
-	confidenceFieldSet: {
-		filterName: 'confidenceFilter',
-		fields: ['confidence.name'],
 	},
 	constructNameFieldSet: {
 		filterName: 'constructNameFilter',
@@ -241,11 +237,11 @@ export const FIELD_SETS = Object.freeze({
 		filterName: 'dataProviderFilter',
 		fields: ['dataProvider.abbreviation', 'dataProvider.fullName', 'dataProvider.shortName'],
 	},
-	dataCreatedFieldSet: {
+	dateCreatedFieldSet: {
 		filterName: 'dateCreatedFilter',
 		fields: ['dateCreated'],
 	},
-	dataUpdatedFieldSet: {
+	dateUpdatedFieldSet: {
 		filterName: 'dateUpdatedFilter',
 		fields: ['dateUpdated'],
 	},
@@ -507,12 +503,12 @@ export const FIELD_SETS = Object.freeze({
 		filterName: 'memberTermsFilter',
 		fields: ['memberTerms.name'],
 	},
-	primaryexternalidFieldSet: {
-		filterName: 'primaryexternalidFilter',
+	primaryExternalIdFieldSet: {
+		filterName: 'primaryExternalIdFilter',
 		fields: ['primaryExternalId'],
 	},
-	modinternalidFieldSet: {
-		filterName: 'modinternalidFilter',
+	modInternalIdFieldSet: {
+		filterName: 'modInternalIdFilter',
 		fields: ['modInternalId'],
 	},
 	nameFieldSet: {
@@ -538,17 +534,6 @@ export const FIELD_SETS = Object.freeze({
 	ontologySynonymsFieldSet: {
 		filterName: 'ontologySynonymsFilter',
 		fields: ['synonyms.name'],
-	},
-	orthologyAggregationFieldSet: {
-		filterName: 'orthologyAggregationFilter',
-		fields: [
-			'predictionMethodsMatched.name',
-			'predictionMethodsNotMatched.name',
-			'predictionMethodsNotCalled.name',
-			'confidence.name',
-			'isBestScore.name',
-			'isBestScoreReverse.name',
-		],
 	},
 	pageDescriptionFieldSet: {
 		filterName: 'pageDescriptionFilter',
@@ -608,9 +593,25 @@ export const FIELD_SETS = Object.freeze({
 		filterName: 'subsetsFilter',
 		fields: ['subsets'],
 	},
-	secondaryIdsFieldSet: {
+	// OntologyTerm.secondaryIdentifiers — the native indexed field on ontology
+	// term entities. Different document path than the bridged secondaryIds field
+	// used by BiologicalEntity subclasses (see secondaryIdsBridgedFieldSet).
+	secondaryIdentifiersFieldSet: {
 		filterName: 'secondaryIdsFilter',
 		fields: ['secondaryIdentifiers'],
+	},
+	// Bridged from BiologicalEntityTypeBridge — denormalized flat field across
+	// Gene/Allele/AGM/etc. (the per-type secondaryIds slot annotations). Path
+	// differs from secondaryIdentifiersFieldSet, which targets ontology terms.
+	secondaryIdsBridgedFieldSet: {
+		filterName: 'secondaryIdsBridgedFilter',
+		fields: ['secondaryIds'],
+	},
+	// Bridged from BiologicalEntityTypeBridge — denormalized flat symbol field
+	// for Gene/Allele (AGM has no symbol).
+	symbolFieldSet: {
+		filterName: 'symbolFilter',
+		fields: ['symbol'],
 	},
 	sgdStrainBackgroundFieldSet: {
 		filterName: 'sgdStrainBackgroundFilter',
@@ -903,8 +904,8 @@ export const FILTER_CONFIGS = Object.freeze({
 		nullFields: FIELD_SETS.conditionRelationsHandleFieldSet,
 	},
 
-	dataCreatedFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.dataCreatedFieldSet] },
-	dateUpdatedFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.dataUpdatedFieldSet] },
+	dateCreatedFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.dateCreatedFieldSet] },
+	dateUpdatedFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.dateUpdatedFieldSet] },
 	defaultUrlTemplateFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.defaultUrlTemplateFieldSet] },
 	definitionFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.definitionFieldSet] },
 	detectionMethodFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.detectionMethodFieldSet] },
@@ -972,8 +973,8 @@ export const FILTER_CONFIGS = Object.freeze({
 		filterComponentType: 'input',
 		fieldSets: [FIELD_SETS.literatureCrossReferenceFieldSet],
 	},
-	primaryexternalidFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.primaryexternalidFieldSet] },
-	modinternalidFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.modinternalidFieldSet] },
+	primaryExternalIdFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.primaryExternalIdFieldSet] },
+	modInternalIdFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.modInternalIdFieldSet] },
 	nameFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.nameFieldSet] },
 	namespaceFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.namespaceFieldSet] },
 	phenotypeAnnotationSubjectFilterConfig: {
@@ -1004,7 +1005,10 @@ export const FILTER_CONFIGS = Object.freeze({
 	relatedNotesFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.relatedNotesFieldSet] },
 	resourceDescriptorFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.resourceDescriptorFieldSet] },
 	subsetsFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.subsetsFieldSet] },
-	secondaryIdsFilterConfig: { filterComponentType: 'input', fieldSets: [FIELD_SETS.secondaryIdsFieldSet] },
+	secondaryIdentifiersFilterConfig: {
+		filterComponentType: 'input',
+		fieldSets: [FIELD_SETS.secondaryIdentifiersFieldSet],
+	},
 	sgdStrainBackgroundFilterConfig: {
 		filterComponentType: 'input',
 		fieldSets: [FIELD_SETS.sgdStrainBackgroundFieldSet],
@@ -1232,5 +1236,109 @@ export const FILTER_CONFIGS = Object.freeze({
 		fieldSets: [FIELD_SETS.curieFieldSet, FIELD_SETS.literatureCrossReferenceFieldSet],
 		useKeywordFields: true,
 	},
-	// nameAutoCompleteFilterConfig: { filterType: "autocomplete", fieldSets: [FIELD_SETS.curieFieldSet, FIELD_SETS.geneNameFieldSet, FIELD_SETS.alleleNameFieldSet] }
 });
+
+// Autocomplete editors compose their searchable fields from the same FIELD_SETS
+// used by column filters. Each entry lists fieldSets only — the runtime
+// filterName, endpoint, valueDisplay, and otherFilters stay colocated with the
+// editor's local search config.
+//
+// One config (biologicalEntityAutocompleteConfig) covers Gene/Allele/AGM and
+// every other BiologicalEntity subtype because BiologicalEntityTypeBridge
+// denormalizes type-specific symbol/name/synonyms/secondaryIds into flat
+// `symbol`/`name`/`synonyms`/`secondaryIds` index fields on every entity. So a
+// single set of bridge fields routes to gene fields on Gene docs, allele fields
+// on Allele docs, etc.
+export const AUTOCOMPLETE_CONFIGS = Object.freeze({
+	biologicalEntityAutocompleteConfig: {
+		fieldSets: [
+			FIELD_SETS.curieFieldSet,
+			FIELD_SETS.primaryExternalIdFieldSet,
+			FIELD_SETS.modInternalIdFieldSet,
+			FIELD_SETS.crossReferencesFieldSet,
+			FIELD_SETS.nameFieldSet,
+			FIELD_SETS.symbolFieldSet,
+			FIELD_SETS.synonymsFieldSet,
+			FIELD_SETS.secondaryIdsBridgedFieldSet,
+			// geneSystematicName is the only commonly-searched name component not
+			// surfaced by BiologicalEntityTypeBridge (which only writes
+			// geneSymbol/geneFullName/geneSynonyms into the flat fields). Yeast
+			// curators identify genes by systematic name (e.g. YGR240C). The path
+			// resolves to nothing on non-Gene documents, so adding it is safe.
+			FIELD_SETS.geneSystematicNameFieldSet,
+		],
+	},
+	// Used for the disease-annotation Subject picker against the BIOLOGICAL_ENTITY
+	// endpoint, which aggregates Gene/Allele/AGM/Variant/SQTR/Transcript/etc. The
+	// bridge fields would match all subtypes; we scope to Gene/Allele/AGM by
+	// listing per-type slot-annotation paths instead. Paths that don't exist on a
+	// document type silently no-op, so non-Gene/Allele/AGM docs cannot match.
+	diseaseAnnotationSubjectAutocompleteConfig: {
+		fieldSets: [
+			FIELD_SETS.curieFieldSet,
+			FIELD_SETS.primaryExternalIdFieldSet,
+			FIELD_SETS.modInternalIdFieldSet,
+			FIELD_SETS.crossReferencesFieldSet,
+			FIELD_SETS.geneSymbolFieldSet,
+			FIELD_SETS.geneNameFieldSet,
+			FIELD_SETS.geneSynonymsFieldSet,
+			FIELD_SETS.geneSystematicNameFieldSet,
+			FIELD_SETS.geneSecondaryIdsFieldSet,
+			FIELD_SETS.alleleSymbolFieldSet,
+			FIELD_SETS.alleleNameFieldSet,
+			FIELD_SETS.alleleSynonymsFieldSet,
+			FIELD_SETS.alleleSecondaryIdsFieldSet,
+			FIELD_SETS.agmNameFieldSet,
+			FIELD_SETS.agmSynonymsFieldSet,
+			FIELD_SETS.agmSecondaryIdsFieldSet,
+		],
+	},
+	assertedGenesAutocompleteConfig: {
+		fieldSets: [
+			FIELD_SETS.curieFieldSet,
+			FIELD_SETS.primaryExternalIdFieldSet,
+			FIELD_SETS.modInternalIdFieldSet,
+			FIELD_SETS.crossReferencesFieldSet,
+			FIELD_SETS.nameFieldSet,
+			FIELD_SETS.symbolFieldSet,
+			FIELD_SETS.synonymsFieldSet,
+		],
+	},
+	referenceAutocompleteConfig: {
+		fieldSets: [FIELD_SETS.curieFieldSet, FIELD_SETS.literatureCrossReferenceFieldSet],
+	},
+	ontologyTermAutocompleteConfig: {
+		fieldSets: [
+			FIELD_SETS.curieFieldSet,
+			FIELD_SETS.nameFieldSet,
+			FIELD_SETS.crossReferencesFieldSet,
+			FIELD_SETS.secondaryIdentifiersFieldSet,
+			FIELD_SETS.ontologySynonymsFieldSet,
+		],
+	},
+	evidenceCodeAutocompleteConfig: {
+		fieldSets: [FIELD_SETS.curieFieldSet, FIELD_SETS.nameFieldSet, FIELD_SETS.abbreviationFieldSet],
+	},
+	nameOnlyAutocompleteConfig: {
+		fieldSets: [FIELD_SETS.nameFieldSet],
+	},
+	experimentalConditionAutocompleteConfig: {
+		fieldSets: [FIELD_SETS.conditionRelationSummaryFieldSet],
+	},
+	experimentalConditionDetailedAutocompleteConfig: {
+		fieldSets: [
+			FIELD_SETS.conditionRelationSummaryFieldSet,
+			FIELD_SETS.conditionIdFieldSet,
+			FIELD_SETS.conditionClassFieldSet,
+			FIELD_SETS.conditionTaxonFieldSet,
+			FIELD_SETS.conditionGeneOntologyFieldSet,
+			FIELD_SETS.conditionChemicalFieldSet,
+			FIELD_SETS.conditionAnatomyFieldSet,
+		],
+	},
+	resourceDescriptorAutocompleteConfig: {
+		fieldSets: [FIELD_SETS.prefixFieldSet, FIELD_SETS.nameFieldSet],
+	},
+});
+
+export const getAutocompleteFields = (config) => Array.from(new Set(config.fieldSets.flatMap((fs) => fs.fields)));

--- a/src/main/cliapp/src/containers/affectedGenomicModelPage/AffectedGenomicModelTable.jsx
+++ b/src/main/cliapp/src/containers/affectedGenomicModelPage/AffectedGenomicModelTable.jsx
@@ -85,14 +85,14 @@ export const AffectedGenomicModelTable = () => {
 				header: 'Primary External ID',
 				body: (rowData) => <IdTemplate id={rowData.primaryExternalId} />,
 				sortable: true,
-				filterConfig: FILTER_CONFIGS.primaryexternalidFilterConfig,
+				filterConfig: FILTER_CONFIGS.primaryExternalIdFilterConfig,
 			},
 			{
 				field: 'modInternalId',
 				header: 'MOD Internal ID',
 				body: (rowData) => <IdTemplate id={rowData.modInternalId} />,
 				sortable: true,
-				filterConfig: FILTER_CONFIGS.modinternalidFilterConfig,
+				filterConfig: FILTER_CONFIGS.modInternalIdFilterConfig,
 			},
 			{
 				field: 'agmFullName.displayText',
@@ -192,7 +192,7 @@ export const AffectedGenomicModelTable = () => {
 				sortable: true,
 				filter: true,
 				body: (rowData) => <StringTemplate string={rowData.dateCreated} />,
-				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+				filterConfig: FILTER_CONFIGS.dateCreatedFilterConfig,
 			},
 			{
 				field: 'internal',

--- a/src/main/cliapp/src/containers/allelesPage/AllelesTable.jsx
+++ b/src/main/cliapp/src/containers/allelesPage/AllelesTable.jsx
@@ -436,14 +436,14 @@ export const AllelesTable = () => {
 				header: 'Primary External ID',
 				body: (rowData) => <IdTemplate id={rowData.primaryExternalId} />,
 				sortable: true,
-				filterConfig: FILTER_CONFIGS.primaryexternalidFilterConfig,
+				filterConfig: FILTER_CONFIGS.primaryExternalIdFilterConfig,
 			},
 			{
 				field: 'modInternalId',
 				header: 'MOD Internal ID',
 				body: (rowData) => <IdTemplate id={rowData.modInternalId} />,
 				sortable: true,
-				filterConfig: FILTER_CONFIGS.modinternalidFilterConfig,
+				filterConfig: FILTER_CONFIGS.modInternalIdFilterConfig,
 			},
 			{
 				field: 'alleleFullName',
@@ -838,7 +838,7 @@ export const AllelesTable = () => {
 				sortable: true,
 				filter: true,
 				body: (rowData) => <StringTemplate string={rowData.dateCreated} />,
-				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+				filterConfig: FILTER_CONFIGS.dateCreatedFilterConfig,
 			},
 			{
 				field: 'internal',

--- a/src/main/cliapp/src/containers/conditionRelationPage/NewRelationForm.jsx
+++ b/src/main/cliapp/src/containers/conditionRelationPage/NewRelationForm.jsx
@@ -13,6 +13,7 @@ import { FormErrorMessageComponent } from '../../components/Error/FormErrorMessa
 import { classNames } from 'primereact/utils';
 import { autocompleteSearch, buildAutocompleteFilter } from '../../utils/utils';
 import { Endpoints } from '../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../constants/FilterFields';
 import { AutocompleteMultiEditor } from '../../components/Editors/autocomplete/base/AutocompleteMultiEditor';
 import ErrorBoundary from '../../components/Error/ErrorBoundary';
 
@@ -93,7 +94,7 @@ export const NewRelationForm = ({
 	};
 
 	const referenceSearch = (event, setFiltered, setQuery) => {
-		const autocompleteFields = ['curie', 'cross_references.curie'];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.referenceAutocompleteConfig);
 		const endpoint = Endpoints.Document.LITERATURE_REFERENCE;
 		const filterName = 'curieFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
@@ -111,7 +112,7 @@ export const NewRelationForm = ({
 	};
 
 	const conditionSearch = (event, setFiltered, setInputValue) => {
-		const autocompleteFields = ['conditionSummary'];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.experimentalConditionAutocompleteConfig);
 		const endpoint = Endpoints.Annotation.EXPERIMENTAL_CONDITION;
 		const filterName = 'experimentalConditionFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);

--- a/src/main/cliapp/src/containers/constructsPage/ConstructsTable.jsx
+++ b/src/main/cliapp/src/containers/constructsPage/ConstructsTable.jsx
@@ -155,14 +155,14 @@ export const ConstructsTable = () => {
 				header: 'Primary External ID',
 				sortable: { isInEditMode },
 				body: (rowData) => <IdTemplate id={rowData.primaryExternalId} />,
-				filterConfig: FILTER_CONFIGS.primaryexternalidFilterConfig,
+				filterConfig: FILTER_CONFIGS.primaryExternalIdFilterConfig,
 			},
 			{
 				field: 'modInternalId',
 				header: 'MOD Internal ID',
 				sortable: { isInEditMode },
 				body: (rowData) => <IdTemplate id={rowData.modInternalId} />,
-				filterConfig: FILTER_CONFIGS.modinternalidFilterConfig,
+				filterConfig: FILTER_CONFIGS.modInternalIdFilterConfig,
 			},
 			{
 				field: 'constructSymbol.displayText',
@@ -212,7 +212,7 @@ export const ConstructsTable = () => {
 				field: 'secondaryIdentifiers',
 				header: 'Secondary IDs',
 				sortable: true,
-				filterConfig: FILTER_CONFIGS.secondaryIdsFilterConfig,
+				filterConfig: FILTER_CONFIGS.secondaryIdentifiersFilterConfig,
 				body: (rowData) => <StringListTemplate list={rowData.secondaryIdentifiers} />,
 			},
 			{
@@ -291,7 +291,7 @@ export const ConstructsTable = () => {
 				sortable: { isInEditMode },
 				filter: true,
 				body: (rowData) => <StringTemplate string={rowData.dateCreated} />,
-				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+				filterConfig: FILTER_CONFIGS.dateCreatedFilterConfig,
 			},
 			{
 				field: 'internal',

--- a/src/main/cliapp/src/containers/controlledVocabularyPage/ControlledVocabularyTable.jsx
+++ b/src/main/cliapp/src/containers/controlledVocabularyPage/ControlledVocabularyTable.jsx
@@ -209,7 +209,7 @@ export const ControlledVocabularyTable = () => {
 				sortable: true,
 				filter: true,
 				body: (rowData) => <StringTemplate string={rowData.dateCreated} />,
-				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+				filterConfig: FILTER_CONFIGS.dateCreatedFilterConfig,
 			},
 			{
 				field: 'obsolete',

--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/ConditionRelationsForm.jsx
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/ConditionRelationsForm.jsx
@@ -12,6 +12,7 @@ import { ExConAutocompleteTemplate } from '../../components/Editors/autocomplete
 import { AutocompleteMultiEditor } from '../../components/Editors/autocomplete/base/AutocompleteMultiEditor';
 import { autocompleteSearch, buildAutocompleteFilter } from '../../utils/utils';
 import { Endpoints } from '../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../constants/FilterFields';
 
 export const ConditionRelationsForm = ({
 	dispatch,
@@ -79,7 +80,7 @@ export const ConditionRelationsForm = ({
 	};
 
 	const conditionSearch = (event, setFiltered, setInputValue) => {
-		const autocompleteFields = ['conditionSummary'];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.experimentalConditionAutocompleteConfig);
 		const endpoint = Endpoints.Annotation.EXPERIMENTAL_CONDITION;
 		const filterName = 'conditionSummaryFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);

--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/DiseaseAnnotationsTable.jsx
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/DiseaseAnnotationsTable.jsx
@@ -233,14 +233,14 @@ export const DiseaseAnnotationsTable = () => {
 				header: 'MOD Annotation ID',
 				body: (rowData) => <IdTemplate id={rowData.primaryExternalId} />,
 				sortable: true,
-				filterConfig: FILTER_CONFIGS.primaryexternalidFilterConfig,
+				filterConfig: FILTER_CONFIGS.primaryExternalIdFilterConfig,
 			},
 			{
 				field: 'modInternalId',
 				header: 'MOD Internal ID',
 				body: (rowData) => <IdTemplate id={rowData.modInternalId} />,
 				sortable: true,
-				filterConfig: FILTER_CONFIGS.modinternalidFilterConfig,
+				filterConfig: FILTER_CONFIGS.modInternalIdFilterConfig,
 			},
 			{
 				field: 'diseaseAnnotationSubject',
@@ -625,7 +625,7 @@ export const DiseaseAnnotationsTable = () => {
 				header: 'Date Created',
 				sortable: true,
 				body: (rowData) => <StringTemplate string={rowData.dateCreated} />,
-				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+				filterConfig: FILTER_CONFIGS.dateCreatedFilterConfig,
 			},
 			{
 				field: 'internal',

--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/NewAnnotationForm.jsx
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/NewAnnotationForm.jsx
@@ -45,6 +45,7 @@ import { getDefaultFormState, getModFormFields } from '../../service/TableStateS
 import { useGetUserSettings } from '../../service/useGetUserSettings';
 import { useVocabularyTermSetService } from '../../service/useVocabularyTermSetService';
 import { Endpoints } from '../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../constants/FilterFields';
 
 export const NewAnnotationForm = ({
 	newAnnotationState,
@@ -224,7 +225,7 @@ export const NewAnnotationForm = ({
 	};
 
 	const referenceSearch = (event, setFiltered, setQuery) => {
-		const autocompleteFields = ['curie', 'cross_references.curie'];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.referenceAutocompleteConfig);
 		const endpoint = Endpoints.Document.LITERATURE_REFERENCE;
 		const filterName = 'curieFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
@@ -233,13 +234,7 @@ export const NewAnnotationForm = ({
 	};
 
 	const sgdStrainBackgroundSearch = (event, setFiltered, setQuery) => {
-		const autocompleteFields = [
-			'name',
-			'curie',
-			'primaryExternalId',
-			'modInternalId',
-			'crossReferences.referencedCurie',
-		];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig);
 		const endpoint = Endpoints.Entity.AGM;
 		const filterName = 'sgdStrainBackgroundFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
@@ -255,13 +250,7 @@ export const NewAnnotationForm = ({
 	};
 
 	const geneticModifierAgmsSearch = (event, setFiltered, setQuery) => {
-		const autocompleteFields = [
-			'primaryExternalId',
-			'modInternalId',
-			'name',
-			'curie',
-			'crossReferences.referencedCurie',
-		];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig);
 		const endpoint = Endpoints.Entity.AGM;
 		const filterName = 'geneticModifierAgmsFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
@@ -270,16 +259,7 @@ export const NewAnnotationForm = ({
 	};
 
 	const geneticModifierAllelesSearch = (event, setFiltered, setQuery) => {
-		const autocompleteFields = [
-			'alleleSymbol.displayText',
-			'alleleFullName.displayText',
-			'primaryExternalId',
-			'modInternalId',
-			'curie',
-			'crossReferences.referencedCurie',
-			'alleleSecondaryIds.secondaryId',
-			'alleleSynonyms.displayText',
-		];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig);
 		const endpoint = Endpoints.Entity.ALLELE;
 		const filterName = 'geneticModifierAllelesFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
@@ -288,15 +268,7 @@ export const NewAnnotationForm = ({
 	};
 
 	const geneticModifierGenesSearch = (event, setFiltered, setQuery) => {
-		const autocompleteFields = [
-			'geneSymbol.displayText',
-			'geneFullName.displayText',
-			'primaryExternalId',
-			'modInternalId',
-			'curie',
-			'crossReferences.referencedCurie',
-			'geneSynonyms.displayText',
-		];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig);
 		const endpoint = Endpoints.Entity.GENE;
 		const filterName = 'geneticModifierGenesFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
@@ -344,32 +316,7 @@ export const NewAnnotationForm = ({
 	};
 
 	const subjectSearch = (event, setFiltered, setQuery) => {
-		//The order of the below fields are as per the Autocomplete search result
-		const autocompleteFields = [
-			'geneSymbol.formatText',
-			'alleleSymbol.formatText',
-			'agmFullName.formatText',
-			'geneFullName.formatText',
-			'alleleFullName.formatText',
-			'alleleSynonyms.formatText',
-			'geneSynonyms.formatText',
-			'agmSynonyms.formatText',
-			'geneSymbol.displayText',
-			'alleleSymbol.displayText',
-			'agmFullName.displayText',
-			'geneFullName.displayText',
-			'alleleFullName.displayText',
-			'alleleSynonyms.displayText',
-			'geneSynonyms.displayText',
-			'agmSynonyms.displayText',
-			'primaryExternalId',
-			'modInternalId',
-			'curie',
-			'crossReferences.referencedCurie',
-			'alleleSecondaryIds.secondaryId',
-			'agmSecondaryIds.secondaryId',
-			'geneSecondaryIds.secondaryId',
-		];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.diseaseAnnotationSubjectAutocompleteConfig);
 		const endpoint = Endpoints.Entity.BIOLOGICAL_ENTITY;
 		const filterName = 'diseaseAnnotationSubjectFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
@@ -390,13 +337,7 @@ export const NewAnnotationForm = ({
 	};
 
 	const diseaseSearch = (event, setFiltered, setQuery) => {
-		const autocompleteFields = [
-			'curie',
-			'name',
-			'crossReferences.referencedCurie',
-			'secondaryIdentifiers',
-			'synonyms.name',
-		];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.ontologyTermAutocompleteConfig);
 		const endpoint = Endpoints.Ontology.DO;
 		const filterName = 'diseaseFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
@@ -448,7 +389,7 @@ export const NewAnnotationForm = ({
 		return newAnnotation.conditionRelations?.[0] && newAnnotation.conditionRelations?.[0].handle;
 	};
 	const evidenceSearch = (event, setFiltered, setInputValue) => {
-		const autocompleteFields = ['curie', 'name', 'abbreviation'];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.evidenceCodeAutocompleteConfig);
 		const endpoint = Endpoints.Ontology.ECO;
 		const filterName = 'evidenceFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
@@ -465,15 +406,7 @@ export const NewAnnotationForm = ({
 	};
 
 	const withSearch = (event, setFiltered, setInputValue) => {
-		const autocompleteFields = [
-			'geneSymbol.displayText',
-			'geneFullName.displayText',
-			'primaryExternalId',
-			'modInternalId',
-			'curie',
-			'crossReferences.referencedCurie',
-			'geneSynonyms.displayText',
-		];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig);
 		const endpoint = Endpoints.Entity.GENE;
 		const filterName = 'withFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
@@ -518,15 +451,7 @@ export const NewAnnotationForm = ({
 	);
 
 	const assertedGenesSearch = (event, setFiltered, setInputValue) => {
-		const autocompleteFields = [
-			'geneSymbol.displayText',
-			'geneFullName.displayText',
-			'primaryExternalId',
-			'modInternalId',
-			'curie',
-			'crossReferences.referencedCurie',
-			'geneSynonyms.displayText',
-		];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.assertedGenesAutocompleteConfig);
 		const endpoint = Endpoints.Entity.GENE;
 		const filterName = 'assertedGenesFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
@@ -535,16 +460,7 @@ export const NewAnnotationForm = ({
 	};
 
 	const assertedAllelesSearch = (event, setFiltered, setInputValue) => {
-		const autocompleteFields = [
-			'alleleSymbol.displayText',
-			'alleleFullName.displayText',
-			'primaryExternalId',
-			'modInternalId',
-			'curie',
-			'crossReferences.referencedCurie',
-			'alleleSecondaryIds.secondaryId',
-			'alleleSynonyms.displayText',
-		];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig);
 		const endpoint = Endpoints.Entity.ALLELE;
 		const filterName = 'assertedAllelesFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.jsx
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/ExperimentalConditionsTable.jsx
@@ -8,7 +8,7 @@ import { ConditionChemicalTableEditor } from '../../components/Editors/autocompl
 import { ConditionAnatomyTableEditor } from '../../components/Editors/autocomplete/ontology/ConditionAnatomyTableEditor';
 import { ConditionTaxonTableEditor } from '../../components/Editors/autocomplete/ontology/ConditionTaxonTableEditor';
 import { BooleanTableEditor } from '../../components/Editors/dropdown/boolean/BooleanTableEditor';
-import { curieAutocompleteFields } from '../../components/Editors/autocomplete/ontology/utils';
+import { ontologyTermAutocompleteFields } from '../../components/Editors/autocomplete/ontology/utils';
 import { useMutation } from '@tanstack/react-query';
 import { Toast } from 'primereact/toast';
 import { SearchService } from '../../service/SearchService';
@@ -260,7 +260,7 @@ export const ExperimentalConditionsTable = () => {
 				setNewExperimentalCondition={(newExCon, queryClient) =>
 					setNewEntity(tableState, setExperimentalConditions, newExCon, queryClient)
 				}
-				curieAutocompleteFields={curieAutocompleteFields}
+				ontologyTermAutocompleteFields={ontologyTermAutocompleteFields}
 			/>
 		</div>
 	);

--- a/src/main/cliapp/src/containers/experimentalConditionsPage/NewConditionForm.jsx
+++ b/src/main/cliapp/src/containers/experimentalConditionsPage/NewConditionForm.jsx
@@ -20,7 +20,7 @@ export const NewConditionForm = ({
 	searchService,
 	experimentalConditionService,
 	setNewExperimentalCondition,
-	curieAutocompleteFields,
+	ontologyTermAutocompleteFields,
 }) => {
 	const toast_success = useRef(null);
 	const toast_error = useRef(null);
@@ -78,7 +78,7 @@ export const NewConditionForm = ({
 	const conditionClassSearch = (event, setFiltered, setQuery) => {
 		const endpoint = Endpoints.Ontology.ZECO;
 		const filterName = 'conditionClassEditorFilter';
-		const filter = buildAutocompleteFilter(event, curieAutocompleteFields);
+		const filter = buildAutocompleteFilter(event, ontologyTermAutocompleteFields);
 		const otherFilters = {
 			subsetFilter: {
 				subsets: {
@@ -93,7 +93,7 @@ export const NewConditionForm = ({
 	const conditionIdSearch = (event, setFiltered, setQuery) => {
 		const endpoint = Endpoints.Ontology.EXPERIMENTAL_CONDITION;
 		const filterName = 'singleOntologyFilter';
-		const filter = buildAutocompleteFilter(event, curieAutocompleteFields);
+		const filter = buildAutocompleteFilter(event, ontologyTermAutocompleteFields);
 		setQuery(event.query);
 		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered);
 	};
@@ -101,7 +101,7 @@ export const NewConditionForm = ({
 	const conditionGeneOntologySearch = (event, setFiltered, setQuery) => {
 		const endpoint = Endpoints.Ontology.GO;
 		const filterName = 'singleOntologyFilter';
-		const filter = buildAutocompleteFilter(event, curieAutocompleteFields);
+		const filter = buildAutocompleteFilter(event, ontologyTermAutocompleteFields);
 
 		setQuery(event.query);
 		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered);
@@ -110,7 +110,7 @@ export const NewConditionForm = ({
 	const conditionChemicalSearch = (event, setFiltered, setQuery) => {
 		const endpoint = Endpoints.Ontology.CHEMICAL;
 		const filterName = 'singleOntologyFilter';
-		const filter = buildAutocompleteFilter(event, curieAutocompleteFields);
+		const filter = buildAutocompleteFilter(event, ontologyTermAutocompleteFields);
 		setQuery(event.query);
 		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered);
 	};
@@ -118,7 +118,7 @@ export const NewConditionForm = ({
 	const conditionAnatomySearch = (event, setFiltered, setQuery) => {
 		const endpoint = Endpoints.Ontology.ANATOMICAL;
 		const filterName = 'singleOntologyFilter';
-		const filter = buildAutocompleteFilter(event, curieAutocompleteFields);
+		const filter = buildAutocompleteFilter(event, ontologyTermAutocompleteFields);
 		setQuery(event.query);
 		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered);
 	};
@@ -126,7 +126,7 @@ export const NewConditionForm = ({
 	const conditionTaxonSearch = (event, setFiltered, setQuery) => {
 		const endpoint = Endpoints.Ontology.NCBI_TAXON;
 		const filterName = 'singleOntologyFilter';
-		const filter = buildAutocompleteFilter(event, curieAutocompleteFields);
+		const filter = buildAutocompleteFilter(event, ontologyTermAutocompleteFields);
 		setQuery(event.query);
 		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered);
 	};

--- a/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/GeneExpressionAnnotationsTable.jsx
+++ b/src/main/cliapp/src/containers/geneExpressionAnnotationsPage/GeneExpressionAnnotationsTable.jsx
@@ -259,7 +259,7 @@ export const GeneExpressionAnnotationsTable = () => {
 				header: 'Annotation Date Created',
 				body: (rowData) => <StringTemplate string={rowData.dateCreated} />,
 				sortable: true,
-				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+				filterConfig: FILTER_CONFIGS.dateCreatedFilterConfig,
 			},
 			{
 				field: 'updatedBy.uniqueId',

--- a/src/main/cliapp/src/containers/genesPage/GenesTable.jsx
+++ b/src/main/cliapp/src/containers/genesPage/GenesTable.jsx
@@ -208,14 +208,14 @@ export const GenesTable = () => {
 				header: 'Primary External ID',
 				sortable: true,
 				body: (rowData) => <IdTemplate id={rowData.primaryExternalId} />,
-				filterConfig: FILTER_CONFIGS.primaryexternalidFilterConfig,
+				filterConfig: FILTER_CONFIGS.primaryExternalIdFilterConfig,
 			},
 			{
 				field: 'modInternalId',
 				header: 'MOD Internal ID',
 				sortable: true,
 				body: (rowData) => <IdTemplate id={rowData.modInternalId} />,
-				filterConfig: FILTER_CONFIGS.modinternalidFilterConfig,
+				filterConfig: FILTER_CONFIGS.modInternalIdFilterConfig,
 			},
 			{
 				field: 'geneFullName.displayText',
@@ -364,7 +364,7 @@ export const GenesTable = () => {
 				sortable: true,
 				filter: true,
 				body: (rowData) => <StringTemplate string={rowData.dateCreated} />,
-				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+				filterConfig: FILTER_CONFIGS.dateCreatedFilterConfig,
 			},
 			{
 				field: 'internal',

--- a/src/main/cliapp/src/containers/genomeAssemblyPage/GenomeAssembliesTable.jsx
+++ b/src/main/cliapp/src/containers/genomeAssemblyPage/GenomeAssembliesTable.jsx
@@ -55,14 +55,14 @@ export const GenomeAssembliesTable = () => {
 				header: 'Primary External ID',
 				sortable: true,
 				body: (rowData) => <IdTemplate id={rowData.primaryExternalId} />,
-				filterConfig: FILTER_CONFIGS.primaryexternalidFilterConfig,
+				filterConfig: FILTER_CONFIGS.primaryExternalIdFilterConfig,
 			},
 			{
 				field: 'modInternalId',
 				header: 'MOD Internal ID',
 				sortable: true,
 				body: (rowData) => <IdTemplate id={rowData.modInternalId} />,
-				filterConfig: FILTER_CONFIGS.modinternalidFilterConfig,
+				filterConfig: FILTER_CONFIGS.modInternalIdFilterConfig,
 			},
 			{
 				field: 'taxon.name',

--- a/src/main/cliapp/src/containers/genomeAssemblyPage/GenomeAssembliesTable.jsx
+++ b/src/main/cliapp/src/containers/genomeAssemblyPage/GenomeAssembliesTable.jsx
@@ -126,7 +126,7 @@ export const GenomeAssembliesTable = () => {
 				header: 'Date Created',
 				sortable: true,
 				body: (rowData) => <StringTemplate string={rowData.dateCreated} />,
-				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+				filterConfig: FILTER_CONFIGS.dateCreatedFilterConfig,
 			},
 			{
 				field: 'internal',

--- a/src/main/cliapp/src/containers/ontologies/GeneralOntologyComponent.jsx
+++ b/src/main/cliapp/src/containers/ontologies/GeneralOntologyComponent.jsx
@@ -90,7 +90,7 @@ export const GeneralOntologyComponent = ({ name, endpoint, showNamespace, showAb
 		header: 'Secondary IDs',
 		sortable: true,
 		body: (rowData) => <StringListTemplate list={rowData.secondaryIdentifiers} />,
-		filterConfig: FILTER_CONFIGS.secondaryIdsFilterConfig,
+		filterConfig: FILTER_CONFIGS.secondaryIdentifiersFilterConfig,
 	});
 	columns.push({
 		field: 'obsolete',

--- a/src/main/cliapp/src/containers/phenotypeAnnotationsPage/PhenotypeAnnotationsTable.jsx
+++ b/src/main/cliapp/src/containers/phenotypeAnnotationsPage/PhenotypeAnnotationsTable.jsx
@@ -170,7 +170,7 @@ export const PhenotypeAnnotationsTable = () => {
 				field: 'dateCreated',
 				header: 'Date Created',
 				sortable: true,
-				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+				filterConfig: FILTER_CONFIGS.dateCreatedFilterConfig,
 			},
 			{
 				field: 'internal',

--- a/src/main/cliapp/src/containers/resourceDescriptorPage/ResourceDescriptorsTable.jsx
+++ b/src/main/cliapp/src/containers/resourceDescriptorPage/ResourceDescriptorsTable.jsx
@@ -150,7 +150,7 @@ export const ResourceDescriptorsTable = () => {
 				sortable: true,
 				filter: true,
 				body: (rowData) => <StringTemplate string={rowData.dateCreated} />,
-				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+				filterConfig: FILTER_CONFIGS.dateCreatedFilterConfig,
 			},
 			{
 				field: 'updatedBy.uniqueId',

--- a/src/main/cliapp/src/containers/resourceDescriptorPagePage/ResourceDescriptorPagesTable.jsx
+++ b/src/main/cliapp/src/containers/resourceDescriptorPagePage/ResourceDescriptorPagesTable.jsx
@@ -128,7 +128,7 @@ export const ResourceDescriptorPagesTable = () => {
 				sortable: true,
 				filter: true,
 				body: (rowData) => <StringTemplate string={rowData.dateCreated} />,
-				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+				filterConfig: FILTER_CONFIGS.dateCreatedFilterConfig,
 			},
 			{
 				field: 'updatedBy.uniqueId',

--- a/src/main/cliapp/src/containers/variantsPage/VariantsTable.jsx
+++ b/src/main/cliapp/src/containers/variantsPage/VariantsTable.jsx
@@ -104,14 +104,14 @@ export const VariantsTable = () => {
 				header: 'Primary External ID',
 				sortable: true,
 				body: (rowData) => <IdTemplate id={rowData.primaryExternalId} />,
-				filterConfig: FILTER_CONFIGS.primaryexternalidFilterConfig,
+				filterConfig: FILTER_CONFIGS.primaryExternalIdFilterConfig,
 			},
 			{
 				field: 'modInternalId',
 				header: 'MOD Internal ID',
 				sortable: true,
 				body: (rowData) => <IdTemplate id={rowData.modInternalId} />,
-				filterConfig: FILTER_CONFIGS.modinternalidFilterConfig,
+				filterConfig: FILTER_CONFIGS.modInternalIdFilterConfig,
 			},
 			{
 				field: 'taxon',
@@ -246,7 +246,7 @@ export const VariantsTable = () => {
 				sortable: true,
 				filter: true,
 				body: (rowData) => <StringTemplate string={rowData.dateCreated} />,
-				filterConfig: FILTER_CONFIGS.dataCreatedFilterConfig,
+				filterConfig: FILTER_CONFIGS.dateCreatedFilterConfig,
 			},
 			{
 				field: 'internal',

--- a/src/main/cliapp/src/containers/vocabularyTermSetPage/NewVocabularyTermSetForm.jsx
+++ b/src/main/cliapp/src/containers/vocabularyTermSetPage/NewVocabularyTermSetForm.jsx
@@ -12,6 +12,7 @@ import { AutocompleteMultiEditor } from '../../components/Editors/autocomplete/b
 import { AutocompleteEditor } from '../../components/Editors/autocomplete/base/AutocompleteEditor';
 import { autocompleteSearch, buildAutocompleteFilter } from '../../utils/utils';
 import { Endpoints } from '../../constants/Endpoints';
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../constants/FilterFields';
 import ErrorBoundary from '../../components/Error/ErrorBoundary';
 
 export const NewVocabularyTermSetForm = ({
@@ -96,7 +97,7 @@ export const NewVocabularyTermSetForm = ({
 		});
 	};
 	const vocabularySearch = (event, setFiltered, setQuery) => {
-		const autocompleteFields = ['name'];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.nameOnlyAutocompleteConfig);
 		const endpoint = Endpoints.Vocabulary.VOCABULARY;
 		const filterName = 'vocabularyFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
@@ -115,7 +116,7 @@ export const NewVocabularyTermSetForm = ({
 	};
 
 	const memberTermSearch = (event, setFiltered, setInputValue, props) => {
-		const autocompleteFields = ['name'];
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.nameOnlyAutocompleteConfig);
 		const endpoint = Endpoints.Vocabulary.TERM;
 		const filterName = 'memberTermsFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);

--- a/src/main/cliapp/src/utils/__tests__/utils.test.js
+++ b/src/main/cliapp/src/utils/__tests__/utils.test.js
@@ -19,7 +19,7 @@ describe('removeInvalidFilters', () => {
 					tokenOperator: 'OR',
 				},
 			},
-			primaryexternalidFilter: {
+			primaryExternalIdFilter: {
 				primaryExternalId: {
 					queryString: 's',
 					tokenOperator: 'AND',
@@ -48,7 +48,7 @@ describe('removeInvalidFilters', () => {
 					tokenOperator: 'OR',
 				},
 			},
-			primaryexternalidFilter: {
+			primaryExternalIdFilter: {
 				primaryExternalId: {
 					queryString: 's',
 					tokenOperator: 'AND',
@@ -71,7 +71,7 @@ describe('removeInvalidFilters', () => {
 					tokenOperator: 'OR',
 				},
 			},
-			primaryexternalidFilter: {
+			primaryExternalIdFilter: {
 				primaryExternalId: {
 					queryString: 's',
 					tokenOperator: 'AND',
@@ -98,7 +98,7 @@ describe('removeInvalidFilters', () => {
 					tokenOperator: 'OR',
 				},
 			},
-			primaryexternalidFilter: {
+			primaryExternalIdFilter: {
 				invalidPrimaryExternalId: {
 					queryString: 's',
 					tokenOperator: 'AND',


### PR DESCRIPTION
  Extract `autocompleteFields` arrays from 30+ call sites into a new
  `AUTOCOMPLETE_CONFIGS` registry in `FilterFields.js`, composed from
  existing `FIELD_SETS`.

  Use `BiologicalEntityTypeBridge`'s denormalized fields
  (`name`/`symbol`/`synonyms`/`secondaryIds`) to collapse the
  per-entity-type configs into a single `biologicalEntityAutocompleteConfig`.
  Type-scoped endpoints prevent cross-type noise; the abstract-class
  subject picker keeps a separate `diseaseAnnotationSubjectAutocompleteConfig`
  to scope to Gene/Allele/AGM.

  Also clean up a handful of pre-existing typos/casing inconsistencies
  encountered along the way (dataCreated → dateCreated,
  primaryexternalid → primaryExternalId, etc.).