### PR TITLE
release/v0.50.3: expose taxon.species.genomeAssembly on VariantSummaryDocument

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
@@ -109,6 +109,6 @@ public class Species extends AuditedObject {
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
 	@Fetch(FetchMode.SELECT)
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class })
 	private GenomeAssembly genomeAssembly;
 }


### PR DESCRIPTION
## Summary

Adds `CurationView.VariantSummaryDocument.class` to the `@JsonView` on `Species.genomeAssembly` (`src/main/java/org/alliancegenome/curation_api/model/entities/Species.java:112`).

Follows v0.50.2 (#2763), which exposed `taxon.species.fullName` to the same view. `GenomeAssembly.curie` is inherited from `CurieObject` and already includes `VariantSummaryDocument`, so this single annotation is all that's needed for `allele.taxon.species.genomeAssembly.curie` to land in the indexed JSON.

## Why

SCRUM-6081 replaced the Species `assembly_curie` free-text field with a `genomeAssembly` ManyToOne relation. The original `assembly_curie` was exposed in `{FieldsOnly, GeneSummaryDocument, AlleleSummaryDocument}`. The new relation carried over those same views — but consumers of the new variant_summary view (the file generator's VCF contig pre-pass and any other downstream consumer) still couldn't see the assembly info on `allele.taxon.species.genomeAssembly.curie`.

Once this lands and the mass indexer reindexes, variant_summary docs will carry both `species.fullName` (#2763) and `species.genomeAssembly.curie`.

## Test plan

- [x] Local compile clean
- [ ] After deploy: mass-reindex, sample a variant_summary doc to confirm `_source.allele.taxon.species.genomeAssembly.curie` populated
- [ ] Rerun file generator after the refresh script pulls the updated docs; confirm `##contig` lines appear in `VARIANT-CONSEQUENCE_VCF_*.vcf.gz`