### PR TITLE
Add species field to BulkLoad and phenotype booleans to Organization

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Organization.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Organization.java
@@ -69,4 +69,16 @@ public class Organization extends Agent {
 	@OneToOne
 	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class})
 	private ResourceDescriptorPage homepageResourceDescriptorPage;
+
+	@JsonView({CurationView.FieldsOnly.class})
+	private Boolean hasInferredGenePhenotypeAnnotations = false;
+
+	@JsonView({CurationView.FieldsOnly.class})
+	private Boolean hasAssertedGenePhenotypeAnnotations = false;
+
+	@JsonView({CurationView.FieldsOnly.class})
+	private Boolean hasInferredAllelePhenotypeAnnotations = false;
+
+	@JsonView({CurationView.FieldsOnly.class})
+	private Boolean hasAssertedAllelePhenotypeAnnotations = false;
 }

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoad.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkLoad.java
@@ -8,6 +8,7 @@ import org.alliancegenome.curation_api.enums.BackendBulkLoadType;
 import org.alliancegenome.curation_api.enums.JobStatus;
 import org.alliancegenome.curation_api.enums.OntologyBulkLoadType;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
 import org.alliancegenome.curation_api.view.CurationView;
 
@@ -49,7 +50,8 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 		@Index(name = "bulkload_updatedby_index", columnList = "updatedBy_id"),
 		@Index(name = "bulkload_backendBulkLoadType_index", columnList = "backendBulkLoadType"),
 		@Index(name = "bulkload_ontologyType_index", columnList = "ontologyType"),
-		@Index(name = "bulkload_bulkloadStatus_index", columnList = "bulkloadStatus")
+		@Index(name = "bulkload_bulkloadStatus_index", columnList = "bulkloadStatus"),
+		@Index(name = "bulkload_species_index", columnList = "species_id")
 	}
 )
 public abstract class BulkLoad extends AuditedObject {
@@ -91,5 +93,9 @@ public abstract class BulkLoad extends AuditedObject {
 
 	@ManyToMany(mappedBy = "dependencies")
 	private Set<BulkLoad> depends;
-	
+
+	@JsonView({ CurationView.FieldsOnly.class })
+	@ManyToOne
+	private Species species;
+
 }

--- a/src/main/resources/db/migration/v0.50.0.4__add_species_to_bulkload.sql
+++ b/src/main/resources/db/migration/v0.50.0.4__add_species_to_bulkload.sql
@@ -1,0 +1,32 @@
+ALTER TABLE organization ADD COLUMN hasinferredgenephenotypeannotations boolean NOT NULL DEFAULT false;
+ALTER TABLE organization ADD COLUMN hasassertedgenephenotypeannotations boolean NOT NULL DEFAULT false;
+ALTER TABLE organization ADD COLUMN hasinferredallelephenotypeannotations boolean NOT NULL DEFAULT false;
+ALTER TABLE organization ADD COLUMN hasassertedallelephenotypeannotations boolean NOT NULL DEFAULT false;
+
+UPDATE organization SET hasinferredgenephenotypeannotations = true WHERE abbreviation = 'MGI';
+UPDATE organization SET hasinferredgenephenotypeannotations = true, hasinferredallelephenotypeannotations = true WHERE abbreviation = 'ZFIN';
+UPDATE organization SET hasinferredgenephenotypeannotations = true WHERE abbreviation = 'FB';
+UPDATE organization SET hasinferredgenephenotypeannotations = true WHERE abbreviation = 'SGD';
+UPDATE organization SET hasinferredgenephenotypeannotations = true, hasassertedallelephenotypeannotations = true WHERE abbreviation = 'WB';
+UPDATE organization SET hasinferredgenephenotypeannotations = true WHERE abbreviation = 'XB';
+
+ALTER TABLE bulkload ADD COLUMN species_id bigint;
+
+UPDATE bulkload SET species_id = s.id
+FROM bulkmanualload bml
+JOIN species s ON s.displayname = bml.dataprovider
+WHERE bulkload.id = bml.id;
+
+UPDATE bulkload SET species_id = s.id
+FROM bulkfmsload f
+JOIN species s ON s.displayname = f.fmsdatasubtype
+WHERE bulkload.id = f.id AND bulkload.species_id IS NULL;
+
+UPDATE bulkload SET species_id = s.id
+FROM bulkurlload u, species s
+WHERE bulkload.id = u.id AND bulkload.species_id IS NULL
+AND bulkload.backendbulkloadtype = 'EXPRESSION_ATLAS'
+AND bulkload.name LIKE s.displayname || ' %';
+
+ALTER TABLE bulkload ADD CONSTRAINT bulkload_species_id_fk FOREIGN KEY (species_id) REFERENCES species (id);
+CREATE INDEX bulkload_species_index ON bulkload USING btree(species_id);


### PR DESCRIPTION
- Add nullable Species @ManyToOne to BulkLoad base class with index
- Add phenotype annotation boolean flags to Organization entity
- Migration populates species_id from bulkmanualload.dataprovider, bulkfmsload.fmsdatasubtype, and URL load names for Expression Atlas
- Migration sets phenotype flags for MGI, ZFIN, FB, SGD, WB, XB

This is the foundation for incrementally replacing BackendBulkDataProvider enum with Species entity across load executors in subsequent PRs.