### PR TITLE
SCRUM-6121 link CrossReference.resourceDescriptorPage at literature-s…

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/document/builders/GeneExpressionDocumentBuilder.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/document/builders/GeneExpressionDocumentBuilder.java
@@ -1,10 +1,13 @@
 package org.alliancegenome.curation_api.model.document.builders;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.alliancegenome.curation_api.constants.ReferenceConstants;
 import org.alliancegenome.curation_api.model.document.es.GeneExpressionDocument;
 import org.alliancegenome.curation_api.model.entities.AnatomicalSite;
 import org.alliancegenome.curation_api.model.entities.CrossReference;
@@ -31,7 +34,7 @@ public class GeneExpressionDocumentBuilder {
 	public static final String UBERON__POST_EMBRYONIC_PRE_ADULT = "PostEmbryonicPreAdult";
 
 	public static final String GO_CELLULAR_OTHER = "otherLocations";
-	
+
 	public GeneExpressionDocument buildDocument(GeneExpressionAnnotation annotation) {
 
 		List<String> uberonTermIds = new ArrayList<>();
@@ -97,6 +100,12 @@ public class GeneExpressionDocumentBuilder {
 		expressionDocument.setTermIds(termIds);
 		if (annotation.getEvidenceItem() != null && annotation.getEvidenceItem() instanceof Reference reference) {
 			expressionDocument.setReferenceId(List.of(reference.getReferenceID()));
+			CrossReference priorityXref = findPriorityReferenceXref(reference);
+			if (priorityXref != null) {
+				Set<CrossReference> xrefs = new LinkedHashSet<>();
+				xrefs.add(priorityXref);
+				expressionDocument.setReferenceXrefs(xrefs);
+			}
 		}
 		expressionDocument.setPhylogeneticSortingIndex(annotation.getExpressionAnnotationSubject().getTaxon().getSpecies().getPhylogeneticOrder());
 		
@@ -108,6 +117,34 @@ public class GeneExpressionDocumentBuilder {
 		}
 		return expressionDocument;
 
+	}
+
+	/**
+	 * Walk Reference.crossReferences in ReferenceConstants.primaryXrefOrder and return the
+	 * first matching CrossReference (carries pre-linked resourceDescriptorPage). Falls back
+	 * to a transient CrossReference wrapping the reference's own AGRKB curie when no
+	 * priority-prefixed xref is attached — matches Reference.getReferenceID() semantics.
+	 */
+	private CrossReference findPriorityReferenceXref(Reference reference) {
+		if (reference == null) {
+			return null;
+		}
+		if (CollectionUtils.isNotEmpty(reference.getCrossReferences())) {
+			for (String prefix : ReferenceConstants.primaryXrefOrder) {
+				for (CrossReference xref : reference.getCrossReferences()) {
+					if (xref.getReferencedCurie() != null && xref.getReferencedCurie().startsWith(prefix + ":")) {
+						return xref;
+					}
+				}
+			}
+		}
+		if (reference.getCurie() == null) {
+			return null;
+		}
+		CrossReference fallback = new CrossReference();
+		fallback.setReferencedCurie(reference.getCurie());
+		fallback.setDisplayName(reference.getCurie());
+		return fallback;
 	}
 
 	public List<GeneExpressionDocument> consolidateExpressionDocuments(List<GeneExpressionDocument> documents) {
@@ -133,10 +170,14 @@ public class GeneExpressionDocumentBuilder {
 
 				List<CrossReference> allCrossReferences = new ArrayList<>();
 				List<String> allReferenceIds = new ArrayList<>();
+				Set<CrossReference> allReferenceXrefs = new LinkedHashSet<>();
 
-				// logic behind this consolidation is to have 1:1 mapping for reference and crossReference for consolidated annotations, 
+				// logic behind this consolidation is to have 1:1 mapping for reference and crossReference for consolidated annotations,
 				// which is useful while deconsolidating later for download endpoint
 				for (GeneExpressionDocument doc : group) {
+					if (CollectionUtils.isNotEmpty(doc.getReferenceXrefs())) {
+						allReferenceXrefs.addAll(doc.getReferenceXrefs());
+					}
 					int annotationSize = Math.max(
 						CollectionUtils.isNotEmpty(doc.getGeneExpressionAnnotation().getCrossReferences()) ? doc.getGeneExpressionAnnotation().getCrossReferences().size() : 0,
 						CollectionUtils.isNotEmpty(doc.getReferenceId()) ? doc.getReferenceId().size() : 0
@@ -159,6 +200,9 @@ public class GeneExpressionDocumentBuilder {
 
 				consolidated.getGeneExpressionAnnotation().setCrossReferences(allCrossReferences);
 				consolidated.setReferenceId(allReferenceIds);
+				if (!allReferenceXrefs.isEmpty()) {
+					consolidated.setReferenceXrefs(allReferenceXrefs);
+				}
 
 				consolidatedDocuments.add(consolidated);
 			}

--- a/src/main/java/org/alliancegenome/curation_api/services/ResourceDescriptorPageService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ResourceDescriptorPageService.java
@@ -48,6 +48,30 @@ public class ResourceDescriptorPageService extends BaseEntityCrudService<Resourc
 		return new ObjectResponse<>(resourceDescriptorPageDAO.persist(dbEntity));
 	}
 
+	/**
+	 * Resolve the ResourceDescriptorPage for a reference-style curie ({@code PREFIX:localId}):
+	 * tries {@code (prefix, "reference")} first, then falls back to {@code (prefix, "default")}.
+	 * Returns null for malformed curies (null, missing colon, empty prefix) and for prefixes
+	 * with no matching resource descriptor. Use this anywhere a CrossReference is constructed
+	 * from a curie and we want the persisted resourceDescriptorPage link.
+	 */
+	public ResourceDescriptorPage resolvePageForReferenceCurie(String curie) {
+		if (curie == null) {
+			return null;
+		}
+		int colon = curie.indexOf(':');
+		if (colon <= 0) {
+			// no colon, or empty prefix (curie starts with ':')
+			return null;
+		}
+		String prefix = curie.substring(0, colon);
+		ResourceDescriptorPage page = getPageForResourceDescriptor(prefix, "reference");
+		if (page == null) {
+			page = getPageForResourceDescriptor(prefix, "default");
+		}
+		return page;
+	}
+
 	public ResourceDescriptorPage getPageForResourceDescriptor(String resourceDescriptorPrefix, String pageName) {
 
 		ResourceDescriptorPage page = null;

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/ReferenceSynchronisationHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/ReferenceSynchronisationHelper.java
@@ -17,6 +17,7 @@ import org.alliancegenome.curation_api.model.input.Pagination;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.ReferenceService;
+import org.alliancegenome.curation_api.services.ResourceDescriptorPageService;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
 import org.apache.commons.collections.CollectionUtils;
 
@@ -31,6 +32,7 @@ public class ReferenceSynchronisationHelper {
 	@Inject ReferenceService referenceService;
 	@Inject LiteratureReferenceDAO literatureReferenceDAO;
 	@Inject CrossReferenceDAO crossReferenceDAO;
+	@Inject ResourceDescriptorPageService resourceDescriptorPageService;
 
 	public Reference retrieveFromLiteratureService(String curie) {
 
@@ -96,18 +98,23 @@ public class ReferenceSynchronisationHelper {
 				curationSystemXrefMap.put(xref.getReferencedCurie(), xref);
 			}
 		}
-		
+
 		List<CrossReference> consolidatedXrefs = new ArrayList<>();
 		if (CollectionUtils.isNotEmpty(litRef.getCrossReferences())) {
 			for (LiteratureCrossReference litXref : litRef.getCrossReferences()) {
 				if (curationSystemXrefMap.containsKey(litXref.getCurie())) {
-					consolidatedXrefs.add(curationSystemXrefMap.get(litXref.getCurie()));
+					CrossReference existingXref = curationSystemXrefMap.get(litXref.getCurie());
+					if (existingXref.getResourceDescriptorPage() == null) {
+						existingXref.setResourceDescriptorPage(resourceDescriptorPageService.resolvePageForReferenceCurie(existingXref.getReferencedCurie()));
+					}
+					consolidatedXrefs.add(existingXref);
 				} else {
 					CrossReference xref = new CrossReference();
 					xref.setReferencedCurie(litXref.getCurie());
 					xref.setDisplayName(litXref.getCurie());
 					xref.setInternal(false);
 					xref.setObsolete(false);
+					xref.setResourceDescriptorPage(resourceDescriptorPageService.resolvePageForReferenceCurie(litXref.getCurie()));
 					consolidatedXrefs.add(crossReferenceDAO.persist(xref));
 				}
 			}


### PR DESCRIPTION
…ync time

  - ResourceDescriptorPageService: add resolvePageForReferenceCurie(curie) — splits the prefix and tries (prefix, "reference") with fallback to (prefix, "default"). Returns null for malformed curies (null, no colon, empty prefix) and prefixes with no matching resource descriptor.
  - ReferenceSynchronisationHelper.copyLiteratureReferenceFields: inject the service and set resourceDescriptorPage on every CrossReference processed by lit-sync. Newly created xrefs get the page before persist; reused existing xrefs with a null page get backfilled (JPA dirty-checking inside the @Transactional synchroniseReference flush). Idempotent — won't clobber a curator-set page.
  - GeneExpressionDocumentBuilder: populate GeneExpressionDocument.referenceXrefs by walking Reference.crossReferences in ReferenceConstants.primaryXrefOrder and returning the persisted matched CrossReference (carries the pre-linked resourceDescriptorPage). Falls back to a transient AGRKB-curie xref to match Reference.getReferenceID() semantics. Consolidation aggregates per-doc xrefs across grouped annotations via LinkedHashSet (dedup by referencedCurie + displayName).