### PR TITLE
SCRUM-6199: add references to transgenic_allele_summary documents

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/controllers/document/AlleleDocumentController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/document/AlleleDocumentController.java
@@ -64,6 +64,12 @@ public class AlleleDocumentController implements AlleleDocumentInterface {
 		if (response.getResults() != null) {
 			TransgenicAlleleDocumentBuilder builder = new TransgenicAlleleDocumentBuilder();
 			for (AlleleConstructAssociation association : response.getResults()) {
+				// Force-initialize the allele's references (size() loads the lazy collection) so they
+				// serialize onto the transgenic document. The deeper graph (crossReferences, resource
+				// descriptor pages) lazy-loads during JSON serialization, which depends on the request-scoped
+				// session staying open - do not make this method @Transactional or those fields will hit a
+				// LazyInitializationException.
+				association.getAlleleAssociationSubject().getReferences().size();
 				TransgenicAlleleDocument doc = builder.buildTransgenicAlleleDocument(association);
 				list.add(doc);
 			}

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Allele.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Allele.java
@@ -84,7 +84,7 @@ public class Allele extends GenomicEntity {
 		@Index(name = "allele_reference_references_index", columnList = "references_id"),
 		@Index(name = "allele_reference_allele_references_index", columnList = "allele_id, references_id")
 	})
-	@JsonView({ CurationView.FieldsAndLists.class, CurationView.AlleleView.class, CurationView.AlleleDetailView.class, CurationView.AlleleSummaryDocument.class })
+	@JsonView({ CurationView.FieldsAndLists.class, CurationView.AlleleView.class, CurationView.AlleleDetailView.class, CurationView.AlleleSummaryDocument.class, CurationView.TransgenicAllelesDocument.class })
 	private List<Reference> references;
 
 	@IndexedEmbedded(includePaths = {"name", "name_keyword"})

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Reference.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Reference.java
@@ -45,7 +45,7 @@ public class Reference extends InformationContentEntity {
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@OneToMany(cascade = CascadeType.MERGE, orphanRemoval = true)
 	@Fetch(FetchMode.SUBSELECT)
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class})
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.TransgenicAllelesDocument.class})
 	@JoinTable(
 		indexes = {
 			@Index(name = "reference_crossreference_reference_index", columnList = "Reference_id"),
@@ -54,7 +54,7 @@ public class Reference extends InformationContentEntity {
 	)
 	private Set<CrossReference> crossReferences;
 
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.AlleleSummaryDocument.class})
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.AlleleSummaryDocument.class, CurationView.TransgenicAllelesDocument.class})
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "shortCitation_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
 	@Column(columnDefinition = "TEXT")
@@ -65,7 +65,7 @@ public class Reference extends InformationContentEntity {
 	 * else the reference's own AGRKB curie.
 	 */
 	@Transient
-	@JsonView({CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class})
+	@JsonView({CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.TransgenicAllelesDocument.class})
 	public String getReferenceID() {
 		return getReferenceID(true);
 	}
@@ -74,7 +74,7 @@ public class Reference extends InformationContentEntity {
 	 * Display priority: PubMod ID (MOD-prefixed) if present in crossReferences, else the reference's own AGRKB curie.
 	 */
 	@Transient
-	@JsonView({CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.AlleleSummaryDocument.class})
+	@JsonView({CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.TransgenicAllelesDocument.class})
 	public String getPubModID() {
 		return getReferenceID(false);
 	}

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/base/CurieObject.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/base/CurieObject.java
@@ -28,7 +28,7 @@ public class CurieObject extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "curie_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.DiseaseSummaryDocument.class, CurationView.ModelDocument.class, CurationView.GeneExpressionDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.OntologyTermClosureView.class, CurationView.SpeciesView.class })
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneToGeneOrthologyDocument.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.DiseaseSummaryDocument.class, CurationView.ModelDocument.class, CurationView.GeneExpressionDocument.class, CurationView.AlleleSummaryDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class, CurationView.OntologyTermClosureView.class, CurationView.SpeciesView.class, CurationView.TransgenicAllelesDocument.class })
 	@Column(nullable = false)
 	protected String curie;
 


### PR DESCRIPTION
  Expose allele.references on the transgenic allele document so the
  transgenic_allele_summary ES docs carry paper associations for the
  reference page.

  - Add the TransgenicAllelesDocument JSON view to Allele.references, CurieObject.curie, and Reference.crossReferences/shortCitation/ getReferenceID/getPubModID so the reference shape serializes.
  - Pre-load references in AlleleDocumentController.findDocuments() via Hibernate.initialize (mirrors VariantDocumentController); the nested allele.references then rides through the indexer to ES.