### PR TITLE
fix: orthology species name shows strain suffix (S288C) [SCRUM-6212]

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Species.java
@@ -64,17 +64,17 @@ public class Species extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "fullName_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class, CurationView.GeneToGeneOrthologyDocument.class })
 	private String fullName;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "abbreviation_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class, CurationView.GeneToGeneOrthologyDocument.class })
 	private String abbreviation;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "displayName_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class, CurationView.GeneToGeneOrthologyDocument.class })
 	private String displayName;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ontology/NCBITaxonTerm.java
@@ -26,7 +26,7 @@ import lombok.ToString;
 public class NCBITaxonTerm extends OntologyTerm {
 
 	@OneToOne(mappedBy = "taxon", cascade = CascadeType.ALL, orphanRemoval = true)
-	@JsonView({CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class})
+	@JsonView({CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.TransgenicAllelesDocument.class, CurationView.GeneToGeneOrthologyDocument.class})
 	private Species species;
 
 }


### PR DESCRIPTION
## SCRUM-6212

Fixes the yeast species name showing as "Saccharomyces cerevisiae S288C" (strain-suffixed) in the gene page Orthology section, instead of the clean "Saccharomyces cerevisiae".

### Root cause
The gene-to-gene orthology ES document only serialized the strain-level `taxon.name` ("Saccharomyces cerevisiae S288C"). The clean species name lives on `taxon.species.fullName`, which was not included in the orthology document's `@JsonView` (unlike the expression document, which already exposes it).

### Change
Added `CurationView.GeneToGeneOrthologyDocument` to the `@JsonView` on:
- `NCBITaxonTerm.species`
- `Species.fullName`, `Species.abbreviation`, `Species.displayName`

So the orthology document now carries `taxon.species.fullName` for the UI to render.

### Follow-up
- Requires an orthology reindex after deploy for the new field to populate.
- Paired with an agr_ui change (branch `SCRUM-6212`) that rebinds the Orthology and Expression species columns to `taxon.species.fullName`.