### PR TITLE
Fix NCBITaxonTerm and Construct mass indexing failures

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
@@ -108,7 +108,7 @@ public class Species extends AuditedObject {
 	@IndexedEmbedded(includePaths = {"curie", "curie_keyword", "primaryExternalId", "primaryExternalId_keyword"})
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
-	@Fetch(FetchMode.JOIN)
+	@Fetch(FetchMode.SELECT)
 	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class })
 	private GenomeAssembly genomeAssembly;
 }


### PR DESCRIPTION
## Summary
- Change `@Fetch(FetchMode.JOIN)` to `@Fetch(FetchMode.SELECT)` on `Species.genomeAssembly` to fix a circular JOIN chain introduced in SCRUM-6081
- The JOIN fetch caused Hibernate to create a circular query path (`NCBITaxonTerm → Species → GenomeAssembly → BiologicalEntity → NCBITaxonTerm`) during entity loading
- This resulted in `NullPointerException` ("loadedState" is null) for all 1,737 NCBITaxonTerm entities and ~110K Construct entities during mass indexing

## Test plan
- [ ] Deploy to beta and trigger NCBITaxonTerm reindex — should index all 1,737 records successfully
- [ ] Trigger Construct reindex — should index all 236,683 records without errors
- [ ] Trigger full mass reindex — all entity types should complete without HSEARCH errors
- [ ] Verify Species pages still load correctly in the UI (genomeAssembly field should still display)

🤖 Generated with [Claude Code](https://claude.com/claude-code)