### PR TITLE
SCRUM-5419 fix Internal dropdown and RD autocomplete in New dialogs

### DIFF
--- a/src/main/cliapp/src/containers/resourceDescriptorPage/NewResourceDescriptorForm.jsx
+++ b/src/main/cliapp/src/containers/resourceDescriptorPage/NewResourceDescriptorForm.jsx
@@ -68,9 +68,8 @@ export const NewResourceDescriptorForm = ({
 	};
 
 	const onInternalChange = (value) => {
-		if (value === undefined || value === null || value === '') return;
-		const parsed = typeof value === 'string' ? JSON.parse(value) : value;
-		setResourceDescriptor((prev) => ({ ...prev, internal: parsed }));
+		if (value === undefined || value === null) return;
+		setResourceDescriptor((prev) => ({ ...prev, internal: value }));
 	};
 
 	const hideDialog = () => {
@@ -224,11 +223,7 @@ export const NewResourceDescriptorForm = ({
 						<label htmlFor="internal">Internal</label>
 						<Dropdown
 							id="internal"
-							value={
-								resourceDescriptor.internal === null || resourceDescriptor.internal === undefined
-									? null
-									: String(resourceDescriptor.internal)
-							}
+							value={resourceDescriptor.internal}
 							options={booleanTerms?.terms || []}
 							optionLabel="text"
 							optionValue="name"

--- a/src/main/cliapp/src/containers/resourceDescriptorPagePage/NewResourceDescriptorPageForm.jsx
+++ b/src/main/cliapp/src/containers/resourceDescriptorPagePage/NewResourceDescriptorPageForm.jsx
@@ -55,15 +55,12 @@ export const NewResourceDescriptorPageForm = ({
 	};
 
 	const onResourceDescriptorChange = (event) => {
-		const value = event.target?.value;
-		const resolved = value && typeof value === 'object' ? value : null;
-		setResourceDescriptorPage((prev) => ({ ...prev, resourceDescriptor: resolved }));
+		setResourceDescriptorPage((prev) => ({ ...prev, resourceDescriptor: event.target?.value }));
 	};
 
 	const onInternalChange = (value) => {
-		if (value === undefined || value === null || value === '') return;
-		const parsed = typeof value === 'string' ? JSON.parse(value) : value;
-		setResourceDescriptorPage((prev) => ({ ...prev, internal: parsed }));
+		if (value === undefined || value === null) return;
+		setResourceDescriptorPage((prev) => ({ ...prev, internal: value }));
 	};
 
 	const hideDialog = () => {
@@ -213,11 +210,7 @@ export const NewResourceDescriptorPageForm = ({
 						<label htmlFor="internal">Internal</label>
 						<Dropdown
 							id="internal"
-							value={
-								resourceDescriptorPage.internal === null || resourceDescriptorPage.internal === undefined
-									? null
-									: String(resourceDescriptorPage.internal)
-							}
+							value={resourceDescriptorPage.internal}
 							options={booleanTerms?.terms || []}
 							optionLabel="text"
 							optionValue="name"


### PR DESCRIPTION
  - Bind the Internal dropdown directly to state (drop the String/ JSON.parse coercion) so it displays and accepts selections again.
  - Store the AutoComplete's onChange value as-is so typed input persists while searching; the submit guard still requires a selected object.