### PR TITLE
SCRUM-6200: add references to allele_summary documents

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
@@ -1214,6 +1214,57 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 			}
 		}
 
+		// Allele references
+		String alleleRefsQueryString = """
+			SELECT ar.allele_id, r.id AS ref_id, ice.curie, r.shortcitation, cr.referencedcurie, cr.displayname, rdp.name AS rdp_name, rdp.urltemplate
+			FROM allele_reference ar
+			JOIN reference r ON r.id = ar.references_id
+			JOIN informationcontententity ice ON ice.id = r.id
+			LEFT JOIN reference_crossreference rcr ON rcr.reference_id = r.id
+			LEFT JOIN crossreference cr ON cr.id = rcr.crossreferences_id
+			LEFT JOIN resourcedescriptorpage rdp ON rdp.id = cr.resourcedescriptorpage_id
+			WHERE ar.allele_id IN :alleleIds
+			""";
+		Query alleleRefsQuery = entityManager.createNativeQuery(alleleRefsQueryString);
+		alleleRefsQuery.setParameter("alleleIds", alleleIds);
+		List<Object[]> alleleRefsResults = alleleRefsQuery.getResultList();
+
+		Map<Long, Map<Long, Reference>> alleleRefMap = new HashMap<>();
+		for (Object[] row : alleleRefsResults) {
+			Long alleleId = (Long) row[0];
+			Long refId = (Long) row[1];
+			Map<Long, Reference> refMap = alleleRefMap.computeIfAbsent(alleleId, k -> new HashMap<>());
+			Reference ref = refMap.get(refId);
+			if (ref == null) {
+				ref = new Reference();
+				ref.setCurie((String) row[2]);
+				ref.setShortCitation((String) row[3]);
+				ref.setCrossReferences(new HashSet<>());
+				refMap.put(refId, ref);
+			}
+			if (row[4] != null) {
+				CrossReference cr = new CrossReference();
+				cr.setReferencedCurie((String) row[4]);
+				cr.setDisplayName((String) row[5]);
+				if (row[6] != null) {
+					ResourceDescriptorPage rdp = new ResourceDescriptorPage();
+					rdp.setName((String) row[6]);
+					rdp.setUrlTemplate((String) row[7]);
+					cr.setResourceDescriptorPage(rdp);
+				}
+				if (ref.getCrossReferences().stream().noneMatch(c -> cr.getReferencedCurie().equals(c.getReferencedCurie()))) {
+					ref.getCrossReferences().add(cr);
+				}
+			}
+		}
+
+		for (Map.Entry<Long, Map<Long, Reference>> entry : alleleRefMap.entrySet()) {
+			Allele allele = alleleMap.get(entry.getKey());
+			if (allele != null) {
+				allele.setReferences(new ArrayList<>(entry.getValue().values()));
+			}
+		}
+
 		// Build documents
 		List<AlleleSummaryDocument> docs = new ArrayList<>();
 		for (Allele allele : alleles) {

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Allele.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Allele.java
@@ -84,7 +84,7 @@ public class Allele extends GenomicEntity {
 		@Index(name = "allele_reference_references_index", columnList = "references_id"),
 		@Index(name = "allele_reference_allele_references_index", columnList = "allele_id, references_id")
 	})
-	@JsonView({ CurationView.FieldsAndLists.class, CurationView.AlleleView.class, CurationView.AlleleDetailView.class })
+	@JsonView({ CurationView.FieldsAndLists.class, CurationView.AlleleView.class, CurationView.AlleleDetailView.class, CurationView.AlleleSummaryDocument.class })
 	private List<Reference> references;
 
 	@IndexedEmbedded(includePaths = {"name", "name_keyword"})

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Reference.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Reference.java
@@ -54,7 +54,7 @@ public class Reference extends InformationContentEntity {
 	)
 	private Set<CrossReference> crossReferences;
 
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class})
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.AlleleSummaryDocument.class})
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "shortCitation_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
 	@Column(columnDefinition = "TEXT")
@@ -74,7 +74,7 @@ public class Reference extends InformationContentEntity {
 	 * Display priority: PubMod ID (MOD-prefixed) if present in crossReferences, else the reference's own AGRKB curie.
 	 */
 	@Transient
-	@JsonView({CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class})
+	@JsonView({CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.AlleleSummaryDocument.class})
 	public String getPubModID() {
 		return getReferenceID(false);
 	}


### PR DESCRIPTION
  Populate allele.references on the allele_summary ES documents so the
  reference page can list alleles associated with a paper.

  - Load each allele's references in AlleleDAO.enrichAllelesAndBuildDocuments(), joining informationcontententity for the AGRKB curie plus shortCitation and cross-references.
  - Expose Allele.references, Reference.shortCitation, and Reference.getPubModID() under the AlleleSummaryDocument JSON view.