### PR TITLE
SCRUM-6121: add ResourceDescriptor document endpoint

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/controllers/document/ResourceDescriptorDocumentController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/document/ResourceDescriptorDocumentController.java
@@ -1,0 +1,18 @@
+package org.alliancegenome.curation_api.controllers.document;
+
+import org.alliancegenome.curation_api.dao.ResourceDescriptorDAO;
+import org.alliancegenome.curation_api.interfaces.document.ResourceDescriptorDocumentInterface;
+import org.alliancegenome.curation_api.model.entities.ResourceDescriptor;
+import org.alliancegenome.curation_api.response.SearchResponse;
+
+import jakarta.inject.Inject;
+
+public class ResourceDescriptorDocumentController implements ResourceDescriptorDocumentInterface {
+
+	@Inject ResourceDescriptorDAO resourceDescriptorDAO;
+
+	@Override
+	public SearchResponse<ResourceDescriptor> findAll() {
+		return resourceDescriptorDAO.findAllWithPages();
+	}
+}

--- a/src/main/java/org/alliancegenome/curation_api/dao/ResourceDescriptorDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/ResourceDescriptorDAO.java
@@ -15,13 +15,36 @@ public class ResourceDescriptorDAO extends BaseSQLDAO<ResourceDescriptor> {
 	protected ResourceDescriptorDAO() {
 		super(ResourceDescriptor.class);
 	}
-	
+
 	public List<String> findAllNames() {
 		SearchResponse<ResourceDescriptor> response = findAll();
 		List<ResourceDescriptor> resourceDescriptors = response.getResults();
 		List<String> resourceDescriptorNames = resourceDescriptors.stream().map(ResourceDescriptor::getName).collect(Collectors.toList());
-		
+
 		return resourceDescriptorNames;
 	}
-	
+
+	public SearchResponse<ResourceDescriptor> findAllWithPages() {
+		List<ResourceDescriptor> results = entityManager
+			.createQuery(
+				"SELECT DISTINCT rd FROM ResourceDescriptor rd "
+					+ "LEFT JOIN FETCH rd.resourcePages "
+					+ "WHERE rd.internal = false AND rd.obsolete = false "
+					+ "ORDER BY rd.id",
+				ResourceDescriptor.class)
+			.getResultList();
+		// Filter obsolete/internal pages here rather than in JPQL — Hibernate 6
+		// rejects WITH on fetch joins. The ResourceDescriptorDocument view does not
+		// expose internal/obsolete on pages, so consumers cannot filter downstream.
+		for (ResourceDescriptor descriptor : results) {
+			if (descriptor.getResourcePages() != null) {
+				descriptor.getResourcePages().removeIf(page ->
+					Boolean.TRUE.equals(page.getInternal()) || Boolean.TRUE.equals(page.getObsolete()));
+			}
+		}
+		SearchResponse<ResourceDescriptor> response = new SearchResponse<>(results);
+		response.setTotalResults((long) results.size());
+		return response;
+	}
+
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/document/ResourceDescriptorDocumentInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/document/ResourceDescriptorDocumentInterface.java
@@ -1,0 +1,26 @@
+package org.alliancegenome.curation_api.interfaces.document;
+
+import org.alliancegenome.curation_api.model.entities.ResourceDescriptor;
+import org.alliancegenome.curation_api.response.SearchResponse;
+import org.alliancegenome.curation_api.view.CurationView;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/resourcedescriptor/document")
+@Tag(name = "Public Document Endpoints")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface ResourceDescriptorDocumentInterface {
+
+	@GET
+	@Path("/all")
+	@JsonView(CurationView.ResourceDescriptorDocument.class)
+	SearchResponse<ResourceDescriptor> findAll();
+}

--- a/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneExpressionDocument.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/es/GeneExpressionDocument.java
@@ -2,14 +2,16 @@ package org.alliancegenome.curation_api.model.document.es;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 
+import org.alliancegenome.curation_api.model.entities.CrossReference;
 import org.alliancegenome.curation_api.model.entities.GeneExpressionAnnotation;
 import org.alliancegenome.curation_api.view.CurationView;
 
 import com.fasterxml.jackson.annotation.JsonView;
 
-import groovy.transform.EqualsAndHashCode;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -20,6 +22,7 @@ public class GeneExpressionDocument extends ESDocument {
 	}
 	private GeneExpressionAnnotation geneExpressionAnnotation;
 	private List<String> referenceId;
+	private Set<CrossReference> referenceXrefs;
 	private List<String> uberonTermIds;
 	private List<String> goTermIds;
 	private List<String> termIds;

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ResourceDescriptor.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ResourceDescriptor.java
@@ -48,7 +48,7 @@ public class ResourceDescriptor extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "prefix_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.TransgenicAllelesDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.TransgenicAllelesDocument.class, CurationView.ResourceDescriptorDocument.class })
 	@Column(unique = true, nullable = false)
 	@EqualsAndHashCode.Include
 	protected String prefix;
@@ -64,7 +64,7 @@ public class ResourceDescriptor extends AuditedObject {
 	@ElementCollection
 	@JoinTable(indexes = @Index(columnList = "resourcedescriptor_id"))
 	@Fetch(FetchMode.JOIN)
-	@JsonView({ CurationView.ResourceDescriptorView.class, CurationView.FieldsAndLists.class })
+	@JsonView({ CurationView.ResourceDescriptorView.class, CurationView.FieldsAndLists.class, CurationView.ResourceDescriptorDocument.class })
 	@Column(columnDefinition = "TEXT")
 	private List<String> synonyms;
 
@@ -82,13 +82,13 @@ public class ResourceDescriptor extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "defaultUrlTemplate_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.TransgenicAllelesDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.TransgenicAllelesDocument.class, CurationView.ResourceDescriptorDocument.class })
 	@EqualsAndHashCode.Include
 	private String defaultUrlTemplate;
 
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@OneToMany(mappedBy = "resourceDescriptor", cascade = CascadeType.ALL)
-	@JsonView({ CurationView.ResourceDescriptorView.class, CurationView.FieldsAndLists.class })
+	@JsonView({ CurationView.ResourceDescriptorView.class, CurationView.FieldsAndLists.class, CurationView.ResourceDescriptorDocument.class })
 	private List<ResourceDescriptorPage> resourcePages;
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ResourceDescriptorPage.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ResourceDescriptorPage.java
@@ -47,13 +47,13 @@ public class ResourceDescriptorPage extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "name_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ModelDocument.class, CurationView.TransgenicAllelesDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ModelDocument.class, CurationView.TransgenicAllelesDocument.class, CurationView.ResourceDescriptorDocument.class })
 	@EqualsAndHashCode.Include
 	private String name;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "urlTemplate_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.ModelDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.TransgenicAllelesDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.GeneExpressionDocument.class, CurationView.ModelDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.TransgenicAllelesDocument.class, CurationView.ResourceDescriptorDocument.class })
 	@EqualsAndHashCode.Include
 	private String urlTemplate;
 

--- a/src/main/java/org/alliancegenome/curation_api/response/SearchResponse.java
+++ b/src/main/java/org/alliancegenome/curation_api/response/SearchResponse.java
@@ -34,7 +34,8 @@ import lombok.Data;
 	CurationView.HTPDatasetSearchResultDocument.class,
 	CurationView.GeneExpressionDocument.class,
 	CurationView.TransgenicAllelesDocument.class,
-	CurationView.OntologyTermClosureView.class
+	CurationView.OntologyTermClosureView.class,
+	CurationView.ResourceDescriptorDocument.class
 })
 public class SearchResponse<E> extends APIResponse {
 

--- a/src/main/java/org/alliancegenome/curation_api/view/CurationView.java
+++ b/src/main/java/org/alliancegenome/curation_api/view/CurationView.java
@@ -166,6 +166,7 @@ public class CurationView {
 	public static class GeneExpressionDocument { }
 	public static class ModelDocument { }
 	public static class TransgenicAllelesDocument { }
+	public static class ResourceDescriptorDocument { }
 
 	public static Class<?> viewLookup(String name) {
 		for (Class<?> innerClass : CurationView.class.getDeclaredClasses()) {


### PR DESCRIPTION
GET /resourcedescriptor/document/all returns descriptors + pages under a dedicated JsonView, for indexer-side URL-template resolution. Also adds referenceXrefs to GeneExpressionDocument and fixes a groovy/lombok EqualsAndHashCode import.