### PR TITLE
release/v0.50.2: expose taxon.species.fullName on VariantSummaryDocument

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
@@ -63,7 +63,7 @@ public class Species extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "fullName_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class })
 	private String fullName;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java
@@ -26,7 +26,7 @@ import lombok.ToString;
 public class NCBITaxonTerm extends OntologyTerm {
 
 	@OneToOne(mappedBy = "taxon", cascade = CascadeType.ALL, orphanRemoval = true)
-	@JsonView({CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class})
+	@JsonView({CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class})
 	private Species species;
 
 }


### PR DESCRIPTION
## Summary

Adds `CurationView.VariantSummaryDocument.class` to the `@JsonView` on:
- `NCBITaxonTerm.species` (`src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java:29`)
- `Species.fullName` (`src/main/java/org/alliancegenome/curation_api/model/entities/Species.java:66`)

These two views are the gate that controls whether `variant_summary` ES docs include `allele.taxon.species.fullName`. Without them, the field is silently dropped from the indexed JSON.

## Why

The agr_file_generator VCF generator (PR alliance-genome/agr_java_software#1619) runs a per-MOD `multi_terms` aggregation over chrom + assembly + species to populate the `##contig=<ID=...,assembly=...,species=...>` header lines. The SCRUM-5964 rename moved `SPECIES_PATH` from `allele.taxon.name` to `allele.taxon.species.fullName`. Since `variant_summary` docs were never opted into that JsonView, the species field is missing from the indexed JSON and the multi_terms agg returns 0 buckets — contig header lines disappear from every generated VCF on prod.

Chris Grove flagged this in [SCRUM-6019](https://agr-jira.atlassian.net/browse/SCRUM-6019).

After this lands and the mass indexer reindexes, `allele.taxon.species.fullName` will be present on `variant_summary` docs and the VCF generator's contig pre-pass will populate properly.

## Test plan

- [x] Local compile clean
- [ ] After deploy: mass-reindex, then verify `_source.allele.taxon.species.fullName` populated on a sampled variant_summary doc
- [ ] Rerun file generator; confirm `##contig` lines appear in `VARIANT-CONSEQUENCE_VCF_*.vcf.gz`

[SCRUM-6019]: https://agr-jira.atlassian.net/browse/SCRUM-6019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ