### PR TITLE
release/v0.50.4: break taxon -> species -> genomeAssembly -> taxon JSON cycle

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
@@ -23,6 +23,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmb
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 
 import jakarta.persistence.ElementCollection;
@@ -110,5 +111,7 @@ public class Species extends AuditedObject {
 	@ManyToOne
 	@Fetch(FetchMode.SELECT)
 	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class })
+	// Break the species -> genomeAssembly -> taxon -> species cycle during JSON serialization: GenomeAssembly inherits taxon from BiologicalEntity, and BiologicalEntity.taxon is exposed in the same views as this field, so without this annotation Jackson loops until the stack overflows.
+	@JsonIgnoreProperties("taxon")
 	private GenomeAssembly genomeAssembly;
 }


### PR DESCRIPTION
## Summary

Adds `@JsonIgnoreProperties(\"taxon\")` to `Species.genomeAssembly` (`src/main/java/org/alliancegenome/curation_api/model/entities/Species.java:113`).

## Why

After v0.50.3 (#2766) opted `Species.genomeAssembly` into the `VariantSummaryDocument` JsonView, Jackson now sees a fully open cycle in that view:

`BiologicalEntity.taxon` -> `NCBITaxonTerm.species` -> `Species.genomeAssembly` -> `GenomeAssembly` (extends `BiologicalEntity`) -> `taxon` -> `NCBITaxonTerm.species` -> ...

All four hops carry `VariantSummaryDocument.class`, so the serializer recurses to a stack overflow. The same cycle exists for `GeneSummaryDocument` / `AlleleSummaryDocument` views but only manifested now because the variant_summary path is being exercised end-to-end.

`@JsonIgnoreProperties(\"taxon\")` on the forward reference tells Jackson to skip the back-pointer when walking the embedded `GenomeAssembly` via this `Species.genomeAssembly` path. The useful fields (`curie`, `primaryExternalId`, etc) still serialize, and other paths into `GenomeAssembly` (where the taxon back-ref is wanted) are unaffected.

## Test plan

- [x] Local compile clean
- [ ] After deploy: mass reindex completes without a `StackOverflowError`
- [ ] Sample a variant_summary doc: confirm `_source.allele.taxon.species.genomeAssembly.curie` populated and no `_source.allele.taxon.species.genomeAssembly.taxon` regression