### PR TITLE
Replace BackendBulkDataProvider with Species in core infrastructure

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/controllers/DQMSubmissionController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/DQMSubmissionController.java
@@ -1,9 +1,10 @@
 package org.alliancegenome.curation_api.controllers;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.enums.BackendBulkLoadType;
 import org.alliancegenome.curation_api.interfaces.DQMSubmissionInterface;
 import org.alliancegenome.curation_api.jobs.processors.BulkLoadManualProcessor;
+import org.alliancegenome.curation_api.model.entities.Species;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 
 import jakarta.inject.Inject;
@@ -13,17 +14,20 @@ public class DQMSubmissionController implements DQMSubmissionInterface {
 	@Inject
 	BulkLoadManualProcessor bulkLoadManualProcessor;
 
+	@Inject
+	SpeciesService speciesService;
+
 	@Override
 	public String update(MultipartFormDataInput input, Boolean cleanUp) {
 		for (String key : input.getFormDataMap().keySet()) {
 			String separator = "_";
 			int sepPos = key.lastIndexOf(separator);
 			BackendBulkLoadType loadType = BackendBulkLoadType.valueOf(key.substring(0, sepPos));
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(key.substring(sepPos + 1));
-			if (loadType == null || dataProvider == null) {
+			Species species = speciesService.getByDisplayName(key.substring(sepPos + 1));
+			if (loadType == null || species == null) {
 				return "FAIL";
 			} else {
-				bulkLoadManualProcessor.processBulkManualLoadFromDQM(input, loadType, dataProvider, cleanUp);
+				bulkLoadManualProcessor.processBulkManualLoadFromDQM(input, loadType, species, cleanUp);
 			}
 		}
 

--- a/src/main/java/org/alliancegenome/curation_api/controllers/base/BaseAnnotationDTOCrudController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/base/BaseAnnotationDTOCrudController.java
@@ -1,10 +1,10 @@
 package org.alliancegenome.curation_api.controllers.base;
 
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.base.BaseUpsertControllerInterface;
 import org.alliancegenome.curation_api.model.entities.Annotation;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.ingest.dto.AnnotationDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.services.base.BaseAnnotationDTOCrudService;
@@ -27,8 +27,8 @@ public abstract class BaseAnnotationDTOCrudController<S extends BaseAnnotationDT
 		return service.upsert(dto);
 	}
 
-	public ObjectResponse<E> upsert(T dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return service.upsert(dto, dataProvider);
+	public ObjectResponse<E> upsert(T dto, Species species) throws ValidationException {
+		return service.upsert(dto, species);
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/controllers/base/SubmittedObjectCrudController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/base/SubmittedObjectCrudController.java
@@ -1,10 +1,10 @@
 package org.alliancegenome.curation_api.controllers.base;
 
 import org.alliancegenome.curation_api.dao.base.BaseEntityDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.base.BaseSubmittedObjectCrudInterface;
 import org.alliancegenome.curation_api.interfaces.base.BaseUpsertControllerInterface;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.base.SubmittedObject;
 import org.alliancegenome.curation_api.model.ingest.dto.base.BaseDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -25,8 +25,8 @@ public abstract class SubmittedObjectCrudController<S extends SubmittedObjectCru
 		return service.upsert(dto);
 	}
 
-	public ObjectResponse<E> upsert(T dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return service.upsert(dto, dataProvider);
+	public ObjectResponse<E> upsert(T dto, Species species) throws ValidationException {
+		return service.upsert(dto, species);
 	}
 
 	@Override

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/BaseUpsertServiceInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/BaseUpsertServiceInterface.java
@@ -1,7 +1,7 @@
 package org.alliancegenome.curation_api.interfaces.crud;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
 import org.alliancegenome.curation_api.model.ingest.dto.base.BaseDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -12,6 +12,6 @@ public interface BaseUpsertServiceInterface<E extends AuditedObject, T extends B
 		return upsert(dto, null);
 	}
 
-	ObjectResponse<E> upsert(T dto, BackendBulkDataProvider dataProvider) throws ValidationException;
+	ObjectResponse<E> upsert(T dto, Species species) throws ValidationException;
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/AgmDiseaseAnnotationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/AgmDiseaseAnnotationExecutor.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.alliancegenome.curation_api.dao.AGMDiseaseAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
 import org.alliancegenome.curation_api.model.ingest.dto.AGMDiseaseAnnotationDTO;
@@ -29,8 +29,8 @@ public class AgmDiseaseAnnotationExecutor extends LoadFileExecutor {
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory, Boolean cleanUp) {
 
 		BulkManualLoad manual = (BulkManualLoad) bulkLoadFileHistory.getBulkLoad();
-		BackendBulkDataProvider dataProvider = manual.getDataProvider();
-		log.info("Running with dataProvider: " + dataProvider.name());
+		Species species = manual.getSpecies();
+		log.info("Running with dataProvider: " + species.getDisplayName());
 
 		IngestDTO ingestDto = readIngestFile(bulkLoadFileHistory, AGMDiseaseAnnotationDTO.class);
 		if (ingestDto == null) {
@@ -45,7 +45,7 @@ public class AgmDiseaseAnnotationExecutor extends LoadFileExecutor {
 		List<Long> annotationIdsLoaded = new ArrayList<>();
 		List<Long> annotationIdsBefore = new ArrayList<>();
 		if (cleanUp) {
-			annotationIdsBefore.addAll(agmDiseaseAnnotationService.getAnnotationIdsByDataProvider(dataProvider));
+			annotationIdsBefore.addAll(agmDiseaseAnnotationService.getAnnotationIdsBySpecies(species));
 			annotationIdsBefore.removeIf(Objects::isNull);
 		}
 
@@ -53,9 +53,9 @@ public class AgmDiseaseAnnotationExecutor extends LoadFileExecutor {
 		bulkLoadFileDAO.merge(bulkLoadFileHistory.getBulkLoadFile());
 
 		String countType = "AGM Disease Annotations";
-		boolean success = runLoad(agmDiseaseAnnotationService, bulkLoadFileHistory, dataProvider, annotations, annotationIdsLoaded, countType);
+		boolean success = runLoad(agmDiseaseAnnotationService, bulkLoadFileHistory, species, annotations, annotationIdsLoaded, countType);
 		if (success && cleanUp) {
-			runCleanup(diseaseAnnotationService, bulkLoadFileHistory, dataProvider.name(), annotationIdsBefore, annotationIdsLoaded, countType);
+			runCleanup(diseaseAnnotationService, bulkLoadFileHistory, species.getDisplayName(), annotationIdsBefore, annotationIdsLoaded, countType);
 		}
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/AgmExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/AgmExecutor.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.alliancegenome.curation_api.dao.AffectedGenomicModelDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
 import org.alliancegenome.curation_api.model.ingest.dto.AffectedGenomicModelDTO;
@@ -29,7 +29,7 @@ public class AgmExecutor extends LoadFileExecutor {
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory, Boolean cleanUp) {
 
 		BulkManualLoad manual = (BulkManualLoad) bulkLoadFileHistory.getBulkLoad();
-		Log.info("Running with: " + manual.getDataProvider().name());
+		Log.info("Running with: " + manual.getSpecies().getDisplayName());
 
 		IngestDTO ingestDto = readIngestFile(bulkLoadFileHistory, AffectedGenomicModelDTO.class);
 		if (ingestDto == null) {
@@ -41,12 +41,12 @@ public class AgmExecutor extends LoadFileExecutor {
 			return;
 		}
 
-		BackendBulkDataProvider dataProvider = manual.getDataProvider();
+		Species species = manual.getSpecies();
 
 		List<Long> agmIdsLoaded = new ArrayList<>();
 		List<Long> agmIdsBefore = new ArrayList<>();
 		if (cleanUp) {
-			agmIdsBefore.addAll(affectedGenomicModelService.getIdsByDataProvider(dataProvider.name()));
+			agmIdsBefore.addAll(affectedGenomicModelService.getIdsByDataProvider(species.getDisplayName()));
 			Log.debug("runLoad: Before: total " + agmIdsBefore.size());
 		}
 
@@ -56,9 +56,9 @@ public class AgmExecutor extends LoadFileExecutor {
 		bulkLoadFileHistory.setCount(agms.size());
 		updateHistory(bulkLoadFileHistory);
 
-		boolean success = runLoad(affectedGenomicModelService, bulkLoadFileHistory, dataProvider, agms, agmIdsLoaded);
+		boolean success = runLoad(affectedGenomicModelService, bulkLoadFileHistory, species, agms, agmIdsLoaded);
 		if (success && cleanUp) {
-			runCleanup(affectedGenomicModelService, bulkLoadFileHistory, dataProvider.name(), agmIdsBefore, agmIdsLoaded, "AGM");
+			runCleanup(affectedGenomicModelService, bulkLoadFileHistory, species.getDisplayName(), agmIdsBefore, agmIdsLoaded, "AGM");
 		}
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/AlleleDiseaseAnnotationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/AlleleDiseaseAnnotationExecutor.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.alliancegenome.curation_api.dao.AlleleDiseaseAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
 import org.alliancegenome.curation_api.model.ingest.dto.AlleleDiseaseAnnotationDTO;
@@ -29,8 +29,8 @@ public class AlleleDiseaseAnnotationExecutor extends LoadFileExecutor {
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory, Boolean cleanUp) {
 
 		BulkManualLoad manual = (BulkManualLoad) bulkLoadFileHistory.getBulkLoad();
-		BackendBulkDataProvider dataProvider = manual.getDataProvider();
-		log.info("Running with dataProvider: " + dataProvider.name());
+		Species species = manual.getSpecies();
+		log.info("Running with dataProvider: " + species.getDisplayName());
 
 		IngestDTO ingestDto = readIngestFile(bulkLoadFileHistory, AlleleDiseaseAnnotationDTO.class);
 		if (ingestDto == null) {
@@ -45,7 +45,7 @@ public class AlleleDiseaseAnnotationExecutor extends LoadFileExecutor {
 		List<Long> annotationIdsLoaded = new ArrayList<>();
 		List<Long> annotationIdsBefore = new ArrayList<>();
 		if (cleanUp) {
-			annotationIdsBefore.addAll(alleleDiseaseAnnotationService.getAnnotationIdsByDataProvider(dataProvider));
+			annotationIdsBefore.addAll(alleleDiseaseAnnotationService.getAnnotationIdsBySpecies(species));
 			annotationIdsBefore.removeIf(Objects::isNull);
 		}
 
@@ -53,9 +53,9 @@ public class AlleleDiseaseAnnotationExecutor extends LoadFileExecutor {
 		bulkLoadFileDAO.merge(bulkLoadFileHistory.getBulkLoadFile());
 		
 		String countType = "Allele Disease Annotations";
-		boolean success = runLoad(alleleDiseaseAnnotationService, bulkLoadFileHistory, dataProvider, annotations, annotationIdsLoaded, countType);
+		boolean success = runLoad(alleleDiseaseAnnotationService, bulkLoadFileHistory, species, annotations, annotationIdsLoaded, countType);
 		if (success && cleanUp) {
-			runCleanup(diseaseAnnotationService, bulkLoadFileHistory, dataProvider.name(), annotationIdsBefore, annotationIdsLoaded, countType);
+			runCleanup(diseaseAnnotationService, bulkLoadFileHistory, species.getDisplayName(), annotationIdsBefore, annotationIdsLoaded, countType);
 		}
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/AlleleExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/AlleleExecutor.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.alliancegenome.curation_api.dao.AlleleDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
 import org.alliancegenome.curation_api.model.ingest.dto.AlleleDTO;
@@ -25,7 +25,7 @@ public class AlleleExecutor extends LoadFileExecutor {
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory, Boolean cleanUp) {
 
 		BulkManualLoad manual = (BulkManualLoad) bulkLoadFileHistory.getBulkLoad();
-		Log.info("Running with: " + manual.getDataProvider().name());
+		Log.info("Running with: " + manual.getSpecies().getDisplayName());
 
 		IngestDTO ingestDto = readIngestFile(bulkLoadFileHistory, AlleleDTO.class);
 		if (ingestDto == null) {
@@ -37,12 +37,12 @@ public class AlleleExecutor extends LoadFileExecutor {
 			return;
 		}
 
-		BackendBulkDataProvider dataProvider = manual.getDataProvider();
+		Species species = manual.getSpecies();
 
 		List<Long> alleleIdsLoaded = new ArrayList<>();
 		List<Long> alleleIdsBefore = new ArrayList<>();
 		if (cleanUp) {
-			alleleIdsBefore.addAll(alleleService.getIdsByDataProvider(dataProvider.name()));
+			alleleIdsBefore.addAll(alleleService.getIdsByDataProvider(species.getDisplayName()));
 			Log.debug("runLoad: Before: total " + alleleIdsBefore.size());
 		}
 
@@ -52,9 +52,9 @@ public class AlleleExecutor extends LoadFileExecutor {
 		bulkLoadFileHistory.setCount(alleles.size());
 		updateHistory(bulkLoadFileHistory);
 		
-		boolean success = runLoad(alleleService, bulkLoadFileHistory, dataProvider, alleles, alleleIdsLoaded);
+		boolean success = runLoad(alleleService, bulkLoadFileHistory, species, alleles, alleleIdsLoaded);
 		if (success && cleanUp) {
-			runCleanup(alleleService, bulkLoadFileHistory, dataProvider.name(), alleleIdsBefore, alleleIdsLoaded, "Allele");
+			runCleanup(alleleService, bulkLoadFileHistory, species.getDisplayName(), alleleIdsBefore, alleleIdsLoaded, "Allele");
 		}
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/BiogridOrcExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/BiogridOrcExecutor.java
@@ -9,7 +9,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
@@ -20,6 +20,7 @@ import org.alliancegenome.curation_api.model.ingest.dto.fms.BiogridOrcFmsDTO;
 import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.LoadHistoryResponce;
 import org.alliancegenome.curation_api.services.GeneService;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -38,6 +39,7 @@ import jakarta.inject.Inject;
 public class BiogridOrcExecutor extends LoadFileExecutor {
 
 	@Inject GeneService geneService;
+	@Inject SpeciesService speciesService;
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) {
 		try (TarArchiveInputStream tarInputStream = new TarArchiveInputStream(
@@ -45,9 +47,7 @@ public class BiogridOrcExecutor extends LoadFileExecutor {
 			TarArchiveEntry tarEntry;
 
 			List<BiogridOrcFmsDTO> biogridData = new ArrayList<>();
-			String name = bulkLoadFileHistory.getBulkLoad().getName();
-			String dataProviderName = name.substring(0, name.indexOf(" "));
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(dataProviderName);
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 
 			while ((tarEntry = tarInputStream.getNextEntry()) != null) {
 
@@ -71,7 +71,7 @@ public class BiogridOrcExecutor extends LoadFileExecutor {
 				biogridData.addAll(it.readAll());
 
 			}
-			runLoad(bulkLoadFileHistory, biogridData, dataProvider);
+			runLoad(bulkLoadFileHistory, biogridData, species);
 			
 			bulkLoadFileHistory.finishLoad();
 			updateHistory(bulkLoadFileHistory);
@@ -83,15 +83,15 @@ public class BiogridOrcExecutor extends LoadFileExecutor {
 		}
 	}
 
-	private void runLoad(BulkLoadFileHistory history, List<BiogridOrcFmsDTO> biogridList, BackendBulkDataProvider dataProvider) {
+	private void runLoad(BulkLoadFileHistory history, List<BiogridOrcFmsDTO> biogridList, Species species) {
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.addDisplayHandler(loadProcessDisplayService);
 		if (CollectionUtils.isNotEmpty(biogridList)) {
 			Set<String> entrezIds = populateEntrezIdsFromFiles(biogridList);
-			
+
 			String loadMessage = "BioGRID-ORCS cross-reference update";
-			if (dataProvider != null) {
-				loadMessage = loadMessage + " for " + dataProvider.name();
+			if (species != null) {
+				loadMessage = loadMessage + " for " + species.getDisplayName();
 			}
 			ph.startProcess(loadMessage, entrezIds.size());
 			
@@ -100,7 +100,7 @@ public class BiogridOrcExecutor extends LoadFileExecutor {
 			
 			for (String entrezId : entrezIds) {
 				try {
-					geneService.addBiogridXref(entrezId, dataProvider);
+					geneService.addBiogridXref(entrezId, species);
 					history.incrementCompleted();
 				} catch (ObjectUpdateException e) {
 					history.incrementFailed();
@@ -137,11 +137,11 @@ public class BiogridOrcExecutor extends LoadFileExecutor {
 	public APIResponse runLoadApi(String dataProviderName, List<BiogridOrcFmsDTO> biogridDTOs) {
 		BulkLoadFileHistory history = new BulkLoadFileHistory(biogridDTOs.size());
 		history = bulkLoadFileHistoryDAO.persist(history);
-		BackendBulkDataProvider dataProvider = null;
+		Species species = null;
 		if (dataProviderName != null) {
-			dataProvider = BackendBulkDataProvider.valueOf(dataProviderName);
+			species = speciesService.getByDisplayName(dataProviderName);
 		}
-		runLoad(history, biogridDTOs, dataProvider);
+		runLoad(history, biogridDTOs, species);
 		history.finishLoad();
 
 		return new LoadHistoryResponce(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/ConstructExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/ConstructExecutor.java
@@ -6,7 +6,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
 import org.alliancegenome.curation_api.model.ingest.dto.ConstructDTO;
@@ -31,7 +31,7 @@ public class ConstructExecutor extends LoadFileExecutor {
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory, Boolean cleanUp) {
 
 		BulkManualLoad manual = (BulkManualLoad) bulkLoadFileHistory.getBulkLoad();
-		Log.info("Running with: " + manual.getDataProvider().name());
+		Log.info("Running with: " + manual.getSpecies().getDisplayName());
 
 		IngestDTO ingestDto = readIngestFile(bulkLoadFileHistory, ConstructDTO.class);
 		if (ingestDto == null) {
@@ -43,12 +43,12 @@ public class ConstructExecutor extends LoadFileExecutor {
 			return;
 		}
 
-		BackendBulkDataProvider dataProvider = manual.getDataProvider();
+		Species species = manual.getSpecies();
 
 		List<Long> constructIdsLoaded = new ArrayList<>();
 		List<Long> constructIdsBefore = new ArrayList<>();
 		if (cleanUp) {
-			constructIdsBefore.addAll(constructService.getConstructIdsByDataProvider(dataProvider));
+			constructIdsBefore.addAll(constructService.getConstructIdsBySpecies(species));
 			Log.debug("runLoad: Before: total " + constructIdsBefore.size());
 		}
 
@@ -65,9 +65,9 @@ public class ConstructExecutor extends LoadFileExecutor {
 
 		constructService.preLoadReferences(refList);
 
-		boolean success = runLoad(constructService, bulkLoadFileHistory, dataProvider, constructs, constructIdsLoaded);
+		boolean success = runLoad(constructService, bulkLoadFileHistory, species, constructs, constructIdsLoaded);
 		if (success && cleanUp) {
-			runCleanup(constructService, bulkLoadFileHistory, dataProvider.name(), constructIdsBefore, constructIdsLoaded, "construct");
+			runCleanup(constructService, bulkLoadFileHistory, species.getDisplayName(), constructIdsBefore, constructIdsLoaded, "construct");
 		}
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/ExpressionAtlasExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/ExpressionAtlasExecutor.java
@@ -5,7 +5,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
@@ -41,19 +41,16 @@ public class ExpressionAtlasExecutor extends LoadFileExecutor {
 			.map(sUrl -> sUrl.substring(sUrl.lastIndexOf("/") + 1))
 			.toList();
 
-		String name = bulkLoadFileHistory.getBulkLoad().getName();
-		String dataProviderName = name.substring(0, name.indexOf(" "));
-		
-		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(dataProviderName);
+		Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 
-		runLoad(bulkLoadFileHistory, dataProvider, accessions);
+		runLoad(bulkLoadFileHistory, species, accessions);
 
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);
 		updateExceptions(bulkLoadFileHistory);
 	}
 		
-	private void runLoad(BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<String> identifiers) {
+	private void runLoad(BulkLoadFileHistory history, Species species, List<String> identifiers) {
 		if (Thread.currentThread().isInterrupted()) {
 			history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
 			throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
@@ -63,8 +60,8 @@ public class ExpressionAtlasExecutor extends LoadFileExecutor {
 		ph.addDisplayHandler(loadProcessDisplayService);
 		if (CollectionUtils.isNotEmpty(identifiers)) {
 			String loadMessage = "Expression Atlas cross-reference update";
-			if (dataProvider != null) {
-				loadMessage = loadMessage + " for " + dataProvider.name();
+			if (species != null) {
+				loadMessage = loadMessage + " for " + species.getDisplayName();
 			}
 			ph.startProcess(loadMessage, identifiers.size());
 			
@@ -73,7 +70,7 @@ public class ExpressionAtlasExecutor extends LoadFileExecutor {
 			
 			for (String identifier : identifiers) {
 				try {
-					geneService.addExpressionAtlasXref(identifier, dataProvider);
+					geneService.addExpressionAtlasXref(identifier, species);
 					history.incrementCompleted();
 				} catch (ObjectUpdateException e) {
 					history.incrementFailed();

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneDiseaseAnnotationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneDiseaseAnnotationExecutor.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.alliancegenome.curation_api.dao.GeneDiseaseAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
 import org.alliancegenome.curation_api.model.ingest.dto.GeneDiseaseAnnotationDTO;
@@ -29,8 +29,8 @@ public class GeneDiseaseAnnotationExecutor extends LoadFileExecutor {
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory, Boolean cleanUp) {
 
 		BulkManualLoad manual = (BulkManualLoad) bulkLoadFileHistory.getBulkLoad();
-		BackendBulkDataProvider dataProvider = manual.getDataProvider();
-		log.info("Running with dataProvider: " + dataProvider.name());
+		Species species = manual.getSpecies();
+		log.info("Running with dataProvider: " + species.getDisplayName());
 
 		IngestDTO ingestDto = readIngestFile(bulkLoadFileHistory, GeneDiseaseAnnotationDTO.class);
 		if (ingestDto == null) {
@@ -45,7 +45,7 @@ public class GeneDiseaseAnnotationExecutor extends LoadFileExecutor {
 		List<Long> annotationIdsLoaded = new ArrayList<>();
 		List<Long> annotationIdsBefore = new ArrayList<>();
 		if (cleanUp) {
-			annotationIdsBefore.addAll(geneDiseaseAnnotationService.getAnnotationIdsByDataProvider(dataProvider));
+			annotationIdsBefore.addAll(geneDiseaseAnnotationService.getAnnotationIdsBySpecies(species));
 			annotationIdsBefore.removeIf(Objects::isNull);
 		}
 
@@ -53,9 +53,9 @@ public class GeneDiseaseAnnotationExecutor extends LoadFileExecutor {
 		bulkLoadFileDAO.merge(bulkLoadFileHistory.getBulkLoadFile());
 
 		String countType = "Gene Disease Annotations";
-		boolean success = runLoad(geneDiseaseAnnotationService, bulkLoadFileHistory, dataProvider, annotations, annotationIdsLoaded, countType);
+		boolean success = runLoad(geneDiseaseAnnotationService, bulkLoadFileHistory, species, annotations, annotationIdsLoaded, countType);
 		if (success && cleanUp) {
-			runCleanup(diseaseAnnotationService, bulkLoadFileHistory, dataProvider.name(), annotationIdsBefore, annotationIdsLoaded, countType);
+			runCleanup(diseaseAnnotationService, bulkLoadFileHistory, species.getDisplayName(), annotationIdsBefore, annotationIdsLoaded, countType);
 		}
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneExecutor.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.alliancegenome.curation_api.dao.GeneDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
 import org.alliancegenome.curation_api.model.ingest.dto.GeneDTO;
@@ -30,8 +30,8 @@ public class GeneExecutor extends LoadFileExecutor {
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory, Boolean cleanUp) {
 
 		BulkManualLoad manual = (BulkManualLoad) bulkLoadFileHistory.getBulkLoad();
-		BackendBulkDataProvider dataProvider = manual.getDataProvider();
-		log.info("Running with dataProvider : " + dataProvider.name());
+		Species species = manual.getSpecies();
+		log.info("Running with dataProvider : " + species.getDisplayName());
 
 		IngestDTO ingestDto = readIngestFile(bulkLoadFileHistory, GeneDTO.class);
 		if (ingestDto == null) {
@@ -46,7 +46,7 @@ public class GeneExecutor extends LoadFileExecutor {
 		List<Long> geneIdsLoaded = new ArrayList<>();
 		List<Long> geneIdsBefore = new ArrayList<>();
 		if (cleanUp) {
-			geneIdsBefore.addAll(geneService.getIdsByDataProvider(dataProvider));
+			geneIdsBefore.addAll(geneService.getIdsBySpecies(species));
 			log.debug("runLoad: Before: total " + geneIdsBefore.size());
 		}
 
@@ -56,9 +56,9 @@ public class GeneExecutor extends LoadFileExecutor {
 		bulkLoadFileHistory.setCount(genes.size());
 		updateHistory(bulkLoadFileHistory);
 		
-		boolean success = runLoad(geneService, bulkLoadFileHistory, dataProvider, genes, geneIdsLoaded);
+		boolean success = runLoad(geneService, bulkLoadFileHistory, species, genes, geneIdsLoaded);
 		if (success && cleanUp) {
-			runCleanup(geneService, bulkLoadFileHistory, dataProvider.name(), geneIdsBefore, geneIdsLoaded, "gene");
+			runCleanup(geneService, bulkLoadFileHistory, species.getDisplayName(), geneIdsBefore, geneIdsLoaded, "gene");
 		}
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneExpressionExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneExpressionExecutor.java
@@ -8,13 +8,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.zip.GZIPInputStream;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
 import org.alliancegenome.curation_api.model.entities.GeneExpressionAnnotation;
 import org.alliancegenome.curation_api.model.entities.GeneExpressionExperiment;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.ConsolidatedGeneExpressionFmsDTO;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.CrossReferenceFmsDTO;
@@ -23,6 +22,7 @@ import org.alliancegenome.curation_api.model.ingest.dto.fms.GeneExpressionIngest
 import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.LoadHistoryResponce;
 import org.alliancegenome.curation_api.services.GeneExpressionAnnotationService;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.alliancegenome.curation_api.services.GeneExpressionExperimentService;
 import org.alliancegenome.curation_api.services.helpers.annotations.GeneExpressionAnnotationUniqueIdHelper;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
@@ -37,14 +37,14 @@ public class GeneExpressionExecutor extends LoadFileExecutor {
 	@Inject GeneExpressionAnnotationService geneExpressionAnnotationService;
 	@Inject GeneExpressionExperimentService geneExpressionExperimentService;
 	@Inject GeneExpressionAnnotationUniqueIdHelper geneExpressionAnnotationUniqueIdHelper;
+	@Inject SpeciesService speciesService;
 	static final String ANNOTATIONS = "Annotations";
 	static final String EXPERIMENTS = "Experiments";
 
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) {
 		try {
-			BulkFMSLoad fms = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fms.getFmsDataSubType());
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 
 			GeneExpressionIngestFmsDTO geneExpressionIngestFmsDTO = mapper.readValue(new GZIPInputStream(new FileInputStream(bulkLoadFileHistory.getBulkLoadFile().getLocalFilePath())), GeneExpressionIngestFmsDTO.class);
 			bulkLoadFileHistory.getBulkLoadFile().setRecordCount(geneExpressionIngestFmsDTO.getData().size());
@@ -57,17 +57,17 @@ public class GeneExpressionExecutor extends LoadFileExecutor {
 			bulkLoadFileDAO.merge(bulkLoadFileHistory.getBulkLoadFile());
 
 			List<Long> annotationIdsLoaded = new ArrayList<>();
-			List<Long> annotationIdsBefore = geneExpressionAnnotationService.getAnnotationIdsByDataProvider(dataProvider);
+			List<Long> annotationIdsBefore = geneExpressionAnnotationService.getAnnotationIdsBySpecies(species);
 
 			List<Long> experimentIdsLoaded = new ArrayList<>();
-			List<Long> experimentIdsBefore = geneExpressionExperimentService.getExperimentIdsByDataProvider(dataProvider);
+			List<Long> experimentIdsBefore = geneExpressionExperimentService.getExperimentIdsBySpecies(species);
 
-			boolean success = runLoad(geneExpressionAnnotationService, bulkLoadFileHistory, dataProvider, consolidateFMSDTOs(geneExpressionIngestFmsDTO.getData()), annotationIdsLoaded, ANNOTATIONS);
+			boolean success = runLoad(geneExpressionAnnotationService, bulkLoadFileHistory, species, consolidateFMSDTOs(geneExpressionIngestFmsDTO.getData()), annotationIdsLoaded, ANNOTATIONS);
 
 			if (success) {
-				runCleanup(geneExpressionAnnotationService, bulkLoadFileHistory, dataProvider.name(), annotationIdsBefore, annotationIdsLoaded, ANNOTATIONS);
-				loadExperiments(bulkLoadFileHistory, dataProvider, experimentIdsLoaded);
-				runCleanup(geneExpressionExperimentService, bulkLoadFileHistory, dataProvider.name(), experimentIdsBefore, experimentIdsLoaded, EXPERIMENTS);
+				runCleanup(geneExpressionAnnotationService, bulkLoadFileHistory, species.getDisplayName(), annotationIdsBefore, annotationIdsLoaded, ANNOTATIONS);
+				loadExperiments(bulkLoadFileHistory, species, experimentIdsLoaded);
+				runCleanup(geneExpressionExperimentService, bulkLoadFileHistory, species.getDisplayName(), experimentIdsBefore, experimentIdsLoaded, EXPERIMENTS);
 			}
 
 			bulkLoadFileHistory.finishLoad();
@@ -84,19 +84,19 @@ public class GeneExpressionExecutor extends LoadFileExecutor {
 		List<Long> idsLoaded = new ArrayList<>();
 		BulkLoadFileHistory history = new BulkLoadFileHistory(objectList.size());
 		history = bulkLoadFileHistoryDAO.persist(history);
-		BackendBulkDataProvider dataProvider = null;
+		Species species = null;
 		if (dataProviderName != null) {
-			dataProvider = BackendBulkDataProvider.valueOf(dataProviderName);
+			species = speciesService.getByDisplayName(dataProviderName);
 		}
-		boolean success = runLoad(service, history, dataProvider, consolidateFMSDTOs(objectList), idsLoaded, true, ANNOTATIONS);
+		boolean success = runLoad(service, history, species, consolidateFMSDTOs(objectList), idsLoaded, true, ANNOTATIONS);
 		if (success) {
-			loadExperiments(history, dataProvider, new ArrayList<>());
+			loadExperiments(history, species, new ArrayList<>());
 		}
 		history.finishLoad();
 		return new LoadHistoryResponce(history);
 	}
 
-	private void loadExperiments(BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<Long> experimentIdsLoaded) {
+	private void loadExperiments(BulkLoadFileHistory history, Species species, List<Long> experimentIdsLoaded) {
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		Map<String, Set<String>> experiments = geneExpressionAnnotationService.getExperiments();
 		Map<String, Set<CrossReferenceFmsDTO>> crossReferences = geneExpressionAnnotationService.getCrossReferences();
@@ -104,7 +104,7 @@ public class GeneExpressionExecutor extends LoadFileExecutor {
 		history.setCount(EXPERIMENTS, geneExpressionAnnotationService.getExperiments().size());
 		for (String experimentId: experiments.keySet()) {
 			try {
-				GeneExpressionExperiment experiment = geneExpressionExperimentService.upsert(experimentId, experiments.get(experimentId), dataProvider, crossReferences.get(experimentId));
+				GeneExpressionExperiment experiment = geneExpressionExperimentService.upsert(experimentId, experiments.get(experimentId), species, crossReferences.get(experimentId));
 				if (experiment != null) {
 					experimentIdsLoaded.add(experiment.getId());
 					history.incrementCompleted(EXPERIMENTS);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneOntologyAnnotationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneOntologyAnnotationExecutor.java
@@ -10,12 +10,11 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.zip.GZIPInputStream;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
 import org.alliancegenome.curation_api.model.entities.GeneOntologyAnnotation;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.ingest.dto.GeneOntologyAnnotationDTO;
 import org.alliancegenome.curation_api.response.ObjectListResponse;
@@ -43,8 +42,7 @@ public class GeneOntologyAnnotationExecutor extends LoadFileExecutor {
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) throws IOException {
 
-		BulkFMSLoad fmsLoad = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
-		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fmsLoad.getFmsDataSubType());
+		Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 
 		CsvSchema csvSchema = CsvSchemaBuilder.gafSchema();
 		CsvMapper csvMapper = new CsvMapper();
@@ -63,21 +61,22 @@ public class GeneOntologyAnnotationExecutor extends LoadFileExecutor {
 
 		String name = bulkLoadFileHistory.getBulkLoad().getName();
 
-		List<Long> gafIdsBefore = geneOntologyAnnotationService.getAllGafIdsPerProvider(dataProvider);
+		List<Long> gafIdsBefore = geneOntologyAnnotationService.getAllGafIdsPerProvider(species);
 		Log.info("Prior ID count: " + gafIdsBefore.size());
 		List<Long> gafIdsLoaded = new ArrayList<>();
 
 		Map<String, Set<String>> annotationMap = new HashedMap<>();
 
 		for (GeneOntologyAnnotationDTO annotation : gafData) {
-			if (annotation.getDb().equals(dataProvider.resourceDescriptor)) {
+			String dbMatch = "XB".equals(species.getDataProvider().getAbbreviation()) ? species.getDataProvider().getFullName() : species.getDataProvider().getAbbreviation();
+			if (annotation.getDb().equals(dbMatch)) {
 				String curie = annotation.getDbObjectId();
-				String prefix = dataProvider.curiePrefix;
-				if (dataProvider == BackendBulkDataProvider.HUMAN || dataProvider == BackendBulkDataProvider.MGI) {
+				String prefix = species.getDataProvider().getAbbreviation() + ":";
+				if ("HUMAN".equals(species.getDisplayName()) || "MGI".equals(species.getDisplayName())) {
 					prefix = "";
 				}
-				if (dataProvider == BackendBulkDataProvider.XB) {
-					prefix = dataProvider.resourceDescriptor + ":";
+				if ("XB".equals(species.getDataProvider().getAbbreviation())) {
+					prefix = species.getDataProvider().getFullName() + ":";
 				}
 				
 				annotation.setDbObjectId(prefix + annotation.getDbObjectId());
@@ -91,7 +90,7 @@ public class GeneOntologyAnnotationExecutor extends LoadFileExecutor {
 
 			} else {
 				// System.out.println("DB not found: " + annotation.getDb() + " " +
-				// dataProvider.resourceDescriptor);
+				// dbMatch);
 			}
 		}
 
@@ -126,7 +125,7 @@ public class GeneOntologyAnnotationExecutor extends LoadFileExecutor {
 		}
 		ph.finishProcess();
 
-		runCleanup(geneOntologyAnnotationService, bulkLoadFileHistory, dataProvider.name(), gafIdsBefore, gafIdsLoaded, "GAF Load");
+		runCleanup(geneOntologyAnnotationService, bulkLoadFileHistory, species.getDisplayName(), gafIdsBefore, gafIdsLoaded, "GAF Load");
 		updateHistory(bulkLoadFileHistory);
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeoXrefExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeoXrefExecutor.java
@@ -5,12 +5,11 @@ import java.io.IOException;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.services.GeneService;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
@@ -33,27 +32,25 @@ public class GeoXrefExecutor extends LoadFileExecutor {
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) throws IOException {
 
-		BulkFMSLoad fms = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
-
 		XmlMapper mapper = new XmlMapper();
 		List<String> entrezIds = mapper.readValue(new GZIPInputStream(new FileInputStream(bulkLoadFileHistory.getBulkLoadFile().getLocalFilePath())), ESearchResult.class).getIdList().getIds();
-		
+
 		bulkLoadFileHistory.getBulkLoadFile().setRecordCount(entrezIds.size() + bulkLoadFileHistory.getBulkLoadFile().getRecordCount());
 		bulkLoadFileDAO.merge(bulkLoadFileHistory.getBulkLoadFile());
 
 		bulkLoadFileHistory.setCount(entrezIds.size());
 		updateHistory(bulkLoadFileHistory);
 
-		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fms.getFmsDataSubType());
+		Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 
-		runLoad(bulkLoadFileHistory, dataProvider, entrezIds);
+		runLoad(bulkLoadFileHistory, species, entrezIds);
 
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);
 		updateExceptions(bulkLoadFileHistory);
 	}
 
-	private void runLoad(BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<String> entrezIds) {
+	private void runLoad(BulkLoadFileHistory history, Species species, List<String> entrezIds) {
 		if (Thread.currentThread().isInterrupted()) {
 			history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
 			throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
@@ -62,8 +59,8 @@ public class GeoXrefExecutor extends LoadFileExecutor {
 		ph.addDisplayHandler(loadProcessDisplayService);
 		if (CollectionUtils.isNotEmpty(entrezIds)) {
 			String loadMessage = "GEO cross-reference update";
-			if (dataProvider != null) {
-				loadMessage = loadMessage + " for " + dataProvider.name();
+			if (species != null) {
+				loadMessage = loadMessage + " for " + species.getDisplayName();
 			}
 			ph.startProcess(loadMessage, entrezIds.size());
 			
@@ -72,7 +69,7 @@ public class GeoXrefExecutor extends LoadFileExecutor {
 			
 			for (String entrezId : entrezIds) {
 				try {
-					geneService.addGeoXref(entrezId, dataProvider);
+					geneService.addGeoXref(entrezId, species);
 					history.incrementCompleted();
 				} catch (ObjectUpdateException e) {
 					history.incrementFailed();

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/HTPExpressionDatasetAnnotationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/HTPExpressionDatasetAnnotationExecutor.java
@@ -7,7 +7,7 @@ import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.dao.ExternalDataBaseEntityDAO;
 import org.alliancegenome.curation_api.dao.HTPExpressionDatasetAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
@@ -22,6 +22,7 @@ import org.alliancegenome.curation_api.response.LoadHistoryResponce;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.services.ExternalDataBaseEntityService;
 import org.alliancegenome.curation_api.services.HTPExpressionDatasetAnnotationService;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
 import org.apache.commons.lang3.StringUtils;
 
@@ -36,6 +37,7 @@ public class HTPExpressionDatasetAnnotationExecutor extends LoadFileExecutor {
 	@Inject ExternalDataBaseEntityDAO externalDataBaseEntityDAO;
 	@Inject HTPExpressionDatasetAnnotationService htpExpressionDatasetAnnotationService;
 	@Inject HTPExpressionDatasetAnnotationDAO htpExpressionDatasetAnnotationDAO;
+	@Inject SpeciesService speciesService;
 	
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) {
 		try {
@@ -50,19 +52,19 @@ public class HTPExpressionDatasetAnnotationExecutor extends LoadFileExecutor {
 				bulkLoadFileHistory.getBulkLoadFile().setAllianceMemberReleaseVersion(htpExpressionDatasetData.getMetaData().getRelease());
 			}
 
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fms.getFmsDataSubType());
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 			List<Long> htpAnnotationsIdsLoaded = new ArrayList<>();
-			List<Long> previousIds = htpExpressionDatasetAnnotationService.getAnnotationIdsByDataProvider(dataProvider.name());
+			List<Long> previousIds = htpExpressionDatasetAnnotationService.getAnnotationIdsByDataProvider(species.getDisplayName());
 			
 			bulkLoadFileDAO.merge(bulkLoadFileHistory.getBulkLoadFile());
 
 			bulkLoadFileHistory.setCount(htpExpressionDatasetData.getData().size());
 			updateHistory(bulkLoadFileHistory);
 			
-			boolean success = runLoad(bulkLoadFileHistory, dataProvider, htpExpressionDatasetData.getData(), htpAnnotationsIdsLoaded);
-			
+			boolean success = runLoad(bulkLoadFileHistory, species, htpExpressionDatasetData.getData(), htpAnnotationsIdsLoaded);
+
 			if (success) {
-				runCleanup(htpExpressionDatasetAnnotationService, bulkLoadFileHistory, dataProvider.name(), previousIds, htpAnnotationsIdsLoaded, fms.getFmsDataType());
+				runCleanup(htpExpressionDatasetAnnotationService, bulkLoadFileHistory, species.getDisplayName(), previousIds, htpAnnotationsIdsLoaded, fms.getFmsDataType());
 			}
 			bulkLoadFileHistory.finishLoad();
 
@@ -75,15 +77,15 @@ public class HTPExpressionDatasetAnnotationExecutor extends LoadFileExecutor {
 		}
 	}
 
-	private boolean runLoad(BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<HTPExpressionDatasetAnnotationFmsDTO> htpDatasetAnnotations, List<Long> htpAnnotationsIdsLoaded) {
+	private boolean runLoad(BulkLoadFileHistory history, Species species, List<HTPExpressionDatasetAnnotationFmsDTO> htpDatasetAnnotations, List<Long> htpAnnotationsIdsLoaded) {
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.addDisplayHandler(loadProcessDisplayService);
-		ph.startProcess("HTP Expression Dataset Annotation DTO Update for " + dataProvider.name(), htpDatasetAnnotations.size() * 2);
+		ph.startProcess("HTP Expression Dataset Annotation DTO Update for " + species.getDisplayName(), htpDatasetAnnotations.size() * 2);
 
 		updateHistory(history);
 		for (HTPExpressionDatasetAnnotationFmsDTO dto : htpDatasetAnnotations) {
 			try {
-				ObjectResponse<HTPExpressionDatasetAnnotation> dbObject = htpExpressionDatasetAnnotationService.upsert(dto, dataProvider);
+				ObjectResponse<HTPExpressionDatasetAnnotation> dbObject = htpExpressionDatasetAnnotationService.upsert(dto, species);
 				history.incrementCompleted();
 				if (dbObject.getEntity() != null) {
 					htpAnnotationsIdsLoaded.add(dbObject.getEntity().getId());
@@ -119,9 +121,9 @@ public class HTPExpressionDatasetAnnotationExecutor extends LoadFileExecutor {
 		List<Long> htpAnnotationsIdsLoaded = new ArrayList<>();
 
 		BulkLoadFileHistory history = new BulkLoadFileHistory(htpDataset.size());
-		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(dataProviderName);
+		Species species = speciesService.getByDisplayName(dataProviderName);
 		history = bulkLoadFileHistoryDAO.persist(history);
-		runLoad(history, dataProvider, htpDataset, htpAnnotationsIdsLoaded);
+		runLoad(history, species, htpDataset, htpAnnotationsIdsLoaded);
 		history.finishLoad();
 
 		return new LoadHistoryResponce(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/HTPExpressionDatasetSampleAnnotationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/HTPExpressionDatasetSampleAnnotationExecutor.java
@@ -7,7 +7,7 @@ import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.dao.ExternalDataBaseEntityDAO;
 import org.alliancegenome.curation_api.dao.HTPExpressionDatasetSampleAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
 import org.alliancegenome.curation_api.model.entities.HTPExpressionDatasetSampleAnnotation;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
@@ -41,19 +41,19 @@ public class HTPExpressionDatasetSampleAnnotationExecutor extends LoadFileExecut
 			bulkLoadFileHistory.getBulkLoadFile().setAllianceMemberReleaseVersion(htpExpressionDatasetSampleData.getMetaData().getRelease());
 			}
 
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fms.getFmsDataSubType());
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 			List<Long> htpAnnotationsIdsLoaded = new ArrayList<>();
-			List<Long> previousIds = htpExpressionDatasetSampleAnnotationService.getAnnotationIdsByDataProvider(dataProvider.name());
+			List<Long> previousIds = htpExpressionDatasetSampleAnnotationService.getAnnotationIdsByDataProvider(species.getDisplayName());
 			
 			bulkLoadFileDAO.merge(bulkLoadFileHistory.getBulkLoadFile());
 
 			bulkLoadFileHistory.setCount((long) htpExpressionDatasetSampleData.getData().size());
 			updateHistory(bulkLoadFileHistory);
 			
-			boolean success = runLoad(htpExpressionDatasetSampleAnnotationService, bulkLoadFileHistory, dataProvider, htpExpressionDatasetSampleData.getData(), htpAnnotationsIdsLoaded);
-			
+			boolean success = runLoad(htpExpressionDatasetSampleAnnotationService, bulkLoadFileHistory, species, htpExpressionDatasetSampleData.getData(), htpAnnotationsIdsLoaded);
+
 			if (success) {
-				runCleanup(htpExpressionDatasetSampleAnnotationService, bulkLoadFileHistory, dataProvider.name(), previousIds, htpAnnotationsIdsLoaded, fms.getFmsDataType());
+				runCleanup(htpExpressionDatasetSampleAnnotationService, bulkLoadFileHistory, species.getDisplayName(), previousIds, htpAnnotationsIdsLoaded, fms.getFmsDataType());
 			}
 			bulkLoadFileHistory.finishLoad();
 

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/LoadFileExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/LoadFileExecutor.java
@@ -13,7 +13,7 @@ import org.alliancegenome.curation_api.config.RestDefaultObjectMapper;
 import org.alliancegenome.curation_api.dao.loads.BulkLoadFileDAO;
 import org.alliancegenome.curation_api.dao.loads.BulkLoadFileExceptionDAO;
 import org.alliancegenome.curation_api.dao.loads.BulkLoadFileHistoryDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.enums.JobStatus;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
@@ -31,6 +31,7 @@ import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.LoadHistoryResponce;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.services.APIVersionInfoService;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.alliancegenome.curation_api.services.base.BaseEntityCrudService;
 import org.alliancegenome.curation_api.services.processing.LoadProcessDisplayService;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
@@ -58,6 +59,8 @@ public class LoadFileExecutor {
 	APIVersionInfoService apiVersionInfoService;
 	@Inject
 	SlackNotifier slackNotifier;
+	@Inject
+	SpeciesService speciesService;
 
 	record IdObject(long id) {
 	}
@@ -196,38 +199,38 @@ public class LoadFileExecutor {
 		List<Long> idsLoaded = new ArrayList<>();
 		BulkLoadFileHistory history = new BulkLoadFileHistory(objectList.size());
 		history = bulkLoadFileHistoryDAO.persist(history);
-		BackendBulkDataProvider dataProvider = null;
+		Species species = null;
 		if (dataProviderName != null) {
-			dataProvider = BackendBulkDataProvider.valueOf(dataProviderName);
+			species = speciesService.getByDisplayName(dataProviderName);
 		}
-		runLoad(service, history, dataProvider, objectList, idsLoaded, true, "Records");
+		runLoad(service, history, species, objectList, idsLoaded, true, "Records");
 		history.finishLoad();
 		return new LoadHistoryResponce(history);
 	}
 
-	protected <E extends AuditedObject, T extends BaseDTO> boolean runLoad(BaseUpsertServiceInterface<E, T> service, BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<T> objectList, List<Long> idsAdded) {
-		return runLoad(service, history, dataProvider, objectList, idsAdded, true, "Records");
+	protected <E extends AuditedObject, T extends BaseDTO> boolean runLoad(BaseUpsertServiceInterface<E, T> service, BulkLoadFileHistory history, Species species, List<T> objectList, List<Long> idsAdded) {
+		return runLoad(service, history, species, objectList, idsAdded, true, "Records");
 	}
 
-	protected <E extends AuditedObject, T extends BaseDTO> boolean runLoad(BaseUpsertServiceInterface<E, T> service, BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<T> objectList, List<Long> idsAdded, Boolean terminateFailing) {
-		return runLoad(service, history, dataProvider, objectList, idsAdded, terminateFailing, "Records");
+	protected <E extends AuditedObject, T extends BaseDTO> boolean runLoad(BaseUpsertServiceInterface<E, T> service, BulkLoadFileHistory history, Species species, List<T> objectList, List<Long> idsAdded, Boolean terminateFailing) {
+		return runLoad(service, history, species, objectList, idsAdded, terminateFailing, "Records");
 	}
 
-	protected <E extends AuditedObject, T extends BaseDTO> boolean runLoad(BaseUpsertServiceInterface<E, T> service, BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<T> objectList, List<Long> idsAdded, String countType) {
-		return runLoad(service, history, dataProvider, objectList, idsAdded, true, countType);
+	protected <E extends AuditedObject, T extends BaseDTO> boolean runLoad(BaseUpsertServiceInterface<E, T> service, BulkLoadFileHistory history, Species species, List<T> objectList, List<Long> idsAdded, String countType) {
+		return runLoad(service, history, species, objectList, idsAdded, true, countType);
 	}
 
-	protected <E extends AuditedObject, T extends BaseDTO> boolean runLoad(BaseUpsertServiceInterface<E, T> service, BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<T> objectList, List<Long> idsAdded, Boolean terminateFailing, String countType) {
+	protected <E extends AuditedObject, T extends BaseDTO> boolean runLoad(BaseUpsertServiceInterface<E, T> service, BulkLoadFileHistory history, Species species, List<T> objectList, List<Long> idsAdded, Boolean terminateFailing, String countType) {
 		String dataType = "";
 		if (CollectionUtils.isNotEmpty(objectList)) {
 			dataType = objectList.get(0).getClass().getSimpleName();
 			dataType = dataType.replace("FmsDTO", "");
 			dataType = dataType.replace("DTO", "");
 		}
-		return runLoad(service, history, dataProvider, objectList, idsAdded, terminateFailing, countType, dataType);
+		return runLoad(service, history, species, objectList, idsAdded, terminateFailing, countType, dataType);
 	}
 
-	protected <E extends AuditedObject, T extends BaseDTO> boolean runLoad(BaseUpsertServiceInterface<E, T> service, BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<T> objectList, List<Long> idsAdded, Boolean terminateFailing, String countType, String dataType) {
+	protected <E extends AuditedObject, T extends BaseDTO> boolean runLoad(BaseUpsertServiceInterface<E, T> service, BulkLoadFileHistory history, Species species, List<T> objectList, List<Long> idsAdded, Boolean terminateFailing, String countType, String dataType) {
 		if (Thread.currentThread().isInterrupted()) {
 			history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
 			throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
@@ -236,8 +239,8 @@ public class LoadFileExecutor {
 		ph.addDisplayHandler(loadProcessDisplayService);
 		if (CollectionUtils.isNotEmpty(objectList)) {
 			String loadMessage = dataType + " update";
-			if (dataProvider != null) {
-				loadMessage = loadMessage + " for " + dataProvider.name();
+			if (species != null) {
+				loadMessage = loadMessage + " for " + species.getDisplayName();
 			}
 			ph.startProcess(loadMessage, objectList.size());
 
@@ -245,7 +248,7 @@ public class LoadFileExecutor {
 			updateHistory(history);
 			for (T dtoObject : objectList) {
 				try {
-					ObjectResponse<E> dbObject = service.upsert(dtoObject, dataProvider);
+					ObjectResponse<E> dbObject = service.upsert(dtoObject, species);
 					if (dbObject.hasWarnings()) {
 						for (Entry<String, String> entry : dbObject.getWarningMessages().entrySet()) {
 							history.incrementWarnings(countType);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/OrthologyExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/OrthologyExecutor.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.dao.orthology.GeneToGeneOrthologyGeneratedDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
@@ -40,8 +40,8 @@ public class OrthologyExecutor extends LoadFileExecutor {
 			}
 
 			List<Long> orthoPairIdsLoaded = new ArrayList<>();
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fms.getFmsDataSubType());
-			List<Long> orthoPairIdsBefore = generatedOrthologyService.getAllOrthologyPairIdsBySubjectGeneDataProvider(dataProvider);
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
+			List<Long> orthoPairIdsBefore = generatedOrthologyService.getAllOrthologyPairIdsBySubjectGeneDataProvider(species);
 			log.debug("runLoad: Before: total " + orthoPairIdsBefore.size());
 
 			bulkLoadFileDAO.merge(bulkLoadFileHistory.getBulkLoadFile());
@@ -49,7 +49,7 @@ public class OrthologyExecutor extends LoadFileExecutor {
 			bulkLoadFileHistory.setCount(orthologyData.getData().size());
 			updateHistory(bulkLoadFileHistory);
 
-			boolean success = runLoad(generatedOrthologyService, bulkLoadFileHistory, dataProvider, orthologyData.getData(), orthoPairIdsLoaded);
+			boolean success = runLoad(generatedOrthologyService, bulkLoadFileHistory, species, orthologyData.getData(), orthoPairIdsLoaded);
 			if (success) {
 				runCleanup(generatedOrthologyService, bulkLoadFileHistory, fms.getFmsDataSubType(), orthoPairIdsBefore, orthoPairIdsLoaded, fms.getFmsDataType());
 			}

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/ParalogyExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/ParalogyExecutor.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.dao.GeneToGeneParalogyDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
 import org.alliancegenome.curation_api.model.entities.GeneToGeneParalogy;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
@@ -39,8 +39,8 @@ public class ParalogyExecutor extends LoadFileExecutor {
 			}
 
 			List<Long> paralogyIdsLoaded = new ArrayList<>();
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fms.getFmsDataSubType());
-			List<Long> paralogyPairsBefore = geneToGeneParalogyService.getAllParalogyPairIdsBySubjectGeneDataProvider(dataProvider);
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
+			List<Long> paralogyPairsBefore = geneToGeneParalogyService.getAllParalogyPairIdsBySubjectGeneDataProvider(species);
 			Log.debug("runLoad: Before: total " + paralogyPairsBefore.size());
 
 			bulkLoadFileDAO.merge(bulkLoadFileHistory.getBulkLoadFile());
@@ -48,7 +48,7 @@ public class ParalogyExecutor extends LoadFileExecutor {
 			bulkLoadFileHistory.setCount(paralogyData.getData().size());
 			updateHistory(bulkLoadFileHistory);
 
-			boolean success = runLoad(geneToGeneParalogyService, bulkLoadFileHistory, dataProvider, paralogyData.getData(), paralogyIdsLoaded, false);
+			boolean success = runLoad(geneToGeneParalogyService, bulkLoadFileHistory, species, paralogyData.getData(), paralogyIdsLoaded, false);
 
 			if (success) {
 				runCleanup(geneToGeneParalogyService, bulkLoadFileHistory, fms.getFmsDataSubType(), paralogyPairsBefore, paralogyIdsLoaded, fms.getFmsDataType());

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/PhenotypeAnnotationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/PhenotypeAnnotationExecutor.java
@@ -7,19 +7,19 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
 import org.alliancegenome.curation_api.model.entities.Molecule;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.PhenotypeFmsDTO;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.PhenotypeIngestFmsDTO;
 import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.LoadHistoryResponce;
 import org.alliancegenome.curation_api.services.PhenotypeAnnotationService;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -31,12 +31,12 @@ import jakarta.inject.Inject;
 public class PhenotypeAnnotationExecutor extends LoadFileExecutor {
 
 	@Inject PhenotypeAnnotationService phenotypeAnnotationService;
+	@Inject SpeciesService speciesService;
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) {
 		try {
 
-			BulkFMSLoad fmsLoad = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fmsLoad.getFmsDataSubType());
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 
 			PhenotypeIngestFmsDTO phenotypeData = mapper.readValue(new GZIPInputStream(new FileInputStream(bulkLoadFileHistory.getBulkLoadFile().getLocalFilePath())), PhenotypeIngestFmsDTO.class);
 			bulkLoadFileHistory.getBulkLoadFile().setRecordCount(phenotypeData.getData().size());
@@ -53,13 +53,13 @@ public class PhenotypeAnnotationExecutor extends LoadFileExecutor {
 			updateHistory(bulkLoadFileHistory);
 
 			Set<Long> annotationIdsLoaded = new HashSet<>();
-			List<Long> annotationIdsBefore = phenotypeAnnotationService.getAnnotationIdsByDataProvider(dataProvider);
+			List<Long> annotationIdsBefore = phenotypeAnnotationService.getAnnotationIdsBySpecies(species);
 
-			phenotypeAnnotationService.preloadUniqueIds(dataProvider);
+			phenotypeAnnotationService.preloadUniqueIds(species);
 
-			runLoad(bulkLoadFileHistory, phenotypeData.getData(), annotationIdsLoaded, dataProvider);
-			
-			runCleanup(phenotypeAnnotationService, bulkLoadFileHistory, dataProvider.name(), annotationIdsBefore, annotationIdsLoaded.stream().collect(Collectors.toList()), "phenotype annotation");
+			runLoad(bulkLoadFileHistory, phenotypeData.getData(), annotationIdsLoaded, species);
+
+			runCleanup(phenotypeAnnotationService, bulkLoadFileHistory, species.getDisplayName(), annotationIdsBefore, annotationIdsLoaded.stream().collect(Collectors.toList()), "phenotype annotation");
 
 			bulkLoadFileHistory.finishLoad();
 			updateHistory(bulkLoadFileHistory);
@@ -75,33 +75,33 @@ public class PhenotypeAnnotationExecutor extends LoadFileExecutor {
 		Set<Long> annotationIdsLoaded = new HashSet<>();
 		BulkLoadFileHistory history = new BulkLoadFileHistory(annotations.size());
 		history = bulkLoadFileHistoryDAO.persist(history);
-		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(dataProviderName);
-		runLoad(history, annotations, annotationIdsLoaded, dataProvider);
+		Species species = speciesService.getByDisplayName(dataProviderName);
+		runLoad(history, annotations, annotationIdsLoaded, species);
 		history.finishLoad();
 
 		return new LoadHistoryResponce(history);
 	}
 
-	private void runLoad(BulkLoadFileHistory history, List<PhenotypeFmsDTO> annotations, Set<Long> idsAdded, BackendBulkDataProvider dataProvider) {
+	private void runLoad(BulkLoadFileHistory history, List<PhenotypeFmsDTO> annotations, Set<Long> idsAdded, Species species) {
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.addDisplayHandler(loadProcessDisplayService);
-		ph.startProcess("PhenotypeAnnotation update for " + dataProvider.name(), annotations.size());
+		ph.startProcess("PhenotypeAnnotation update for " + species.getDisplayName(), annotations.size());
 
-		loadPrimaryAnnotations(history, annotations, idsAdded, dataProvider, ph);
-		loadSecondaryAnnotations(history, annotations, idsAdded, dataProvider, ph);
+		loadPrimaryAnnotations(history, annotations, idsAdded, species, ph);
+		loadSecondaryAnnotations(history, annotations, idsAdded, species, ph);
 
 		ph.finishProcess();
 
 	}
 	
-	private void loadSecondaryAnnotations(BulkLoadFileHistory history, List<PhenotypeFmsDTO> annotations, Set<Long> idsAdded, BackendBulkDataProvider dataProvider, ProcessDisplayHelper ph) {
+	private void loadSecondaryAnnotations(BulkLoadFileHistory history, List<PhenotypeFmsDTO> annotations, Set<Long> idsAdded, Species species, ProcessDisplayHelper ph) {
 		for (PhenotypeFmsDTO dto : annotations) {
 			if (CollectionUtils.isEmpty(dto.getPrimaryGeneticEntityIds())) {
 				continue;
 			}
 
 			try {
-				phenotypeAnnotationService.addInferredOrAssertedEntities(dto, dataProvider, idsAdded);
+				phenotypeAnnotationService.addInferredOrAssertedEntities(dto, species, idsAdded);
 				history.incrementCompleted();
 			} catch (ObjectUpdateException e) {
 				history.incrementFailed();
@@ -121,14 +121,14 @@ public class PhenotypeAnnotationExecutor extends LoadFileExecutor {
 		updateHistory(history);
 	}
 
-	private void loadPrimaryAnnotations(BulkLoadFileHistory history, List<PhenotypeFmsDTO> annotations, Set<Long> idsAdded, BackendBulkDataProvider dataProvider, ProcessDisplayHelper ph) {
+	private void loadPrimaryAnnotations(BulkLoadFileHistory history, List<PhenotypeFmsDTO> annotations, Set<Long> idsAdded, Species species, ProcessDisplayHelper ph) {
 		for (PhenotypeFmsDTO dto : annotations) {
 			if (CollectionUtils.isNotEmpty(dto.getPrimaryGeneticEntityIds())) {
 				continue;
 			}
 
 			try {
-				Long primaryAnnotationId = phenotypeAnnotationService.upsertPrimaryAnnotation(dto, dataProvider);
+				Long primaryAnnotationId = phenotypeAnnotationService.upsertPrimaryAnnotation(dto, species);
 				if (primaryAnnotationId != null) {
 					history.incrementCompleted();
 					if (idsAdded != null) {

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/SequenceTargetingReagentExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/SequenceTargetingReagentExecutor.java
@@ -7,13 +7,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
 import org.alliancegenome.curation_api.model.entities.SequenceTargetingReagent;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.SequenceTargetingReagentFmsDTO;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.SequenceTargetingReagentIngestFmsDTO;
@@ -21,6 +20,7 @@ import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.LoadHistoryResponce;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.services.SequenceTargetingReagentService;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.alliancegenome.curation_api.services.associations.SequenceTargetingReagentGeneAssociationService;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
 import org.apache.commons.lang3.StringUtils;
@@ -34,12 +34,12 @@ public class SequenceTargetingReagentExecutor extends LoadFileExecutor {
 	SequenceTargetingReagentService sqtrService;
 	@Inject
 	SequenceTargetingReagentGeneAssociationService sqtrGeneAssociationService;
+	@Inject
+	SpeciesService speciesService;
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) {
 
 		try {
-
-			BulkFMSLoad fms = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
 
 			SequenceTargetingReagentIngestFmsDTO sqtrIngestFmsDTO = mapper.readValue(new GZIPInputStream(new FileInputStream(bulkLoadFileHistory.getBulkLoadFile().getLocalFilePath())), SequenceTargetingReagentIngestFmsDTO.class);
 			bulkLoadFileHistory.getBulkLoadFile().setRecordCount(sqtrIngestFmsDTO.getData().size());
@@ -51,23 +51,23 @@ public class SequenceTargetingReagentExecutor extends LoadFileExecutor {
 				bulkLoadFileHistory.getBulkLoadFile().setAllianceMemberReleaseVersion(sqtrIngestFmsDTO.getMetaData().getRelease());
 			}
 
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fms.getFmsDataSubType());
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 
 			Map<String, List<Long>> idsAdded = new HashMap<String, List<Long>>();
 			idsAdded.put("SQTR", new ArrayList<Long>());
 			idsAdded.put("SQTRGeneAssociation", new ArrayList<Long>());
 
-			Map<String, List<Long>> previousIds = getPreviouslyLoadedIds(dataProvider);
+			Map<String, List<Long>> previousIds = getPreviouslyLoadedIds(species);
 
 			bulkLoadFileDAO.merge(bulkLoadFileHistory.getBulkLoadFile());
 
 			bulkLoadFileHistory.setCount((long) sqtrIngestFmsDTO.getData().size() * 2);
 			updateHistory(bulkLoadFileHistory);
-			
-			runLoad(bulkLoadFileHistory, dataProvider, sqtrIngestFmsDTO.getData(), idsAdded.get("SQTR"), idsAdded.get("SQTRGeneAssociation"));
 
-			runCleanup(sqtrService, bulkLoadFileHistory, dataProvider.name(), previousIds.get("SQTRGeneAssociation"), idsAdded.get("SQTRGeneAssociation"), "SQTR Gene Associations");
-			runCleanup(sqtrService, bulkLoadFileHistory, dataProvider.name(), previousIds.get("SQTR"), idsAdded.get("SQTR"), "SQTR");
+			runLoad(bulkLoadFileHistory, species, sqtrIngestFmsDTO.getData(), idsAdded.get("SQTR"), idsAdded.get("SQTRGeneAssociation"));
+
+			runCleanup(sqtrService, bulkLoadFileHistory, species.getDisplayName(), previousIds.get("SQTRGeneAssociation"), idsAdded.get("SQTRGeneAssociation"), "SQTR Gene Associations");
+			runCleanup(sqtrService, bulkLoadFileHistory, species.getDisplayName(), previousIds.get("SQTR"), idsAdded.get("SQTR"), "SQTR");
 
 			bulkLoadFileHistory.finishLoad();
 
@@ -79,12 +79,12 @@ public class SequenceTargetingReagentExecutor extends LoadFileExecutor {
 		}
 	}
 
-	private Map<String, List<Long>> getPreviouslyLoadedIds(BackendBulkDataProvider dataProvider) {
+	private Map<String, List<Long>> getPreviouslyLoadedIds(Species species) {
 		Map<String, List<Long>> previousIds = new HashMap<>();
-		
-		previousIds.put("SQTR", sqtrService.getIdsByDataProvider(dataProvider.name()));
-		previousIds.put("SQTRGeneAssociation", sqtrGeneAssociationService.getIdsByDataProvider(dataProvider));
-		
+
+		previousIds.put("SQTR", sqtrService.getIdsByDataProvider(species.getDisplayName()));
+		previousIds.put("SQTRGeneAssociation", sqtrGeneAssociationService.getIdsBySpecies(species));
+
 		return previousIds;
 	}
 
@@ -94,31 +94,31 @@ public class SequenceTargetingReagentExecutor extends LoadFileExecutor {
 
 		BulkLoadFileHistory history = new BulkLoadFileHistory(sqtrDTOs.size() * 2);
 		history = bulkLoadFileHistoryDAO.persist(history);
-		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(dataProviderName);
-		runLoad(history, dataProvider, sqtrDTOs, sqtrIdsLoaded, sqtrGeneAssociationIdsLoaded);
+		Species species = speciesService.getByDisplayName(dataProviderName);
+		runLoad(history, species, sqtrDTOs, sqtrIdsLoaded, sqtrGeneAssociationIdsLoaded);
 		history.finishLoad();
 
 		return new LoadHistoryResponce(history);
 	}
 
-	private void runLoad(BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<SequenceTargetingReagentFmsDTO> sqtrs, List<Long> sqtrIdsLoaded, List<Long> sqtrGeneAssociationIdsLoaded) {
+	private void runLoad(BulkLoadFileHistory history, Species species, List<SequenceTargetingReagentFmsDTO> sqtrs, List<Long> sqtrIdsLoaded, List<Long> sqtrGeneAssociationIdsLoaded) {
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.addDisplayHandler(loadProcessDisplayService);
-		ph.startProcess("Sequence Targeting Reagent DTO Update for " + dataProvider.name(), sqtrs.size() * 2);
+		ph.startProcess("Sequence Targeting Reagent DTO Update for " + species.getDisplayName(), sqtrs.size() * 2);
 
-		loadSequenceTargetingReagents(history, sqtrs, sqtrIdsLoaded, dataProvider, ph);
-		loadSequenceTargetingReagentGeneAssociations(history, sqtrs, sqtrGeneAssociationIdsLoaded, dataProvider, ph);
+		loadSequenceTargetingReagents(history, sqtrs, sqtrIdsLoaded, species, ph);
+		loadSequenceTargetingReagentGeneAssociations(history, sqtrs, sqtrGeneAssociationIdsLoaded, ph);
 
 		ph.finishProcess();
 
 	}
 
 	private void loadSequenceTargetingReagents(BulkLoadFileHistory history, List<SequenceTargetingReagentFmsDTO> sqtrs,
-			List<Long> idsLoaded, BackendBulkDataProvider dataProvider, ProcessDisplayHelper ph) {
+			List<Long> idsLoaded, Species species, ProcessDisplayHelper ph) {
 		for (SequenceTargetingReagentFmsDTO dto : sqtrs) {
 			try {
 				
-				ObjectResponse<SequenceTargetingReagent> dbObject = sqtrService.upsert(dto, dataProvider);
+				ObjectResponse<SequenceTargetingReagent> dbObject = sqtrService.upsert(dto, species);
 				history.incrementCompleted();
 				if (idsLoaded != null) {
 					idsLoaded.add(dbObject.getEntity().getId());
@@ -140,12 +140,12 @@ public class SequenceTargetingReagentExecutor extends LoadFileExecutor {
 	}
 
 	private void loadSequenceTargetingReagentGeneAssociations(BulkLoadFileHistory history,
-			List<SequenceTargetingReagentFmsDTO> sqtrs, List<Long> idsLoaded, BackendBulkDataProvider dataProvider,
+			List<SequenceTargetingReagentFmsDTO> sqtrs, List<Long> idsLoaded,
 			ProcessDisplayHelper ph) {
 
 		for (SequenceTargetingReagentFmsDTO dto : sqtrs) {
 			try {
-				List<Long> associationIds = sqtrGeneAssociationService.loadGeneAssociations(dto, dataProvider);
+				List<Long> associationIds = sqtrGeneAssociationService.loadGeneAssociations(dto);
 				history.incrementCompleted();
 				if (idsLoaded != null) {
 					idsLoaded.addAll(associationIds);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/VariantExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/VariantExecutor.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.alliancegenome.curation_api.dao.VariantDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
 import org.alliancegenome.curation_api.model.ingest.dto.IngestDTO;
@@ -25,7 +25,7 @@ public class VariantExecutor extends LoadFileExecutor {
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory, Boolean cleanUp) {
 
 		BulkManualLoad manual = (BulkManualLoad) bulkLoadFileHistory.getBulkLoad();
-		Log.info("Running with: " + manual.getDataProvider().name());
+		Log.info("Running with: " + manual.getSpecies().getDisplayName());
 
 		IngestDTO ingestDto = readIngestFile(bulkLoadFileHistory, VariantDTO.class);
 		if (ingestDto == null) {
@@ -37,12 +37,12 @@ public class VariantExecutor extends LoadFileExecutor {
 			return;
 		}
 
-		BackendBulkDataProvider dataProvider = manual.getDataProvider();
+		Species species = manual.getSpecies();
 
 		List<Long> variantIdsLoaded = new ArrayList<>();
 		List<Long> variantIdsBefore = new ArrayList<>();
 		if (cleanUp) {
-			variantIdsBefore.addAll(variantService.getIdsByDataProvider(dataProvider.name()));
+			variantIdsBefore.addAll(variantService.getIdsByDataProvider(species.getDisplayName()));
 			Log.debug("runLoad: Before: total " + variantIdsBefore.size());
 		}
 
@@ -52,9 +52,9 @@ public class VariantExecutor extends LoadFileExecutor {
 		bulkLoadFileHistory.setCount(variants.size());
 		updateHistory(bulkLoadFileHistory);
 		
-		boolean success = runLoad(variantService, bulkLoadFileHistory, dataProvider, variants, variantIdsLoaded);
+		boolean success = runLoad(variantService, bulkLoadFileHistory, species, variants, variantIdsLoaded);
 		if (success && cleanUp) {
-			runCleanup(variantService, bulkLoadFileHistory, dataProvider.name(), variantIdsBefore, variantIdsLoaded, "variant");
+			runCleanup(variantService, bulkLoadFileHistory, species.getDisplayName(), variantIdsBefore, variantIdsLoaded, "variant");
 		}
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/VariantFmsExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/VariantFmsExecutor.java
@@ -5,16 +5,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.VariantFmsDTO;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.VariantIngestFmsDTO;
 import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.LoadHistoryResponce;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.alliancegenome.curation_api.services.VariantService;
 import org.alliancegenome.curation_api.services.associations.AlleleVariantAssociationService;
 import org.alliancegenome.curation_api.services.associations.CuratedVariantGenomicLocationAssociationService;
@@ -32,32 +32,31 @@ public class VariantFmsExecutor extends LoadFileExecutor {
 	@Inject CuratedVariantGenomicLocationAssociationService curatedVariantGenomicLocationAssociationService;
 	@Inject AlleleVariantAssociationService alleleVariantAssociationService;
 	@Inject VariantFmsDTOValidator variantFmsDtoValidator;
+	@Inject SpeciesService speciesService;
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) {
 		try {
-			BulkFMSLoad fms = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
-		
 			VariantIngestFmsDTO variantData = mapper.readValue(new GZIPInputStream(new FileInputStream(bulkLoadFileHistory.getBulkLoadFile().getLocalFilePath())), VariantIngestFmsDTO.class);
-			
+
 			if (variantData.getMetaData() != null && StringUtils.isNotBlank(variantData.getMetaData().getRelease())) {
 				bulkLoadFileHistory.getBulkLoadFile().setAllianceMemberReleaseVersion(variantData.getMetaData().getRelease());
 			}
-		
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fms.getFmsDataSubType());
-		
+
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
+
 			List<Long> entityIdsAdded = new ArrayList<>();
 			List<Long> locationIdsAdded = new ArrayList<>();
 			List<Long> associationIdsAdded = new ArrayList<>();
-			
+
 			bulkLoadFileDAO.merge(bulkLoadFileHistory.getBulkLoadFile());
-		
+
 			updateHistory(bulkLoadFileHistory);
-			
-			boolean success = runLoad(bulkLoadFileHistory, variantData.getData(), entityIdsAdded, locationIdsAdded, associationIdsAdded, dataProvider);
+
+			boolean success = runLoad(bulkLoadFileHistory, variantData.getData(), entityIdsAdded, locationIdsAdded, associationIdsAdded, species);
 			if (success) {
-				runCleanup(alleleVariantAssociationService, bulkLoadFileHistory, dataProvider.name(), alleleVariantAssociationService.getAssociationsByDataProvider(dataProvider), associationIdsAdded, "Allele variant association");
-				runCleanup(curatedVariantGenomicLocationAssociationService, bulkLoadFileHistory, dataProvider.name(), curatedVariantGenomicLocationAssociationService.getIdsByDataProvider(dataProvider), locationIdsAdded, "Curated variant genomic location association");
-				runCleanup(variantService, bulkLoadFileHistory, dataProvider.name(), variantService.getIdsByDataProvider(dataProvider.name()), entityIdsAdded, "Variant");
+				runCleanup(alleleVariantAssociationService, bulkLoadFileHistory, species.getDisplayName(), alleleVariantAssociationService.getAssociationsBySpecies(species), associationIdsAdded, "Allele variant association");
+				runCleanup(curatedVariantGenomicLocationAssociationService, bulkLoadFileHistory, species.getDisplayName(), curatedVariantGenomicLocationAssociationService.getIdsBySpecies(species), locationIdsAdded, "Curated variant genomic location association");
+				runCleanup(variantService, bulkLoadFileHistory, species.getDisplayName(), variantService.getIdsByDataProvider(species.getDisplayName()), entityIdsAdded, "Variant");
 			}
 			bulkLoadFileHistory.finishLoad();
 			updateHistory(bulkLoadFileHistory);
@@ -74,11 +73,11 @@ public class VariantFmsExecutor extends LoadFileExecutor {
 			List<Long> entityIdsAdded,
 			List<Long> locationIdsAdded,
 			List<Long> associationIdsAdded,
-			BackendBulkDataProvider dataProvider) {
+			Species species) {
 
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.addDisplayHandler(loadProcessDisplayService);
-		ph.startProcess("Variant update for " + dataProvider.name(), data.size());
+		ph.startProcess("Variant update for " + species.getDisplayName(), data.size());
 		
 		history.setCount("Entities", data.size());
 		history.setCount("Locations", data.size());
@@ -90,7 +89,7 @@ public class VariantFmsExecutor extends LoadFileExecutor {
 			countType = "Entities";
 			Long variantId = null;
 			try {
-				variantId = variantFmsDtoValidator.validateVariant(dto, entityIdsAdded, dataProvider);
+				variantId = variantFmsDtoValidator.validateVariant(dto, entityIdsAdded, species);
 				history.incrementCompleted(countType);
 			} catch (ObjectUpdateException e) {
 				history.incrementFailed(countType);
@@ -139,10 +138,10 @@ public class VariantFmsExecutor extends LoadFileExecutor {
 
 	public APIResponse runLoadApi(String dataProviderName, List<VariantFmsDTO> gffData) {
 		List<Long> idsAdded = new ArrayList<>();
-		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(dataProviderName);
+		Species species = speciesService.getByDisplayName(dataProviderName);
 		BulkLoadFileHistory history = new BulkLoadFileHistory();
 		history = bulkLoadFileHistoryDAO.persist(history);
-		runLoad(history, gffData, idsAdded, idsAdded, idsAdded, dataProvider);
+		runLoad(history, gffData, idsAdded, idsAdded, idsAdded, species);
 		history.finishLoad();
 		
 		return new LoadHistoryResponce(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/VepGeneExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/VepGeneExecutor.java
@@ -7,18 +7,18 @@ import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.dao.PredictedVariantConsequenceDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.VepTxtDTO;
 import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.LoadHistoryResponce;
 import org.alliancegenome.curation_api.services.PredictedVariantConsequenceService;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
@@ -37,6 +37,7 @@ public class VepGeneExecutor extends LoadFileExecutor {
 
 	@Inject PredictedVariantConsequenceDAO predictedVariantConsequenceDAO;
 	@Inject PredictedVariantConsequenceService predictedVariantConsequenceService;
+	@Inject SpeciesService speciesService;
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) {
 		try {
@@ -47,18 +48,17 @@ public class VepGeneExecutor extends LoadFileExecutor {
 			List<VepTxtDTO> vepData = it.readAll();
 			
 
-			BulkFMSLoad fmsLoad = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fmsLoad.getFmsDataSubType());
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 
 			List<Long> consequenceIdsLoaded = new ArrayList<>();
-			List<Long> consequenceIdsBefore = predictedVariantConsequenceService.getGeneLevelIdsByDataProvider(dataProvider);
+			List<Long> consequenceIdsBefore = predictedVariantConsequenceService.getGeneLevelIdsByDataProvider(species);
 			
 			bulkLoadFileHistory.setCount(vepData.size());
 			updateHistory(bulkLoadFileHistory);
 			
-			boolean success = runLoad(bulkLoadFileHistory, dataProvider, vepData, consequenceIdsLoaded);
+			boolean success = runLoad(bulkLoadFileHistory, species, vepData, consequenceIdsLoaded);
 			if (success) {
-				runCleanup(predictedVariantConsequenceService, bulkLoadFileHistory, dataProvider.name(), consequenceIdsBefore, consequenceIdsLoaded, "gene-level predicted variant consequences");
+				runCleanup(predictedVariantConsequenceService, bulkLoadFileHistory, species.getDisplayName(), consequenceIdsBefore, consequenceIdsLoaded, "gene-level predicted variant consequences");
 			}
 			bulkLoadFileHistory.finishLoad();
 			updateHistory(bulkLoadFileHistory);
@@ -70,7 +70,7 @@ public class VepGeneExecutor extends LoadFileExecutor {
 		}
 	}
 	
-	protected boolean runLoad(BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<VepTxtDTO> objectList, List<Long> idsUpdated) {
+	protected boolean runLoad(BulkLoadFileHistory history, Species species, List<VepTxtDTO> objectList, List<Long> idsUpdated) {
 		if (Thread.currentThread().isInterrupted()) {
 			history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
 			throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
@@ -80,8 +80,8 @@ public class VepGeneExecutor extends LoadFileExecutor {
 		ph.addDisplayHandler(loadProcessDisplayService);
 		if (CollectionUtils.isNotEmpty(objectList)) {
 			String loadMessage = objectList.get(0).getClass().getSimpleName() + " update";
-			if (dataProvider != null) {
-				loadMessage = loadMessage + " for " + dataProvider.name();
+			if (species != null) {
+				loadMessage = loadMessage + " for " + species.getDisplayName();
 			}
 			ph.startProcess(loadMessage, objectList.size());
 			
@@ -171,11 +171,11 @@ public class VepGeneExecutor extends LoadFileExecutor {
 		List<Long> idsLoaded = new ArrayList<>();
 		BulkLoadFileHistory history = new BulkLoadFileHistory(consequenceData.size());
 		history = bulkLoadFileHistoryDAO.persist(history);
-		BackendBulkDataProvider dataProvider = null;
+		Species species = null;
 		if (dataProviderName != null) {
-			dataProvider = BackendBulkDataProvider.valueOf(dataProviderName);
+			species = speciesService.getByDisplayName(dataProviderName);
 		}
-		runLoad(history, dataProvider, consequenceData, idsLoaded);
+		runLoad(history, species, consequenceData, idsLoaded);
 		history.finishLoad();
 		return new LoadHistoryResponce(history);
 	}

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/VepTranscriptExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/VepTranscriptExecutor.java
@@ -6,9 +6,8 @@ import java.util.List;
 import java.util.zip.GZIPInputStream;
 
 import org.alliancegenome.curation_api.dao.PredictedVariantConsequenceDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.VepTxtDTO;
 import org.alliancegenome.curation_api.services.PredictedVariantConsequenceService;
@@ -36,18 +35,17 @@ public class VepTranscriptExecutor extends LoadFileExecutor {
 			List<VepTxtDTO> vepData = it.readAll();
 			
 
-			BulkFMSLoad fmsLoad = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fmsLoad.getFmsDataSubType());
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 
 			List<Long> consequenceIdsLoaded = new ArrayList<>();
-			List<Long> consequenceIdsBefore = predictedVariantConsequenceService.getIdsByDataProvider(dataProvider);
+			List<Long> consequenceIdsBefore = predictedVariantConsequenceService.getIdsBySpecies(species);
 			
 			bulkLoadFileHistory.setCount(vepData.size());
 			updateHistory(bulkLoadFileHistory);
 			
-			boolean success = runLoad(predictedVariantConsequenceService, bulkLoadFileHistory, dataProvider, vepData, consequenceIdsLoaded);
+			boolean success = runLoad(predictedVariantConsequenceService, bulkLoadFileHistory, species, vepData, consequenceIdsLoaded);
 			if (success) {
-				runCleanup(predictedVariantConsequenceService, bulkLoadFileHistory, dataProvider.name(), consequenceIdsBefore, consequenceIdsLoaded, "predicted variant consequences");
+				runCleanup(predictedVariantConsequenceService, bulkLoadFileHistory, species.getDisplayName(), consequenceIdsBefore, consequenceIdsLoaded, "predicted variant consequences");
 			}
 			bulkLoadFileHistory.finishLoad();
 			updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/AgmAgmAssociationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/AgmAgmAssociationExecutor.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.jobs.executors.LoadFileExecutor;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
@@ -27,8 +27,8 @@ public class AgmAgmAssociationExecutor extends LoadFileExecutor {
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory, Boolean cleanUp) {
 
 		BulkManualLoad manual = (BulkManualLoad) bulkLoadFileHistory.getBulkLoad();
-		BackendBulkDataProvider dataProvider = manual.getDataProvider();
-		log.info("Running with dataProvider: " + dataProvider.name());
+		Species species = manual.getSpecies();
+		log.info("Running with dataProvider: " + species.getDisplayName());
 
 		IngestDTO ingestDto = readIngestFile(bulkLoadFileHistory, AgmAgmAssociationDTO.class);
 		if (ingestDto == null) {
@@ -43,7 +43,7 @@ public class AgmAgmAssociationExecutor extends LoadFileExecutor {
 		List<Long> associationIdsLoaded = new ArrayList<>();
 		List<Long> associationIdsBefore = new ArrayList<>();
 		if (cleanUp) {
-			associationIdsBefore.addAll(agmAgmAssociationService.getAssociationsByDataProvider(dataProvider));
+			associationIdsBefore.addAll(agmAgmAssociationService.getAssociationsBySpecies(species));
 			associationIdsBefore.removeIf(Objects::isNull);
 		}
 
@@ -54,9 +54,9 @@ public class AgmAgmAssociationExecutor extends LoadFileExecutor {
 		bulkLoadFileHistory.setCount(countType, associations.size());
 		updateHistory(bulkLoadFileHistory);
 
-		boolean success = runLoad(agmAgmAssociationService, bulkLoadFileHistory, dataProvider, associations, associationIdsLoaded, countType);
+		boolean success = runLoad(agmAgmAssociationService, bulkLoadFileHistory, species, associations, associationIdsLoaded, countType);
 		if (success && cleanUp) {
-			runCleanup(agmAgmAssociationService, bulkLoadFileHistory, dataProvider.name(), associationIdsBefore, associationIdsLoaded, countType);
+			runCleanup(agmAgmAssociationService, bulkLoadFileHistory, species.getDisplayName(), associationIdsBefore, associationIdsLoaded, countType);
 		}
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/AgmAlleleAssociationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/AgmAlleleAssociationExecutor.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.jobs.executors.LoadFileExecutor;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
@@ -26,8 +26,8 @@ public class AgmAlleleAssociationExecutor extends LoadFileExecutor {
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory, Boolean cleanUp) {
 
 		BulkManualLoad manual = (BulkManualLoad) bulkLoadFileHistory.getBulkLoad();
-		BackendBulkDataProvider dataProvider = manual.getDataProvider();
-		log.info("Running with dataProvider: " + dataProvider.name());
+		Species species = manual.getSpecies();
+		log.info("Running with dataProvider: " + species.getDisplayName());
 
 		IngestDTO ingestDto = readIngestFile(bulkLoadFileHistory, AgmAlleleAssociationDTO.class);
 		if (ingestDto == null) {
@@ -42,7 +42,7 @@ public class AgmAlleleAssociationExecutor extends LoadFileExecutor {
 		List<Long> associationIdsLoaded = new ArrayList<>();
 		List<Long> associationIdsBefore = new ArrayList<>();
 		if (cleanUp) {
-			associationIdsBefore.addAll(agmAlleleAssociationService.getAssociationsByDataProvider(dataProvider));
+			associationIdsBefore.addAll(agmAlleleAssociationService.getAssociationsBySpecies(species));
 			associationIdsBefore.removeIf(Objects::isNull);
 		}
 
@@ -53,11 +53,11 @@ public class AgmAlleleAssociationExecutor extends LoadFileExecutor {
 		bulkLoadFileHistory.setCount(countType, associations.size());
 		updateHistory(bulkLoadFileHistory);
 
-		agmAlleleAssociationService.preloadAssociationKeys(dataProvider);
+		agmAlleleAssociationService.preloadAssociationKeys(species);
 
-		boolean success = runLoad(agmAlleleAssociationService, bulkLoadFileHistory, dataProvider, associations, associationIdsLoaded, countType);
+		boolean success = runLoad(agmAlleleAssociationService, bulkLoadFileHistory, species, associations, associationIdsLoaded, countType);
 		if (success && cleanUp) {
-			runCleanup(agmAlleleAssociationService, bulkLoadFileHistory, dataProvider.name(), associationIdsBefore, associationIdsLoaded, countType);
+			runCleanup(agmAlleleAssociationService, bulkLoadFileHistory, species.getDisplayName(), associationIdsBefore, associationIdsLoaded, countType);
 		}
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/AgmStrAssociationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/AgmStrAssociationExecutor.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.jobs.executors.LoadFileExecutor;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
@@ -26,8 +26,8 @@ public class AgmStrAssociationExecutor extends LoadFileExecutor {
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory, Boolean cleanUp) {
 
 		BulkManualLoad manual = (BulkManualLoad) bulkLoadFileHistory.getBulkLoad();
-		BackendBulkDataProvider dataProvider = manual.getDataProvider();
-		log.info("Running with dataProvider: " + dataProvider.name());
+		Species species = manual.getSpecies();
+		log.info("Running with dataProvider: " + species.getDisplayName());
 
 		IngestDTO ingestDto = readIngestFile(bulkLoadFileHistory, AgmSequenceTargetingReagentAssociationDTO.class);
 		if (ingestDto == null) {
@@ -42,7 +42,7 @@ public class AgmStrAssociationExecutor extends LoadFileExecutor {
 		List<Long> associationIdsLoaded = new ArrayList<>();
 		List<Long> associationIdsBefore = new ArrayList<>();
 		if (cleanUp) {
-			associationIdsBefore.addAll(agmStrAssociationService.getAssociationsByDataProvider(dataProvider));
+			associationIdsBefore.addAll(agmStrAssociationService.getAssociationsBySpecies(species));
 			associationIdsBefore.removeIf(Objects::isNull);
 		}
 
@@ -53,9 +53,9 @@ public class AgmStrAssociationExecutor extends LoadFileExecutor {
 		bulkLoadFileHistory.setCount(countType, associations.size());
 		updateHistory(bulkLoadFileHistory);
 		
-		boolean success = runLoad(agmStrAssociationService, bulkLoadFileHistory, dataProvider, associations, associationIdsLoaded, countType);
+		boolean success = runLoad(agmStrAssociationService, bulkLoadFileHistory, species, associations, associationIdsLoaded, countType);
 		if (success && cleanUp) {
-			runCleanup(agmStrAssociationService, bulkLoadFileHistory, dataProvider.name(), associationIdsBefore, associationIdsLoaded, countType);
+			runCleanup(agmStrAssociationService, bulkLoadFileHistory, species.getDisplayName(), associationIdsBefore, associationIdsLoaded, countType);
 		}
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/AlleleConstructAssociationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/AlleleConstructAssociationExecutor.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.jobs.executors.LoadFileExecutor;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
@@ -26,8 +26,8 @@ public class AlleleConstructAssociationExecutor extends LoadFileExecutor {
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory, Boolean cleanUp) {
 
 		BulkManualLoad manual = (BulkManualLoad) bulkLoadFileHistory.getBulkLoad();
-		BackendBulkDataProvider dataProvider = manual.getDataProvider();
-		log.info("Running with dataProvider: " + dataProvider.name());
+		Species species = manual.getSpecies();
+		log.info("Running with dataProvider: " + species.getDisplayName());
 
 		IngestDTO ingestDto = readIngestFile(bulkLoadFileHistory, AlleleConstructAssociationDTO.class);
 		if (ingestDto == null) {
@@ -42,7 +42,7 @@ public class AlleleConstructAssociationExecutor extends LoadFileExecutor {
 		List<Long> associationIdsLoaded = new ArrayList<>();
 		List<Long> associationIdsBefore = new ArrayList<>();
 		if (cleanUp) {
-			associationIdsBefore.addAll(alleleConstructAssociationService.getAssociationsByDataProvider(dataProvider));
+			associationIdsBefore.addAll(alleleConstructAssociationService.getAssociationsBySpecies(species));
 			associationIdsBefore.removeIf(Objects::isNull);
 		}
 
@@ -53,9 +53,9 @@ public class AlleleConstructAssociationExecutor extends LoadFileExecutor {
 		bulkLoadFileHistory.setCount(countType, associations.size());
 		updateHistory(bulkLoadFileHistory);
 		
-		boolean success = runLoad(alleleConstructAssociationService, bulkLoadFileHistory, dataProvider, associations, associationIdsLoaded, countType);
+		boolean success = runLoad(alleleConstructAssociationService, bulkLoadFileHistory, species, associations, associationIdsLoaded, countType);
 		if (success && cleanUp) {
-			runCleanup(alleleConstructAssociationService, bulkLoadFileHistory, dataProvider.name(), associationIdsBefore, associationIdsLoaded, countType);
+			runCleanup(alleleConstructAssociationService, bulkLoadFileHistory, species.getDisplayName(), associationIdsBefore, associationIdsLoaded, countType);
 		}
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/AlleleGeneAssociationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/AlleleGeneAssociationExecutor.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
@@ -36,8 +36,8 @@ public class AlleleGeneAssociationExecutor extends LoadFileExecutor {
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory, Boolean cleanUp) {
 
 		BulkManualLoad manual = (BulkManualLoad) bulkLoadFileHistory.getBulkLoad();
-		BackendBulkDataProvider dataProvider = manual.getDataProvider();
-		log.info("Running with dataProvider: " + dataProvider.name());
+		Species species = manual.getSpecies();
+		log.info("Running with dataProvider: " + species.getDisplayName());
 
 		IngestDTO ingestDto = readIngestFile(bulkLoadFileHistory, AlleleGeneAssociationDTO.class);
 		if (ingestDto == null) {
@@ -52,7 +52,7 @@ public class AlleleGeneAssociationExecutor extends LoadFileExecutor {
 		List<Long> associationIdsLoaded = new ArrayList<>();
 		List<Long> associationIdsBefore = new ArrayList<>();
 		if (cleanUp) {
-			associationIdsBefore.addAll(alleleGeneAssociationService.getAssociationsByDataProvider(dataProvider));
+			associationIdsBefore.addAll(alleleGeneAssociationService.getAssociationsBySpecies(species));
 			associationIdsBefore.removeIf(Objects::isNull);
 		}
 
@@ -63,16 +63,16 @@ public class AlleleGeneAssociationExecutor extends LoadFileExecutor {
 		bulkLoadFileHistory.setCount(countType, associations.size());
 		updateHistory(bulkLoadFileHistory);
 		
-		boolean success = runLoad(bulkLoadFileHistory, dataProvider, associations, associationIdsLoaded, countType, cleanUp);
+		boolean success = runLoad(bulkLoadFileHistory, species, associations, associationIdsLoaded, countType, cleanUp);
 		if (success && cleanUp) {
-			runCleanup(alleleGeneAssociationService, bulkLoadFileHistory, dataProvider.name(), associationIdsBefore, associationIdsLoaded, countType);
+			runCleanup(alleleGeneAssociationService, bulkLoadFileHistory, species.getDisplayName(), associationIdsBefore, associationIdsLoaded, countType);
 		}
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);
 		updateExceptions(bulkLoadFileHistory);
 	}
 	
-	protected boolean runLoad(BulkLoadFileHistory history, BackendBulkDataProvider dataProvider, List<AlleleGeneAssociationDTO> associationDtos, List<Long> idsAdded, String countType, boolean isFullLoad) {
+	protected boolean runLoad(BulkLoadFileHistory history, Species species, List<AlleleGeneAssociationDTO> associationDtos, List<Long> idsAdded, String countType, boolean isFullLoad) {
 		if (Thread.currentThread().isInterrupted()) {
 			history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
 			throw new RuntimeException(ApiErrorException.INTERRUPTED_MESSAGE);
@@ -81,8 +81,8 @@ public class AlleleGeneAssociationExecutor extends LoadFileExecutor {
 		ph.addDisplayHandler(loadProcessDisplayService);
 		if (CollectionUtils.isNotEmpty(associationDtos)) {
 			String loadMessage = "Allele Gene Association update";
-			if (dataProvider != null) {
-				loadMessage = loadMessage + " for " + dataProvider.name();
+			if (species != null) {
+				loadMessage = loadMessage + " for " + species.getDisplayName();
 			}
 			ph.startProcess(loadMessage, associationDtos.size());
 
@@ -92,7 +92,7 @@ public class AlleleGeneAssociationExecutor extends LoadFileExecutor {
 			for (AlleleGeneAssociationDTO dto : associationDtos) {
 				try {
 					
-					ObjectResponse<AlleleGeneAssociation> dbObject = alleleGeneAssociationService.upsert(dto, dataProvider, isAlleleOfAssociationMap, isFullLoad);
+					ObjectResponse<AlleleGeneAssociation> dbObject = alleleGeneAssociationService.upsert(dto, species, isAlleleOfAssociationMap, isFullLoad);
 					history.incrementCompleted(countType);
 					if (idsAdded != null) {
 						idsAdded.add(dbObject.getEntity().getId());

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/ConstructGenomicEntityAssociationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/associations/ConstructGenomicEntityAssociationExecutor.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.jobs.executors.LoadFileExecutor;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
@@ -26,8 +26,8 @@ public class ConstructGenomicEntityAssociationExecutor extends LoadFileExecutor 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory, Boolean cleanUp) {
 
 		BulkManualLoad manual = (BulkManualLoad) bulkLoadFileHistory.getBulkLoad();
-		BackendBulkDataProvider dataProvider = manual.getDataProvider();
-		log.info("Running with dataProvider: " + dataProvider.name());
+		Species species = manual.getSpecies();
+		log.info("Running with dataProvider: " + species.getDisplayName());
 
 		IngestDTO ingestDto = readIngestFile(bulkLoadFileHistory, ConstructGenomicEntityAssociationDTO.class);
 		if (ingestDto == null) {
@@ -42,7 +42,7 @@ public class ConstructGenomicEntityAssociationExecutor extends LoadFileExecutor 
 		List<Long> associationIdsLoaded = new ArrayList<>();
 		List<Long> associationIdsBefore = new ArrayList<>();
 		if (cleanUp) {
-			associationIdsBefore.addAll(constructGenomicEntityAssociationService.getAssociationsByDataProvider(dataProvider));
+			associationIdsBefore.addAll(constructGenomicEntityAssociationService.getAssociationsBySpecies(species));
 			associationIdsBefore.removeIf(Objects::isNull);
 		}
 
@@ -52,9 +52,9 @@ public class ConstructGenomicEntityAssociationExecutor extends LoadFileExecutor 
 		bulkLoadFileHistory.setCount(associations.size());
 		updateHistory(bulkLoadFileHistory);
 
-		boolean success = runLoad(constructGenomicEntityAssociationService, bulkLoadFileHistory, dataProvider, associations, associationIdsLoaded);
+		boolean success = runLoad(constructGenomicEntityAssociationService, bulkLoadFileHistory, species, associations, associationIdsLoaded);
 		if (cleanUp && success) {
-			runCleanup(constructGenomicEntityAssociationService, bulkLoadFileHistory, dataProvider.name(), associationIdsBefore, associationIdsLoaded, "construct genomic entity association");
+			runCleanup(constructGenomicEntityAssociationService, bulkLoadFileHistory, species.getDisplayName(), associationIdsBefore, associationIdsLoaded, "construct genomic entity association");
 		}
 		bulkLoadFileHistory.finishLoad();
 		updateHistory(bulkLoadFileHistory);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3CDSExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3CDSExecutor.java
@@ -6,15 +6,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.Gff3DTO;
 import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.LoadHistoryResponce;
 import org.alliancegenome.curation_api.services.CodingSequenceService;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.alliancegenome.curation_api.services.associations.CodingSequenceGenomicLocationAssociationService;
 import org.alliancegenome.curation_api.services.associations.TranscriptCodingSequenceAssociationService;
 import org.alliancegenome.curation_api.services.helpers.Gff3AttributesHelper;
@@ -38,6 +38,8 @@ public class Gff3CDSExecutor extends Gff3Executor {
 	CodingSequenceGenomicLocationAssociationService cdsLocationService;
 	@Inject
 	TranscriptCodingSequenceAssociationService transcriptCdsService;
+	@Inject
+	SpeciesService speciesService;
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) throws Exception {
 		try {
@@ -63,10 +65,9 @@ public class Gff3CDSExecutor extends Gff3Executor {
 			ph.finishProcess();
 			gffRawData.clear();
 
-			BulkFMSLoad fmsLoad = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fmsLoad.getFmsDataSubType());
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 
-			List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedCDSGffData = Gff3AttributesHelper.getCDSGffData(gffFileData, dataProvider);
+			List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedCDSGffData = Gff3AttributesHelper.getCDSGffData(gffFileData, species);
 
 			gffFileData.clear();
 
@@ -74,13 +75,13 @@ public class Gff3CDSExecutor extends Gff3Executor {
 			List<Long> locationIdsAdded = new ArrayList<>();
 			List<Long> associationIdsAdded = new ArrayList<>();
 
-			String assemblyId = loadGenomeAssemblyFromGFF(bulkLoadFileHistory, gffHeaderData, dataProvider);
+			String assemblyId = loadGenomeAssemblyFromGFF(bulkLoadFileHistory, gffHeaderData, species);
 
-			boolean success = runLoad(bulkLoadFileHistory, gffHeaderData, preProcessedCDSGffData, entityIdsAdded, locationIdsAdded, associationIdsAdded, dataProvider, assemblyId);
+			boolean success = runLoad(bulkLoadFileHistory, gffHeaderData, preProcessedCDSGffData, entityIdsAdded, locationIdsAdded, associationIdsAdded, species, assemblyId);
 			if (success) {
-				runCleanup(cdsLocationService, bulkLoadFileHistory, dataProvider.name(), cdsLocationService.getIdsByDataProvider(dataProvider), locationIdsAdded, "GFF coding sequence genomic location association");
-				runCleanup(transcriptCdsService, bulkLoadFileHistory, dataProvider.name(), transcriptCdsService.getIdsByDataProvider(dataProvider), associationIdsAdded, "GFF transcript coding sequence association");
-				runCleanup(cdsService, bulkLoadFileHistory, dataProvider.name(), cdsService.getIdsByDataProvider(dataProvider), entityIdsAdded, "GFF coding sequence");
+				runCleanup(cdsLocationService, bulkLoadFileHistory, species.getDisplayName(), cdsLocationService.getIdsBySpecies(species), locationIdsAdded, "GFF coding sequence genomic location association");
+				runCleanup(transcriptCdsService, bulkLoadFileHistory, species.getDisplayName(), transcriptCdsService.getIdsBySpecies(species), associationIdsAdded, "GFF transcript coding sequence association");
+				runCleanup(cdsService, bulkLoadFileHistory, species.getDisplayName(), cdsService.getIdsBySpecies(species), entityIdsAdded, "GFF coding sequence");
 			}
 			bulkLoadFileHistory.finishLoad();
 			updateHistory(bulkLoadFileHistory);
@@ -90,12 +91,12 @@ public class Gff3CDSExecutor extends Gff3Executor {
 		}
 	}
 
-	private boolean runLoad(BulkLoadFileHistory history, List<String> gffHeaderData, List<ImmutablePair<Gff3DTO, Map<String, String>>> gffData, List<Long> entityIdsAdded, List<Long> locationIdsAdded, List<Long> associationIdsAdded, BackendBulkDataProvider dataProvider,
-							String assemblyId) {
+	private boolean runLoad(BulkLoadFileHistory history, List<String> gffHeaderData, List<ImmutablePair<Gff3DTO, Map<String, String>>> gffData, List<Long> entityIdsAdded, List<Long> locationIdsAdded, List<Long> associationIdsAdded, Species species,
+			String assemblyId) {
 
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.addDisplayHandler(loadProcessDisplayService);
-		ph.startProcess("GFF CDS update for " + dataProvider.name(), gffData.size());
+		ph.startProcess("GFF CDS update for " + species.getDisplayName(), gffData.size());
 
 		history.setCount("Entities", gffData.size());
 		history.setCount("Locations", gffData.size());
@@ -107,7 +108,7 @@ public class Gff3CDSExecutor extends Gff3Executor {
 			int end = Math.min(i + batchSize, gffData.size());
 			List<ImmutablePair<Gff3DTO, Map<String, String>>> batch = gffData.subList(i, end);
 
-			gff3Service.loadCdsBatch(batch, entityIdsAdded, locationIdsAdded, associationIdsAdded, dataProvider, assemblyId, history, ph);
+			gff3Service.loadCdsBatch(batch, entityIdsAdded, locationIdsAdded, associationIdsAdded, species, assemblyId, history, ph);
 
 			if (Thread.currentThread().isInterrupted()) {
 				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
@@ -121,11 +122,11 @@ public class Gff3CDSExecutor extends Gff3Executor {
 
 	public APIResponse runLoadApi(String dataProviderName, String assemblyName, List<Gff3DTO> gffData) {
 		List<Long> idsAdded = new ArrayList<>();
-		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(dataProviderName);
-		List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedCDSGffData = Gff3AttributesHelper.getCDSGffData(gffData, dataProvider);
+		Species species = speciesService.getByDisplayName(dataProviderName);
+		List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedCDSGffData = Gff3AttributesHelper.getCDSGffData(gffData, species);
 		BulkLoadFileHistory history = new BulkLoadFileHistory();
 		history = bulkLoadFileHistoryDAO.persist(history);
-		runLoad(history, null, preProcessedCDSGffData, idsAdded, idsAdded, idsAdded, dataProvider, assemblyName);
+		runLoad(history, null, preProcessedCDSGffData, idsAdded, idsAdded, idsAdded, species, assemblyName);
 		history.finishLoad();
 
 		return new LoadHistoryResponce(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3Executor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3Executor.java
@@ -2,14 +2,12 @@ package org.alliancegenome.curation_api.jobs.executors.gff;
 
 import java.util.List;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.jobs.executors.LoadFileExecutor;
 import org.alliancegenome.curation_api.model.entities.GenomeAssembly;
 import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.services.Gff3Service;
-import org.alliancegenome.curation_api.services.SpeciesService;
 import org.apache.commons.lang3.StringUtils;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -19,7 +17,6 @@ import jakarta.inject.Inject;
 public class Gff3Executor extends LoadFileExecutor {
 
 	@Inject Gff3Service gff3Service;
-	@Inject SpeciesService speciesService;
 
 	/**
 	 * SCRUM-6080: parse the assembly declared in the GFF header ({@code #!assembly}) and
@@ -30,7 +27,7 @@ public class Gff3Executor extends LoadFileExecutor {
 	 * failed when the header carries no assembly, when no official assembly is designated
 	 * for the provider's taxon, or when the header assembly does not match it.
 	 */
-	public String loadGenomeAssemblyFromGFF(BulkLoadFileHistory history, List<String> gffHeaderData, BackendBulkDataProvider dataProvider) throws ObjectUpdateException {
+	public String loadGenomeAssemblyFromGFF(BulkLoadFileHistory history, List<String> gffHeaderData, Species species) throws ObjectUpdateException {
 		String headerAssembly = null;
 		for (String header : gffHeaderData) {
 			if (header.startsWith("#!assembly")) {
@@ -42,23 +39,22 @@ public class Gff3Executor extends LoadFileExecutor {
 		if (StringUtils.isBlank(headerAssembly)) {
 			throw new ObjectUpdateException(null,
 				"GFF header contains no assembly (expected a '#!assembly <id>' line) for "
-					+ dataProvider.name() + " - load aborted");
+					+ species.getDisplayName() + " - load aborted");
 		}
 
-		Species species = speciesService.getByTaxonCurie(dataProvider.canonicalTaxonCurie);
 		GenomeAssembly officialAssembly = (species != null) ? species.getGenomeAssembly() : null;
 
 		if (officialAssembly == null) {
 			throw new ObjectUpdateException(null,
-				"No official assembly is designated in the Species table for " + dataProvider.name()
-					+ " (taxon " + dataProvider.canonicalTaxonCurie + "); cannot load GFF with header assembly '"
+				"No official assembly is designated in the Species table for " + species.getDisplayName()
+					+ "; cannot load GFF with header assembly '"
 					+ headerAssembly + "' - load aborted");
 		}
 
 		if (!headerAssembly.equals(officialAssembly.getPrimaryExternalId())) {
 			throw new ObjectUpdateException(null,
 				"GFF header assembly '" + headerAssembly + "' does not match the official assembly '"
-					+ officialAssembly.getPrimaryExternalId() + "' designated for " + dataProvider.name()
+					+ officialAssembly.getPrimaryExternalId() + "' designated for " + species.getDisplayName()
 					+ " in the Species table - load aborted");
 		}
 

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3ExonExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3ExonExecutor.java
@@ -6,15 +6,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.Gff3DTO;
 import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.LoadHistoryResponce;
 import org.alliancegenome.curation_api.services.ExonService;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.alliancegenome.curation_api.services.associations.ExonGenomicLocationAssociationService;
 import org.alliancegenome.curation_api.services.associations.TranscriptExonAssociationService;
 import org.alliancegenome.curation_api.services.helpers.Gff3AttributesHelper;
@@ -39,6 +39,8 @@ public class Gff3ExonExecutor extends Gff3Executor {
 	ExonGenomicLocationAssociationService exonLocationService;
 	@Inject
 	TranscriptExonAssociationService transcriptExonService;
+	@Inject
+	SpeciesService speciesService;
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) throws Exception {
 		try {
@@ -63,10 +65,9 @@ public class Gff3ExonExecutor extends Gff3Executor {
 			ph.finishProcess();
 			gffRawData.clear();
 
-			BulkFMSLoad fmsLoad = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fmsLoad.getFmsDataSubType());
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 
-			List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedExonGffData = Gff3AttributesHelper.getExonGffData(gffFileData, dataProvider);
+			List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedExonGffData = Gff3AttributesHelper.getExonGffData(gffFileData, species);
 
 			gffFileData.clear();
 
@@ -74,13 +75,13 @@ public class Gff3ExonExecutor extends Gff3Executor {
 			List<Long> locationIdsAdded = new ArrayList<>();
 			List<Long> associationIdsAdded = new ArrayList<>();
 
-			String assemblyId = loadGenomeAssemblyFromGFF(bulkLoadFileHistory, gffHeaderData, dataProvider);
+			String assemblyId = loadGenomeAssemblyFromGFF(bulkLoadFileHistory, gffHeaderData, species);
 
-			boolean success = runLoad(bulkLoadFileHistory, gffHeaderData, preProcessedExonGffData, entityIdsAdded, locationIdsAdded, associationIdsAdded, dataProvider, assemblyId);
+			boolean success = runLoad(bulkLoadFileHistory, gffHeaderData, preProcessedExonGffData, entityIdsAdded, locationIdsAdded, associationIdsAdded, species, assemblyId);
 			if (success) {
-				runCleanup(exonLocationService, bulkLoadFileHistory, dataProvider.name(), exonLocationService.getIdsByDataProvider(dataProvider), locationIdsAdded, "GFF exon genomic location association");
-				runCleanup(transcriptExonService, bulkLoadFileHistory, dataProvider.name(), transcriptExonService.getIdsByDataProvider(dataProvider), associationIdsAdded, "GFF transcript exon association");
-				runCleanup(exonService, bulkLoadFileHistory, dataProvider.name(), exonService.getIdsByDataProvider(dataProvider), entityIdsAdded, "GFF exon");
+				runCleanup(exonLocationService, bulkLoadFileHistory, species.getDisplayName(), exonLocationService.getIdsBySpecies(species), locationIdsAdded, "GFF exon genomic location association");
+				runCleanup(transcriptExonService, bulkLoadFileHistory, species.getDisplayName(), transcriptExonService.getIdsBySpecies(species), associationIdsAdded, "GFF transcript exon association");
+				runCleanup(exonService, bulkLoadFileHistory, species.getDisplayName(), exonService.getIdsBySpecies(species), entityIdsAdded, "GFF exon");
 			}
 			bulkLoadFileHistory.finishLoad();
 			updateHistory(bulkLoadFileHistory);
@@ -90,12 +91,12 @@ public class Gff3ExonExecutor extends Gff3Executor {
 		}
 	}
 
-	private boolean runLoad(BulkLoadFileHistory history, List<String> gffHeaderData, List<ImmutablePair<Gff3DTO, Map<String, String>>> gffData, List<Long> entityIdsAdded, List<Long> locationIdsAdded, List<Long> associationIdsAdded, BackendBulkDataProvider dataProvider,
+	private boolean runLoad(BulkLoadFileHistory history, List<String> gffHeaderData, List<ImmutablePair<Gff3DTO, Map<String, String>>> gffData, List<Long> entityIdsAdded, List<Long> locationIdsAdded, List<Long> associationIdsAdded, Species species,
 			String assemblyId) {
 
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.addDisplayHandler(loadProcessDisplayService);
-		ph.startProcess("GFF Exon update for " + dataProvider.name(), gffData.size());
+		ph.startProcess("GFF Exon update for " + species.getDisplayName(), gffData.size());
 
 		history.setCount("Entities", gffData.size());
 		history.setCount("Locations", gffData.size());
@@ -107,7 +108,7 @@ public class Gff3ExonExecutor extends Gff3Executor {
 			int end = Math.min(i + batchSize, gffData.size());
 			List<ImmutablePair<Gff3DTO, Map<String, String>>> batch = gffData.subList(i, end);
 
-			gff3Service.loadExonBatch(batch, entityIdsAdded, locationIdsAdded, associationIdsAdded, dataProvider, assemblyId, history, ph);
+			gff3Service.loadExonBatch(batch, entityIdsAdded, locationIdsAdded, associationIdsAdded, species, assemblyId, history, ph);
 
 			if (Thread.currentThread().isInterrupted()) {
 				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
@@ -121,11 +122,11 @@ public class Gff3ExonExecutor extends Gff3Executor {
 
 	public APIResponse runLoadApi(String dataProviderName, String assemblyName, List<Gff3DTO> gffData) {
 		List<Long> idsAdded = new ArrayList<Long>();
-		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(dataProviderName);
-		List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedExonGffData = Gff3AttributesHelper.getExonGffData(gffData, dataProvider);
+		Species species = speciesService.getByDisplayName(dataProviderName);
+		List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedExonGffData = Gff3AttributesHelper.getExonGffData(gffData, species);
 		BulkLoadFileHistory history = new BulkLoadFileHistory();
 		history = bulkLoadFileHistoryDAO.persist(history);
-		runLoad(history, null, preProcessedExonGffData, idsAdded, idsAdded, idsAdded, dataProvider, assemblyName);
+		runLoad(history, null, preProcessedExonGffData, idsAdded, idsAdded, idsAdded, species, assemblyName);
 		history.finishLoad();
 
 		return new LoadHistoryResponce(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3GeneExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3GeneExecutor.java
@@ -6,16 +6,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.Gff3DTO;
 import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.LoadHistoryResponce;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.alliancegenome.curation_api.services.associations.GeneGenomicLocationAssociationService;
 import org.alliancegenome.curation_api.services.helpers.Gff3AttributesHelper;
 import org.alliancegenome.curation_api.services.validation.dto.Gff3DtoValidator;
@@ -38,6 +38,8 @@ public class Gff3GeneExecutor extends Gff3Executor {
 	GeneGenomicLocationAssociationService geneLocationService;
 	@Inject
 	Gff3DtoValidator gff3DtoValidator;
+	@Inject
+	SpeciesService speciesService;
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) throws Exception {
 		try {
@@ -62,19 +64,18 @@ public class Gff3GeneExecutor extends Gff3Executor {
 			ph.finishProcess();
 			gffRawData.clear();
 
-			BulkFMSLoad fmsLoad = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fmsLoad.getFmsDataSubType());
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 
-			List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedGeneGffData = Gff3AttributesHelper.getGeneGffData(gffFileData, dataProvider);
+			List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedGeneGffData = Gff3AttributesHelper.getGeneGffData(gffFileData, species);
 
 			gffFileData.clear();
 
 			List<Long> locationIdsAdded = new ArrayList<>();
-			String assemblyId = loadGenomeAssemblyFromGFF(bulkLoadFileHistory, gffHeaderData, dataProvider);
+			String assemblyId = loadGenomeAssemblyFromGFF(bulkLoadFileHistory, gffHeaderData, species);
 
-			boolean success = runLoad(bulkLoadFileHistory, gffHeaderData, preProcessedGeneGffData, locationIdsAdded, dataProvider, assemblyId);
+			boolean success = runLoad(bulkLoadFileHistory, gffHeaderData, preProcessedGeneGffData, locationIdsAdded, species, assemblyId);
 			if (success) {
-				runCleanup(geneLocationService, bulkLoadFileHistory, dataProvider.name(), geneLocationService.getIdsByDataProvider(dataProvider), locationIdsAdded, "GFF gene genomic location association");
+				runCleanup(geneLocationService, bulkLoadFileHistory, species.getDisplayName(), geneLocationService.getIdsBySpecies(species), locationIdsAdded, "GFF gene genomic location association");
 			}
 			bulkLoadFileHistory.finishLoad();
 			updateHistory(bulkLoadFileHistory);
@@ -84,11 +85,11 @@ public class Gff3GeneExecutor extends Gff3Executor {
 		}
 	}
 
-	private boolean runLoad(BulkLoadFileHistory history, List<String> gffHeaderData, List<ImmutablePair<Gff3DTO, Map<String, String>>> gffData, List<Long> locationIdsAdded, BackendBulkDataProvider dataProvider, String assemblyId) {
+	private boolean runLoad(BulkLoadFileHistory history, List<String> gffHeaderData, List<ImmutablePair<Gff3DTO, Map<String, String>>> gffData, List<Long> locationIdsAdded, Species species, String assemblyId) {
 
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.addDisplayHandler(loadProcessDisplayService);
-		ph.startProcess("GFF Gene update for " + dataProvider.name(), gffData.size());
+		ph.startProcess("GFF Gene update for " + species.getDisplayName(), gffData.size());
 
 		String countType = "Locations";
 		history.setCount(countType, gffData.size());
@@ -98,7 +99,7 @@ public class Gff3GeneExecutor extends Gff3Executor {
 			if (assemblyId != null) {
 				countType = "Locations";
 				try {
-					gff3Service.loadGeneLocationAssociations(gff3EntryPair, locationIdsAdded, dataProvider, assemblyId);
+					gff3Service.loadGeneLocationAssociations(gff3EntryPair, locationIdsAdded, species, assemblyId);
 					history.incrementCompleted(countType);
 				} catch (ObjectUpdateException e) {
 					history.incrementFailed(countType);
@@ -121,11 +122,11 @@ public class Gff3GeneExecutor extends Gff3Executor {
 
 	public APIResponse runLoadApi(String dataProviderName, String assemblyName, List<Gff3DTO> gffData) {
 		List<Long> idsAdded = new ArrayList<>();
-		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(dataProviderName);
-		List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedGeneGffData = Gff3AttributesHelper.getGeneGffData(gffData, dataProvider);
+		Species species = speciesService.getByDisplayName(dataProviderName);
+		List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedGeneGffData = Gff3AttributesHelper.getGeneGffData(gffData, species);
 		BulkLoadFileHistory history = new BulkLoadFileHistory();
 		history = bulkLoadFileHistoryDAO.persist(history);
-		runLoad(history, null, preProcessedGeneGffData, idsAdded, dataProvider, assemblyName);
+		runLoad(history, null, preProcessedGeneGffData, idsAdded, species, assemblyName);
 		history.finishLoad();
 
 		return new LoadHistoryResponce(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3TranscriptExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/gff/Gff3TranscriptExecutor.java
@@ -6,14 +6,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.Gff3DTO;
 import org.alliancegenome.curation_api.response.APIResponse;
 import org.alliancegenome.curation_api.response.LoadHistoryResponce;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.alliancegenome.curation_api.services.TranscriptService;
 import org.alliancegenome.curation_api.services.associations.TranscriptGeneAssociationService;
 import org.alliancegenome.curation_api.services.associations.TranscriptGenomicLocationAssociationService;
@@ -39,6 +39,8 @@ public class Gff3TranscriptExecutor extends Gff3Executor {
 	TranscriptGenomicLocationAssociationService transcriptLocationService;
 	@Inject
 	TranscriptGeneAssociationService transcriptGeneService;
+	@Inject
+	SpeciesService speciesService;
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) throws Exception {
 		try {
@@ -63,11 +65,10 @@ public class Gff3TranscriptExecutor extends Gff3Executor {
 			ph.finishProcess();
 			gffRawData.clear();
 
-			BulkFMSLoad fmsLoad = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
-			BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fmsLoad.getFmsDataSubType());
+			Species species = bulkLoadFileHistory.getBulkLoad().getSpecies();
 
-			List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedTranscriptGffData = Gff3AttributesHelper.getTranscriptGffData(gffFileData, dataProvider);
-			Map<String, String> geneIdCurieMap = gff3Service.getGeneIdCurieMap(gffFileData, dataProvider);
+			List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedTranscriptGffData = Gff3AttributesHelper.getTranscriptGffData(gffFileData, species);
+			Map<String, String> geneIdCurieMap = gff3Service.getGeneIdCurieMap(gffFileData, species);
 
 			gffFileData.clear();
 
@@ -75,13 +76,13 @@ public class Gff3TranscriptExecutor extends Gff3Executor {
 			List<Long> locationIdsAdded = new ArrayList<>();
 			List<Long> associationIdsAdded = new ArrayList<>();
 
-			String assemblyId = loadGenomeAssemblyFromGFF(bulkLoadFileHistory, gffHeaderData, dataProvider);
+			String assemblyId = loadGenomeAssemblyFromGFF(bulkLoadFileHistory, gffHeaderData, species);
 
-			boolean success = runLoad(bulkLoadFileHistory, gffHeaderData, preProcessedTranscriptGffData, geneIdCurieMap, entityIdsAdded, locationIdsAdded, associationIdsAdded, dataProvider, assemblyId);
+			boolean success = runLoad(bulkLoadFileHistory, gffHeaderData, preProcessedTranscriptGffData, geneIdCurieMap, entityIdsAdded, locationIdsAdded, associationIdsAdded, species, assemblyId);
 			if (success) {
-				runCleanup(transcriptLocationService, bulkLoadFileHistory, dataProvider.name(), transcriptLocationService.getIdsByDataProvider(dataProvider), locationIdsAdded, "GFF transcript genomic location association");
-				runCleanup(transcriptGeneService, bulkLoadFileHistory, dataProvider.name(), transcriptGeneService.getIdsByDataProvider(dataProvider), associationIdsAdded, "GFF transcript gene association");
-				runCleanup(transcriptService, bulkLoadFileHistory, dataProvider.name(), transcriptService.getIdsByDataProvider(dataProvider), entityIdsAdded, "GFF transcript");
+				runCleanup(transcriptLocationService, bulkLoadFileHistory, species.getDisplayName(), transcriptLocationService.getIdsBySpecies(species), locationIdsAdded, "GFF transcript genomic location association");
+				runCleanup(transcriptGeneService, bulkLoadFileHistory, species.getDisplayName(), transcriptGeneService.getIdsBySpecies(species), associationIdsAdded, "GFF transcript gene association");
+				runCleanup(transcriptService, bulkLoadFileHistory, species.getDisplayName(), transcriptService.getIdsBySpecies(species), entityIdsAdded, "GFF transcript");
 			}
 			bulkLoadFileHistory.finishLoad();
 			updateHistory(bulkLoadFileHistory);
@@ -92,11 +93,11 @@ public class Gff3TranscriptExecutor extends Gff3Executor {
 	}
 
 	private boolean runLoad(BulkLoadFileHistory history, List<String> gffHeaderData, List<ImmutablePair<Gff3DTO, Map<String, String>>> gffData, Map<String, String> geneIdCurieMap, List<Long> entityIdsAdded, List<Long> locationIdsAdded, List<Long> associationIdsAdded,
-			BackendBulkDataProvider dataProvider, String assemblyId) {
+			Species species, String assemblyId) {
 
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
 		ph.addDisplayHandler(loadProcessDisplayService);
-		ph.startProcess("GFF Transcript update for " + dataProvider.name(), gffData.size());
+		ph.startProcess("GFF Transcript update for " + species.getDisplayName(), gffData.size());
 
 		history.setCount("Entities", gffData.size());
 		history.setCount("Locations", gffData.size());
@@ -108,7 +109,7 @@ public class Gff3TranscriptExecutor extends Gff3Executor {
 			int end = Math.min(i + batchSize, gffData.size());
 			List<ImmutablePair<Gff3DTO, Map<String, String>>> batch = gffData.subList(i, end);
 
-			gff3Service.loadTranscriptBatch(batch, entityIdsAdded, locationIdsAdded, associationIdsAdded, dataProvider, assemblyId, geneIdCurieMap, history, ph);
+			gff3Service.loadTranscriptBatch(batch, entityIdsAdded, locationIdsAdded, associationIdsAdded, species, assemblyId, geneIdCurieMap, history, ph);
 
 			if (Thread.currentThread().isInterrupted()) {
 				history.setErrorMessage(ApiErrorException.INTERRUPTED_MESSAGE);
@@ -122,12 +123,12 @@ public class Gff3TranscriptExecutor extends Gff3Executor {
 
 	public APIResponse runLoadApi(String dataProviderName, String assemblyName, List<Gff3DTO> gffData) {
 		List<Long> idsAdded = new ArrayList<>();
-		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(dataProviderName);
-		List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedTranscriptGffData = Gff3AttributesHelper.getTranscriptGffData(gffData, dataProvider);
-		Map<String, String> geneIdCurieMap = gff3Service.getGeneIdCurieMap(gffData, dataProvider);
+		Species species = speciesService.getByDisplayName(dataProviderName);
+		List<ImmutablePair<Gff3DTO, Map<String, String>>> preProcessedTranscriptGffData = Gff3AttributesHelper.getTranscriptGffData(gffData, species);
+		Map<String, String> geneIdCurieMap = gff3Service.getGeneIdCurieMap(gffData, species);
 		BulkLoadFileHistory history = new BulkLoadFileHistory();
 		history = bulkLoadFileHistoryDAO.persist(history);
-		runLoad(history, null, preProcessedTranscriptGffData, geneIdCurieMap, idsAdded, idsAdded, idsAdded, dataProvider, assemblyName);
+		runLoad(history, null, preProcessedTranscriptGffData, geneIdCurieMap, idsAdded, idsAdded, idsAdded, species, assemblyName);
 		history.finishLoad();
 
 		return new LoadHistoryResponce(history);

--- a/src/main/java/org/alliancegenome/curation_api/jobs/processors/BulkLoadManualProcessor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/processors/BulkLoadManualProcessor.java
@@ -4,10 +4,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.enums.BackendBulkLoadType;
 import org.alliancegenome.curation_api.enums.JobStatus;
 import org.alliancegenome.curation_api.jobs.events.StartedBulkLoadJobEvent;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkManualLoad;
 import org.alliancegenome.curation_api.response.SearchResponse;
@@ -30,7 +30,7 @@ public class BulkLoadManualProcessor extends BulkLoadProcessor {
 		}
 	}
 
-	public void processBulkManualLoadFromDQM(MultipartFormDataInput input, BackendBulkLoadType loadType, BackendBulkDataProvider dataProvider, Boolean cleanUp) { // Triggered by the API
+	public void processBulkManualLoadFromDQM(MultipartFormDataInput input, BackendBulkLoadType loadType, Species species, Boolean cleanUp) {
 		Map<String, List<InputPart>> form = input.getFormDataMap();
 
 		if (form.containsKey(loadType)) {
@@ -42,7 +42,7 @@ public class BulkLoadManualProcessor extends BulkLoadProcessor {
 
 		HashMap<String, Object> params = new HashMap<String, Object>();
 		params.put("backendBulkLoadType", loadType);
-		params.put("dataProvider", dataProvider);
+		params.put("species", species);
 		SearchResponse<BulkManualLoad> load = bulkManualLoadDAO.findByParams(params);
 		if (load != null && load.getResults().size() == 1) {
 			bulkManualLoad = load.getResults().get(0);
@@ -50,7 +50,7 @@ public class BulkLoadManualProcessor extends BulkLoadProcessor {
 
 			startLoad(bulkManualLoad);
 
-			String filePath = fileHelper.saveIncomingFile(input, bulkManualLoad.getBackendBulkLoadType().toString() + "_" + bulkManualLoad.getDataProvider().toString());
+			String filePath = fileHelper.saveIncomingFile(input, bulkManualLoad.getBackendBulkLoadType().toString() + "_" + species.getDisplayName());
 			String localFilePath = fileHelper.compressInputFile(filePath);
 			processFilePath(bulkManualLoad, localFilePath, cleanUp);
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkManualLoad.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/bulkloads/BulkManualLoad.java
@@ -1,17 +1,12 @@
 package org.alliancegenome.curation_api.model.entities.bulkloads;
 
 import org.alliancegenome.curation_api.constants.LinkMLSchemaConstants;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
-import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonView;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -25,7 +20,4 @@ import lombok.ToString;
 @JsonTypeName
 public class BulkManualLoad extends BulkLoad {
 
-	@JsonView({ CurationView.FieldsOnly.class })
-	@Enumerated(EnumType.STRING)
-	private BackendBulkDataProvider dataProvider;
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/AGMDiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AGMDiseaseAnnotationService.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.alliancegenome.curation_api.dao.AGMDiseaseAnnotationDAO;
 import org.alliancegenome.curation_api.dao.ConditionRelationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.AGMDiseaseAnnotation;
 import org.alliancegenome.curation_api.model.ingest.dto.AGMDiseaseAnnotationDTO;
@@ -50,9 +50,8 @@ public class AGMDiseaseAnnotationService extends BaseAnnotationDTOCrudService<AG
 
 	@Override
 	@Transactional
-	public ObjectResponse<AGMDiseaseAnnotation> upsert(AGMDiseaseAnnotationDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		ObjectResponse<AGMDiseaseAnnotation> resp = agmDiseaseAnnotationDtoValidator.validateAGMDiseaseAnnotationDTO(dto, dataProvider);
-
+	public ObjectResponse<AGMDiseaseAnnotation> upsert(AGMDiseaseAnnotationDTO dto, Species species) throws ValidationException {
+		ObjectResponse<AGMDiseaseAnnotation> resp = agmDiseaseAnnotationDtoValidator.validateAGMDiseaseAnnotationDTO(dto, species);
 		diseaseAnnotationService.mintCurieIfAbsent(resp.getEntity());
 		agmDiseaseAnnotationDAO.persist(resp.getEntity());
 		
@@ -67,8 +66,8 @@ public class AGMDiseaseAnnotationService extends BaseAnnotationDTOCrudService<AG
 		return ret;
 	}
 
-	public List<Long> getAnnotationIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		return diseaseAnnotationService.getAnnotationIdsByDataProvider(agmDiseaseAnnotationDAO, dataProvider);
+	public List<Long> getAnnotationIdsBySpecies(Species species) {
+		return diseaseAnnotationService.getAnnotationIdsBySpecies(agmDiseaseAnnotationDAO, species);
 	}
 
 	public List<String> getGeneDiseaseAnnotationList() {

--- a/src/main/java/org/alliancegenome/curation_api/services/AGMPhenotypeAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AGMPhenotypeAnnotationService.java
@@ -5,7 +5,7 @@ import java.util.Set;
 
 import org.alliancegenome.curation_api.dao.AGMPhenotypeAnnotationDAO;
 import org.alliancegenome.curation_api.dao.ConditionRelationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.AGMPhenotypeAnnotation;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
@@ -46,14 +46,14 @@ public class AGMPhenotypeAnnotationService extends BaseAnnotationCrudService<AGM
 	}
 
 	@Transactional
-	public AGMPhenotypeAnnotation upsertPrimaryAnnotation(AffectedGenomicModel subject, PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		AGMPhenotypeAnnotation annotation = agmPhenotypeAnnotationFmsDtoValidator.validatePrimaryAnnotation(subject, dto, dataProvider);
+	public AGMPhenotypeAnnotation upsertPrimaryAnnotation(AffectedGenomicModel subject, PhenotypeFmsDTO dto, Species species) throws ValidationException {
+		AGMPhenotypeAnnotation annotation = agmPhenotypeAnnotationFmsDtoValidator.validatePrimaryAnnotation(subject, dto, species);
 		return agmPhenotypeAnnotationDAO.persist(annotation);
 	}
 
 	@Transactional
-	public List<AGMPhenotypeAnnotation> addInferredOrAssertedEntities(AffectedGenomicModel primaryAnnotationSubject, PhenotypeFmsDTO secondaryAnnotationDto, BackendBulkDataProvider dataProvider, Set<Long> idsAdded) throws ValidationException {
-		List<AGMPhenotypeAnnotation> annotations = agmPhenotypeAnnotationFmsDtoValidator.validateInferredOrAssertedEntities(primaryAnnotationSubject, secondaryAnnotationDto, dataProvider, idsAdded);
+	public List<AGMPhenotypeAnnotation> addInferredOrAssertedEntities(AffectedGenomicModel primaryAnnotationSubject, PhenotypeFmsDTO secondaryAnnotationDto, Species species, Set<Long> idsAdded) throws ValidationException {
+		List<AGMPhenotypeAnnotation> annotations = agmPhenotypeAnnotationFmsDtoValidator.validateInferredOrAssertedEntities(primaryAnnotationSubject, secondaryAnnotationDto, species, idsAdded);
 		for (AGMPhenotypeAnnotation annotation : annotations) {
 			agmPhenotypeAnnotationDAO.persist(annotation);
 		}
@@ -68,7 +68,7 @@ public class AGMPhenotypeAnnotationService extends BaseAnnotationCrudService<AGM
 		return ret;
 	}
 
-	public List<Long> getAnnotationIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		return phenotypeAnnotationService.getAnnotationIdsByDataProvider(agmPhenotypeAnnotationDAO, dataProvider);
+	public List<Long> getAnnotationIdsBySpecies(Species species) {
+		return phenotypeAnnotationService.getAnnotationIdsBySpecies(agmPhenotypeAnnotationDAO, species);
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/AffectedGenomicModelService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AffectedGenomicModelService.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.AffectedGenomicModelDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.document.es.ModelSearchResultDocument;
@@ -63,8 +63,8 @@ public class AffectedGenomicModelService extends SubmittedObjectCrudService<Affe
 	}
 
 	@Override
-	public ObjectResponse<AffectedGenomicModel> upsert(AffectedGenomicModelDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return agmDtoValidator.validateAffectedGenomicModelDTO(dto, dataProvider);
+	public ObjectResponse<AffectedGenomicModel> upsert(AffectedGenomicModelDTO dto, Species species) throws ValidationException {
+		return agmDtoValidator.validateAffectedGenomicModelDTO(dto, species);
 	}
 
 	@Override
@@ -148,9 +148,9 @@ public class AffectedGenomicModelService extends SubmittedObjectCrudService<Affe
 		return agmDAO.findAgmsForSummaryByIds(ids);
 	}
 
-	public List<Long> getIdsByDataProvider(String dataProvider) {
+	public List<Long> getIdsByDataProvider(String species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider);
+		params.put(EntityFieldConstants.DATA_PROVIDER, species);
 		List<Long> ids = agmDAO.findIdsByParams(params);
 		ids.removeIf(Objects::isNull);
 		return ids;

--- a/src/main/java/org/alliancegenome/curation_api/services/AlleleDiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AlleleDiseaseAnnotationService.java
@@ -3,7 +3,7 @@ package org.alliancegenome.curation_api.services;
 import java.util.List;
 
 import org.alliancegenome.curation_api.dao.AlleleDiseaseAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.AlleleDiseaseAnnotation;
 import org.alliancegenome.curation_api.model.ingest.dto.AlleleDiseaseAnnotationDTO;
@@ -52,8 +52,8 @@ public class AlleleDiseaseAnnotationService extends BaseAnnotationDTOCrudService
 
 	@Override
 	@Transactional
-	public ObjectResponse<AlleleDiseaseAnnotation> upsert(AlleleDiseaseAnnotationDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		ObjectResponse<AlleleDiseaseAnnotation> resp = alleleDiseaseAnnotationDtoValidator.validateAlleleDiseaseAnnotationDTO(dto, dataProvider);
+	public ObjectResponse<AlleleDiseaseAnnotation> upsert(AlleleDiseaseAnnotationDTO dto, Species species) throws ValidationException {
+		ObjectResponse<AlleleDiseaseAnnotation> resp = alleleDiseaseAnnotationDtoValidator.validateAlleleDiseaseAnnotationDTO(dto, species);
 		diseaseAnnotationService.mintCurieIfAbsent(resp.getEntity());
 		alleleDiseaseAnnotationDAO.persist(resp.getEntity());
 		return resp;
@@ -67,8 +67,8 @@ public class AlleleDiseaseAnnotationService extends BaseAnnotationDTOCrudService
 		return ret;
 	}
 
-	public List<Long> getAnnotationIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		return diseaseAnnotationService.getAnnotationIdsByDataProvider(alleleDiseaseAnnotationDAO, dataProvider);
+	public List<Long> getAnnotationIdsBySpecies(Species species) {
+		return diseaseAnnotationService.getAnnotationIdsBySpecies(alleleDiseaseAnnotationDAO, species);
 	}
 
 	public List<String> getGeneDiseaseAnnotationList() {

--- a/src/main/java/org/alliancegenome/curation_api/services/AllelePhenotypeAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AllelePhenotypeAnnotationService.java
@@ -5,7 +5,7 @@ import java.util.Set;
 
 import org.alliancegenome.curation_api.dao.AllelePhenotypeAnnotationDAO;
 import org.alliancegenome.curation_api.dao.ConditionRelationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.Allele;
 import org.alliancegenome.curation_api.model.entities.AllelePhenotypeAnnotation;
@@ -46,14 +46,14 @@ public class AllelePhenotypeAnnotationService extends BaseAnnotationCrudService<
 	}
 
 	@Transactional
-	public AllelePhenotypeAnnotation upsertPrimaryAnnotation(Allele subject, PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		AllelePhenotypeAnnotation annotation = allelePhenotypeAnnotationFmsDtoValidator.validatePrimaryAnnotation(subject, dto, dataProvider);
+	public AllelePhenotypeAnnotation upsertPrimaryAnnotation(Allele subject, PhenotypeFmsDTO dto, Species species) throws ValidationException {
+		AllelePhenotypeAnnotation annotation = allelePhenotypeAnnotationFmsDtoValidator.validatePrimaryAnnotation(subject, dto, species);
 		return allelePhenotypeAnnotationDAO.persist(annotation);
 	}
 
 	@Transactional
-	public List<AllelePhenotypeAnnotation> addInferredOrAssertedEntities(Allele primaryAnnotationSubject, PhenotypeFmsDTO secondaryAnnotationDto, BackendBulkDataProvider dataProvider, Set<Long> idsAdded) throws ValidationException {
-		List<AllelePhenotypeAnnotation> annotations = allelePhenotypeAnnotationFmsDtoValidator.validateInferredOrAssertedEntities(primaryAnnotationSubject, secondaryAnnotationDto, dataProvider, idsAdded);
+	public List<AllelePhenotypeAnnotation> addInferredOrAssertedEntities(Allele primaryAnnotationSubject, PhenotypeFmsDTO secondaryAnnotationDto, Species species, Set<Long> idsAdded) throws ValidationException {
+		List<AllelePhenotypeAnnotation> annotations = allelePhenotypeAnnotationFmsDtoValidator.validateInferredOrAssertedEntities(primaryAnnotationSubject, secondaryAnnotationDto, species, idsAdded);
 		for (AllelePhenotypeAnnotation annotation : annotations) {
 			allelePhenotypeAnnotationDAO.persist(annotation);
 		}
@@ -68,7 +68,7 @@ public class AllelePhenotypeAnnotationService extends BaseAnnotationCrudService<
 		return ret;
 	}
 
-	public List<Long> getAnnotationIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		return phenotypeAnnotationService.getAnnotationIdsByDataProvider(allelePhenotypeAnnotationDAO, dataProvider);
+	public List<Long> getAnnotationIdsBySpecies(Species species) {
+		return phenotypeAnnotationService.getAnnotationIdsBySpecies(allelePhenotypeAnnotationDAO, species);
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/AlleleService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AlleleService.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.AlleleDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.base.BasePopularityInterface;
@@ -71,8 +71,8 @@ public class AlleleService extends SubmittedObjectCrudService<Allele, AlleleDTO,
 	}
 
 	@Override
-	public ObjectResponse<Allele> upsert(AlleleDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return alleleDtoValidator.validateAlleleDTO(dto, dataProvider);
+	public ObjectResponse<Allele> upsert(AlleleDTO dto, Species species) throws ValidationException {
+		return alleleDtoValidator.validateAlleleDTO(dto, species);
 	}
 
 	@Override
@@ -143,9 +143,9 @@ public class AlleleService extends SubmittedObjectCrudService<Allele, AlleleDTO,
 		return null;
 	}
 
-	public List<Long> getIdsByDataProvider(String dataProvider) {
+	public List<Long> getIdsByDataProvider(String species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider);
+		params.put(EntityFieldConstants.DATA_PROVIDER, species);
 		List<Long> ids = alleleDAO.findIdsByParams(params);
 		ids.removeIf(Objects::isNull);
 		return ids;

--- a/src/main/java/org/alliancegenome/curation_api/services/AssemblyComponentService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AssemblyComponentService.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.AssemblyComponentDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.enums.ChromosomeAccessionEnum;
 import org.alliancegenome.curation_api.model.entities.AssemblyComponent;
 import org.alliancegenome.curation_api.model.entities.GenomeAssembly;
@@ -41,45 +41,45 @@ public class AssemblyComponentService extends BaseEntityCrudService<AssemblyComp
 	}
 
 	@Transactional
-	public AssemblyComponent fetchOrCreate(String name, String assemblyId, String taxonCurie, BackendBulkDataProvider dataProvider) {
+	public AssemblyComponent fetchOrCreate(String name, String assemblyId, String taxonCurie, Species species) {
 		AssemblyComponent assemblyComponent = null;
 		if (assemblyComponentRequest != null) {
 			UniqueIdGeneratorHelper uniqueIdGen = new UniqueIdGeneratorHelper();
 			uniqueIdGen.add(name);
 			uniqueIdGen.add(assemblyId);
 			uniqueIdGen.add(taxonCurie);
-			uniqueIdGen.add(dataProvider.sourceOrganization);
+			uniqueIdGen.add(species.getDataProvider().getAbbreviation());
 			String uniqueId = uniqueIdGen.getUniqueId();
 			if (assemblyComponentCacheMap.containsKey(uniqueId)) {
 				assemblyComponent = assemblyComponentCacheMap.get(uniqueId);
 			} else {
 				Log.debug("AssemblyComponent not cached, caching name|assembly: (" + uniqueId + ")");
-				assemblyComponent = findAssemblyComponentOrCreateDB(name, assemblyId, taxonCurie, dataProvider);
+				assemblyComponent = findAssemblyComponentOrCreateDB(name, assemblyId, taxonCurie, species);
 				assemblyComponentCacheMap.put(uniqueId, assemblyComponent);
 			}
 		} else {
-			assemblyComponent = findAssemblyComponentOrCreateDB(name, assemblyId, taxonCurie, dataProvider);
+			assemblyComponent = findAssemblyComponentOrCreateDB(name, assemblyId, taxonCurie, species);
 			assemblyComponentRequest = new Date();
 		}
 		return assemblyComponent;
 	}
 
-	private AssemblyComponent findAssemblyComponentOrCreateDB(String name, String assemblyId, String taxonCurie, BackendBulkDataProvider dataProvider) {
+	private AssemblyComponent findAssemblyComponentOrCreateDB(String name, String assemblyId, String taxonCurie, Species species) {
 		Map<String, Object> params = new HashMap<>();
 		params.put("name", name);
 		params.put(EntityFieldConstants.ASSEMBLY, assemblyId);
 		params.put(EntityFieldConstants.TAXON, taxonCurie);
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put(EntityFieldConstants.DATA_PROVIDER, species.getDataProvider().getAbbreviation());
 		SearchResponse<AssemblyComponent> assemblyComponentResponse = assemblyComponentDAO.findByParams(params);
 		if (assemblyComponentResponse != null && assemblyComponentResponse.getResults().size() > 0) {
 			return assemblyComponentResponse.getSingleResult();
 		}
 		AssemblyComponent assemblyComponent = new AssemblyComponent();
 		assemblyComponent.setName(name);
-		GenomeAssembly genomeAssembly = genomeAssemblyService.getOrCreate(assemblyId, dataProvider);
+		GenomeAssembly genomeAssembly = genomeAssemblyService.getOrCreate(assemblyId, species);
 		assemblyComponent.setGenomeAssembly(genomeAssembly);
 		assemblyComponent.setTaxon(ncbiTaxonTermService.getByCurie(taxonCurie).getEntity());
-		assemblyComponent.setDataProvider(organizationService.getByAbbr(dataProvider.sourceOrganization).getEntity());
+		assemblyComponent.setDataProvider(organizationService.getByAbbr(species.getDataProvider().getAbbreviation()).getEntity());
 		String primaryExternalId = ChromosomeAccessionEnum.getChromosomeAccession(name, assemblyId);
 		assemblyComponent.setPrimaryExternalId(primaryExternalId);
 		return assemblyComponentDAO.persist(assemblyComponent);

--- a/src/main/java/org/alliancegenome/curation_api/services/BiologicalEntityService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/BiologicalEntityService.java
@@ -1,7 +1,7 @@
 package org.alliancegenome.curation_api.services;
 
 import org.alliancegenome.curation_api.dao.BiologicalEntityDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.BiologicalEntity;
 import org.alliancegenome.curation_api.model.ingest.dto.BiologicalEntityDTO;
@@ -24,7 +24,7 @@ public class BiologicalEntityService extends SubmittedObjectCrudService<Biologic
 	}
 
 	@Override
-	public ObjectResponse<BiologicalEntity> upsert(BiologicalEntityDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public ObjectResponse<BiologicalEntity> upsert(BiologicalEntityDTO dto, Species species) throws ValidationException {
 		return null;
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/services/CodingSequenceService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/CodingSequenceService.java
@@ -4,7 +4,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.alliancegenome.curation_api.dao.CodingSequenceDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.CodingSequence;
 import org.alliancegenome.curation_api.model.entities.Note;
@@ -35,14 +35,14 @@ public class CodingSequenceService extends BaseEntityCrudService<CodingSequence,
 		setSQLDao(codingSequenceDAO);
 	}
 
-	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
-		return codingSequenceDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	public List<Long> getIdsBySpecies(Species species) {
+		String taxon = needsTaxonFilter(species) ? species.getTaxon().getCurie() : null;
+		return codingSequenceDAO.findIdsByDataProvider(species.getDataProvider().getAbbreviation(), taxon);
 	}
 
-	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
-		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
-			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
+	private boolean needsTaxonFilter(Species species) {
+		return StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD")
+			|| StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB");
 	}
 
 	@Override

--- a/src/main/java/org/alliancegenome/curation_api/services/ConstructService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ConstructService.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.ConstructDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
@@ -78,8 +78,8 @@ public class ConstructService extends SubmittedObjectCrudService<Construct, Cons
 
 	@Override
 	@Transactional
-	public ObjectResponse<Construct> upsert(ConstructDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return constructDtoValidator.validateConstructDTO(dto, dataProvider);
+	public ObjectResponse<Construct> upsert(ConstructDTO dto, Species species) throws ValidationException {
+		return constructDtoValidator.validateConstructDTO(dto, species);
 	}
 
 	@Override
@@ -133,9 +133,9 @@ public class ConstructService extends SubmittedObjectCrudService<Construct, Cons
 		return null;
 	}
 
-	public List<Long> getConstructIdsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getConstructIdsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put(EntityFieldConstants.DATA_PROVIDER, species.getDataProvider().getAbbreviation());
 		List<Long> constructIds = constructDAO.findIdsByParams(params);
 		constructIds.removeIf(Objects::isNull);
 

--- a/src/main/java/org/alliancegenome/curation_api/services/DiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/DiseaseAnnotationService.java
@@ -9,7 +9,7 @@ import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.DiseaseAnnotationDAO;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.DiseaseAnnotation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.services.base.BaseAnnotationCrudService;
@@ -68,21 +68,21 @@ public class DiseaseAnnotationService extends BaseAnnotationCrudService<DiseaseA
 		return getAllReferencedConditionRelationIds(diseaseAnnotationDAO);
 	}
 
-	protected <D extends BaseSQLDAO<?>> List<Long> getAnnotationIdsByDataProvider(D dao, BackendBulkDataProvider dataProvider) {
+	protected <D extends BaseSQLDAO<?>> List<Long> getAnnotationIdsBySpecies(D dao, Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put(EntityFieldConstants.DATA_PROVIDER, species.getDataProvider().getAbbreviation());
 
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD")) {
-			params.put(EntityFieldConstants.DA_SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
+		if (StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD")) {
+			params.put(EntityFieldConstants.DA_SUBJECT_TAXON, species.getTaxon().getCurie());
 		}
 
 		List<Long> annotationIds = dao.findIdsByParams(params);
 		annotationIds.removeIf(Objects::isNull);
 
-		if (StringUtils.equals(dataProvider.toString(), "HUMAN")) {
+		if (StringUtils.equals(species.getDisplayName(), "HUMAN")) {
 			Map<String, Object> newParams = new HashMap<>();
-			newParams.put(EntityFieldConstants.SECONDARY_DATA_PROVIDER, dataProvider.sourceOrganization);
-			newParams.put(EntityFieldConstants.DA_SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
+			newParams.put(EntityFieldConstants.SECONDARY_DATA_PROVIDER, species.getDataProvider().getAbbreviation());
+			newParams.put(EntityFieldConstants.DA_SUBJECT_TAXON, species.getTaxon().getCurie());
 			List<Long> additionalIds = dao.findIdsByParams(newParams);
 			annotationIds.addAll(additionalIds);
 		}

--- a/src/main/java/org/alliancegenome/curation_api/services/ExonService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ExonService.java
@@ -4,7 +4,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.alliancegenome.curation_api.dao.ExonDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.Exon;
 import org.alliancegenome.curation_api.model.entities.Note;
@@ -79,14 +79,14 @@ public class ExonService extends BaseEntityCrudService<Exon, ExonDAO> {
 		return null;
 	}
 
-	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
-		return exonDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	public List<Long> getIdsBySpecies(Species species) {
+		String taxon = needsTaxonFilter(species) ? species.getTaxon().getCurie() : null;
+		return exonDAO.findIdsByDataProvider(species.getDataProvider().getAbbreviation(), taxon);
 	}
 
-	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
-		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
-			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
+	private boolean needsTaxonFilter(Species species) {
+		return StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD")
+			|| StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB");
 	}
 
 	@Override

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneDiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneDiseaseAnnotationService.java
@@ -3,7 +3,7 @@ package org.alliancegenome.curation_api.services;
 import java.util.List;
 
 import org.alliancegenome.curation_api.dao.GeneDiseaseAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.GeneDiseaseAnnotation;
 import org.alliancegenome.curation_api.model.ingest.dto.GeneDiseaseAnnotationDTO;
@@ -52,8 +52,8 @@ public class GeneDiseaseAnnotationService extends BaseAnnotationDTOCrudService<G
 
 	@Override
 	@Transactional
-	public ObjectResponse<GeneDiseaseAnnotation> upsert(GeneDiseaseAnnotationDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		ObjectResponse<GeneDiseaseAnnotation> resp = geneDiseaseAnnotationDtoValidator.validateGeneDiseaseAnnotationDTO(dto, dataProvider);
+	public ObjectResponse<GeneDiseaseAnnotation> upsert(GeneDiseaseAnnotationDTO dto, Species species) throws ValidationException {
+		ObjectResponse<GeneDiseaseAnnotation> resp = geneDiseaseAnnotationDtoValidator.validateGeneDiseaseAnnotationDTO(dto, species);
 		diseaseAnnotationService.mintCurieIfAbsent(resp.getEntity());
 		geneDiseaseAnnotationDAO.persist(resp.getEntity());
 		return resp;
@@ -67,8 +67,8 @@ public class GeneDiseaseAnnotationService extends BaseAnnotationDTOCrudService<G
 		return ret;
 	}
 
-	public List<Long> getAnnotationIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		return diseaseAnnotationService.getAnnotationIdsByDataProvider(geneDiseaseAnnotationDAO, dataProvider);
+	public List<Long> getAnnotationIdsBySpecies(Species species) {
+		return diseaseAnnotationService.getAnnotationIdsBySpecies(geneDiseaseAnnotationDAO, species);
 	}
 
 	public List<String> getGeneDiseaseAnnotationList() {

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneExpressionAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneExpressionAnnotationService.java
@@ -7,7 +7,7 @@ import java.util.Set;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.GeneExpressionAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.GeneExpressionAnnotation;
@@ -44,11 +44,11 @@ public class GeneExpressionAnnotationService extends BaseAnnotationCrudService<G
 		crossReferences = new HashMap<>();
 	}
 
-	public List<Long> getAnnotationIdsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getAnnotationIdsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.EA_SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
+		params.put(EntityFieldConstants.DATA_PROVIDER, species.getDataProvider().getAbbreviation());
+		if (StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD") || StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB")) {
+			params.put(EntityFieldConstants.EA_SUBJECT_TAXON, species.getTaxon().getCurie());
 		}
 		List<Long> annotationIds = geneExpressionAnnotationDAO.findIdsByParams(params);
 		return annotationIds;
@@ -56,8 +56,8 @@ public class GeneExpressionAnnotationService extends BaseAnnotationCrudService<G
 
 	@Transactional
 	@Override
-	public ObjectResponse<GeneExpressionAnnotation> upsert(ConsolidatedGeneExpressionFmsDTO consolidatedGeneExpressionFmsDTO, BackendBulkDataProvider dataProvider) throws ValidationException {
-		ObjectResponse<GeneExpressionAnnotation> resp = geneExpressionAnnotationFmsDTOValidator.validateAnnotation(consolidatedGeneExpressionFmsDTO, dataProvider, experiments, crossReferences);
+	public ObjectResponse<GeneExpressionAnnotation> upsert(ConsolidatedGeneExpressionFmsDTO consolidatedGeneExpressionFmsDTO, Species species) throws ValidationException {
+		ObjectResponse<GeneExpressionAnnotation> resp = geneExpressionAnnotationFmsDTOValidator.validateAnnotation(consolidatedGeneExpressionFmsDTO, species, experiments, crossReferences);
 		geneExpressionAnnotationDAO.persist(resp.getEntity());
 		return resp;
 	}

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneExpressionExperimentService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneExpressionExperimentService.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.GeneExpressionAnnotationDAO;
 import org.alliancegenome.curation_api.dao.GeneExpressionExperimentDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.CrossReference;
 import org.alliancegenome.curation_api.model.entities.GeneExpressionAnnotation;
@@ -46,17 +46,17 @@ public class GeneExpressionExperimentService extends BaseEntityCrudService<GeneE
 		setSQLDao(geneExpressionExperimentDAO);
 	}
 
-	public List<Long> getExperimentIdsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getExperimentIdsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.EXP_EXPERIMENT_TAXON, dataProvider.canonicalTaxonCurie);
+		params.put(EntityFieldConstants.DATA_PROVIDER, species.getDataProvider().getAbbreviation());
+		if (StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD") || StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB")) {
+			params.put(EntityFieldConstants.EXP_EXPERIMENT_TAXON, species.getTaxon().getCurie());
 		}
 		return geneExpressionExperimentDAO.findIdsByParams(params);
 	}
 
 	@Transactional
-	public GeneExpressionExperiment upsert(String experimentId, Set<String> geneExpressionAnnotationIds, BackendBulkDataProvider dataProvider, Set<CrossReferenceFmsDTO> crossReferences) throws ValidationException {
+	public GeneExpressionExperiment upsert(String experimentId, Set<String> geneExpressionAnnotationIds, Species species, Set<CrossReferenceFmsDTO> crossReferences) throws ValidationException {
 		GeneExpressionExperiment geneExpressionExperiment;
 		Set<GeneExpressionAnnotation> annotations;
 
@@ -72,7 +72,7 @@ public class GeneExpressionExperimentService extends BaseEntityCrudService<GeneE
 			geneExpressionExperiment = new GeneExpressionExperiment();
 			geneExpressionExperiment.setUniqueId(experimentId);
 		}
-		Organization organization = organizationService.getByAbbr(dataProvider.sourceOrganization).getEntity();
+		Organization organization = organizationService.getByAbbr(species.getDataProvider().getAbbreviation()).getEntity();
 		geneExpressionExperiment.setDataProvider(organization);
 		geneExpressionExperiment.setEntityAssayed(geneService.findByIdentifierString(geneId));
 		geneExpressionExperiment.setSingleReference(referenceService.getByCurie(referenceId).getEntity());
@@ -85,7 +85,7 @@ public class GeneExpressionExperimentService extends BaseEntityCrudService<GeneE
 			annotations = new HashSet<>();
 		}
 
-		if (dataProvider.name().equals("MGI") || dataProvider.name().equals("WB")) {
+		if (species.getDisplayName().equals("MGI") || species.getDisplayName().equals("WB")) {
 			if (geneExpressionExperiment.getCrossReferences() != null) {
 				geneExpressionExperiment.getCrossReferences().clear();
 			} else {

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneGeneticInteractionService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneGeneticInteractionService.java
@@ -3,7 +3,7 @@ package org.alliancegenome.curation_api.services;
 import java.util.List;
 
 import org.alliancegenome.curation_api.dao.GeneGeneticInteractionDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.GeneGeneticInteraction;
@@ -49,7 +49,7 @@ public class GeneGeneticInteractionService extends BaseEntityCrudService<GeneGen
 
 	@Override
 	@Transactional
-	public ObjectResponse<GeneGeneticInteraction> upsert(PsiMiTabDTO dto, BackendBulkDataProvider backendBulkDataProvider) throws ValidationException {
+	public ObjectResponse<GeneGeneticInteraction> upsert(PsiMiTabDTO dto, Species species) throws ValidationException {
 		return geneGeneticInteractionValidator.validateGeneGeneticInteractionFmsDTO(dto);
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneMolecularInteractionService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneMolecularInteractionService.java
@@ -3,7 +3,7 @@ package org.alliancegenome.curation_api.services;
 import java.util.List;
 
 import org.alliancegenome.curation_api.dao.GeneMolecularInteractionDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.GeneMolecularInteraction;
@@ -48,7 +48,7 @@ public class GeneMolecularInteractionService extends BaseEntityCrudService<GeneM
 
 	@Override
 	@Transactional
-	public ObjectResponse<GeneMolecularInteraction> upsert(PsiMiTabDTO dto, BackendBulkDataProvider backendBulkDataProvider) throws ValidationException {
+	public ObjectResponse<GeneMolecularInteraction> upsert(PsiMiTabDTO dto, Species species) throws ValidationException {
 		return geneMolInteractionValidator.validateGeneMolecularInteractionFmsDTO(dto);
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneOntologyAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneOntologyAnnotationService.java
@@ -12,7 +12,8 @@ import org.alliancegenome.curation_api.dao.GeneDAO;
 import org.alliancegenome.curation_api.dao.GeneOntologyAnnotationDAO;
 import org.alliancegenome.curation_api.dao.SpeciesDAO;
 import org.alliancegenome.curation_api.dao.ontology.GoTermDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
+import org.apache.commons.lang3.StringUtils;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.GeneOntologyAnnotation;
 import org.alliancegenome.curation_api.model.entities.Person;
@@ -115,12 +116,12 @@ public class GeneOntologyAnnotationService extends BaseEntityCrudService<GeneOnt
 		return gafDAO.remove(id);
 	}
 
-	public List<Long> getAllGafIdsPerProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getAllGafIdsPerProvider(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		if (dataProvider == BackendBulkDataProvider.HUMAN || dataProvider == BackendBulkDataProvider.RGD) {
-			params.put("singleGene.taxon.curie", dataProvider.canonicalTaxonCurie);
+		if (StringUtils.equals(species.getDisplayName(), "HUMAN") || StringUtils.equals(species.getDisplayName(), "RGD")) {
+			params.put("singleGene.taxon.curie", species.getTaxon().getCurie());
 		} else {
-			params.put("singleGene.taxon.species.dataProvider.abbreviation", dataProvider.sourceOrganization);
+			params.put("singleGene.taxon.species.dataProvider.abbreviation", species.getDataProvider().getAbbreviation());
 		}
 		return gafDAO.findIdsByParams(params);
 	}

--- a/src/main/java/org/alliancegenome/curation_api/services/GenePhenotypeAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GenePhenotypeAnnotationService.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.alliancegenome.curation_api.dao.ConditionRelationDAO;
 import org.alliancegenome.curation_api.dao.GenePhenotypeAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.GenePhenotypeAnnotation;
@@ -45,8 +45,8 @@ public class GenePhenotypeAnnotationService extends BaseAnnotationCrudService<Ge
 	}
 
 	@Transactional
-	public GenePhenotypeAnnotation upsertPrimaryAnnotation(Gene subject, PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		GenePhenotypeAnnotation annotation = genePhenotypeAnnotationFmsDtoValidator.validatePrimaryAnnotation(subject, dto, dataProvider);
+	public GenePhenotypeAnnotation upsertPrimaryAnnotation(Gene subject, PhenotypeFmsDTO dto, Species species) throws ValidationException {
+		GenePhenotypeAnnotation annotation = genePhenotypeAnnotationFmsDtoValidator.validatePrimaryAnnotation(subject, dto, species);
 		return genePhenotypeAnnotationDAO.persist(annotation);
 	}
 
@@ -58,7 +58,7 @@ public class GenePhenotypeAnnotationService extends BaseAnnotationCrudService<Ge
 		return ret;
 	}
 
-	public List<Long> getAnnotationIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		return phenotypeAnnotationService.getAnnotationIdsByDataProvider(genePhenotypeAnnotationDAO, dataProvider);
+	public List<Long> getAnnotationIdsBySpecies(Species species) {
+		return phenotypeAnnotationService.getAnnotationIdsBySpecies(genePhenotypeAnnotationDAO, species);
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneService.java
@@ -16,7 +16,7 @@ import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.dao.GeneDAO;
 import org.alliancegenome.curation_api.model.document.es.GeneSearchResultDocument;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
@@ -88,8 +88,8 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 	}
 
 	@Override
-	public ObjectResponse<Gene> upsert(GeneDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return geneDtoValidator.validateGeneDTO(dto, dataProvider);
+	public ObjectResponse<Gene> upsert(GeneDTO dto, Species species) throws ValidationException {
+		return geneDtoValidator.validateGeneDTO(dto, species);
 	}
 
 	@Override
@@ -176,11 +176,11 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 		return null;
 	}
 
-	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getIdsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD")) {
-			params.put(EntityFieldConstants.TAXON, dataProvider.canonicalTaxonCurie);
+		params.put(EntityFieldConstants.DATA_PROVIDER, species.getDataProvider().getAbbreviation());
+		if (StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD")) {
+			params.put(EntityFieldConstants.TAXON, species.getTaxon().getCurie());
 		}
 		List<Long> ids = geneDAO.findIdsByParams(params);
 		ids.removeIf(Objects::isNull);
@@ -189,19 +189,19 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 	}
 
 	@Transactional
-	public void addBiogridXref(String entrezId, BackendBulkDataProvider dataProvider) throws ValidationException {
-		NCBITaxonTerm taxon = ncbiTaxonTermService.getByCurie(dataProvider.canonicalTaxonCurie).getEntity();
+	public void addBiogridXref(String entrezId, Species species) throws ValidationException {
+		NCBITaxonTerm taxon = ncbiTaxonTermService.getByCurie(species.getTaxon().getCurie()).getEntity();
 		if (taxon == null) {
-			throw new ObjectValidationException(entrezId, "dataProvider - canonical taxon: " + ValidationConstants.INVALID_MESSAGE + " (" + dataProvider.canonicalTaxonCurie + " not found)");
+			throw new ObjectValidationException(entrezId, "dataProvider - canonical taxon: " + ValidationConstants.INVALID_MESSAGE + " (" + species.getTaxon().getCurie() + " not found)");
 		}
 
 		Gene allianceGene = null;
 		SearchResponse<Gene> searchResponse = findByField("crossReferences.referencedCurie", "NCBI_Gene:" + entrezId);
 		if (searchResponse != null) {
-			// Need to check that returned gene belongs to MOD corresponding to taxon
 			for (Gene searchResult : searchResponse.getResults()) {
-				String resultDataProviderCoreGenus = BackendBulkDataProvider.getCoreGenus(searchResult.getDataProvider().getAbbreviation());
-				if (taxon.getName().startsWith(resultDataProviderCoreGenus + " ")) {
+				String resultTaxonName = searchResult.getTaxon() != null ? searchResult.getTaxon().getName() : null;
+				String resultCoreGenus = resultTaxonName != null && resultTaxonName.contains(" ") ? resultTaxonName.substring(0, resultTaxonName.indexOf(" ")) : null;
+				if (resultCoreGenus != null && taxon.getName().startsWith(resultCoreGenus + " ")) {
 					allianceGene = searchResult;
 					break;
 				}
@@ -224,19 +224,19 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 	}
 
 	@Transactional
-	public void addGeoXref(String entrezId, BackendBulkDataProvider dataProvider) throws ValidationException {
-		NCBITaxonTerm taxon = ncbiTaxonTermService.getByCurie(dataProvider.canonicalTaxonCurie).getEntity();
+	public void addGeoXref(String entrezId, Species species) throws ValidationException {
+		NCBITaxonTerm taxon = ncbiTaxonTermService.getByCurie(species.getTaxon().getCurie()).getEntity();
 		if (taxon == null) {
-			throw new ObjectValidationException(entrezId, "dataProvider - canonical taxon: " + ValidationConstants.INVALID_MESSAGE + " (" + dataProvider.canonicalTaxonCurie + " not found)");
+			throw new ObjectValidationException(entrezId, "dataProvider - canonical taxon: " + ValidationConstants.INVALID_MESSAGE + " (" + species.getTaxon().getCurie() + " not found)");
 		}
 
 		Gene allianceGene = null;
 		SearchResponse<Gene> searchResponse = findByField("crossReferences.referencedCurie", "NCBI_Gene:" + entrezId);
 		if (searchResponse != null) {
-			// Need to check that returned gene belongs to MOD corresponding to taxon
 			for (Gene searchResult : searchResponse.getResults()) {
-				String resultDataProviderCoreGenus = BackendBulkDataProvider.getCoreGenus(searchResult.getDataProvider().getAbbreviation());
-				if (taxon.getName().startsWith(resultDataProviderCoreGenus + " ")) {
+				String resultTaxonName = searchResult.getTaxon() != null ? searchResult.getTaxon().getName() : null;
+				String resultCoreGenus = resultTaxonName != null && resultTaxonName.contains(" ") ? resultTaxonName.substring(0, resultTaxonName.indexOf(" ")) : null;
+				if (resultCoreGenus != null && taxon.getName().startsWith(resultCoreGenus + " ")) {
 					allianceGene = searchResult;
 					break;
 				}
@@ -259,25 +259,24 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 	}
 
 	@Transactional
-	public void addExpressionAtlasXref(String identifier, BackendBulkDataProvider dataProvider) throws ValidationException {
-		NCBITaxonTerm taxon = ncbiTaxonTermService.getByCurie(dataProvider.canonicalTaxonCurie).getEntity();
+	public void addExpressionAtlasXref(String identifier, Species species) throws ValidationException {
+		NCBITaxonTerm taxon = ncbiTaxonTermService.getByCurie(species.getTaxon().getCurie()).getEntity();
 		if (taxon == null) {
-			throw new ObjectValidationException(identifier, "dataProvider - canonical taxon: " + ValidationConstants.INVALID_MESSAGE + " (" + dataProvider.canonicalTaxonCurie + " not found)");
+			throw new ObjectValidationException(identifier, "dataProvider - canonical taxon: " + ValidationConstants.INVALID_MESSAGE + " (" + species.getTaxon().getCurie() + " not found)");
 		}
 
-		
 		String searchField;
 		String searchValue;
 		String referencedCurie;
 		String resourceDescriptorPrefix;
-		switch (dataProvider) {
-			case FB -> {
+		switch (species.getDisplayName()) {
+			case "FB" -> {
 				searchField = "primaryExternalId";
 				searchValue = "FB:" + identifier;
 				referencedCurie = searchValue;
 				resourceDescriptorPrefix = "FB";
 			}
-			case SGD -> {
+			case "SGD" -> {
 				searchField = "geneSymbol.displayText";
 				searchValue = identifier;
 				referencedCurie = "SGD:" + identifier;
@@ -290,14 +289,14 @@ public class GeneService extends SubmittedObjectCrudService<Gene, GeneDTO, GeneD
 				resourceDescriptorPrefix = "ENSEMBL";
 			}
 		}
-		
+
 		Gene allianceGene = null;
 		SearchResponse<Gene> searchResponse = findByField(searchField, searchValue);
 		if (searchResponse != null) {
-			// Need to check that returned gene belongs to MOD corresponding to taxon
 			for (Gene searchResult : searchResponse.getResults()) {
-				String resultDataProviderCoreGenus = BackendBulkDataProvider.getCoreGenus(searchResult.getDataProvider().getAbbreviation());
-				if (taxon.getName().startsWith(resultDataProviderCoreGenus + " ")) {
+				String resultTaxonName = searchResult.getTaxon() != null ? searchResult.getTaxon().getName() : null;
+				String resultCoreGenus = resultTaxonName != null && resultTaxonName.contains(" ") ? resultTaxonName.substring(0, resultTaxonName.indexOf(" ")) : null;
+				if (resultCoreGenus != null && taxon.getName().startsWith(resultCoreGenus + " ")) {
 					allianceGene = searchResult;
 					break;
 				}

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneToGeneParalogyService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneToGeneParalogyService.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.GeneToGeneParalogyDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.GeneToGeneParalogy;
@@ -33,16 +33,16 @@ public class GeneToGeneParalogyService extends BaseEntityCrudService<GeneToGeneP
 	}
 
 	@Override
-	public ObjectResponse<GeneToGeneParalogy> upsert(ParalogyFmsDTO paralogyData, BackendBulkDataProvider backendBulkDataProvider) throws ValidationException {
+	public ObjectResponse<GeneToGeneParalogy> upsert(ParalogyFmsDTO paralogyData, Species species) throws ValidationException {
 		return paralogyFmsDtoValidator.validateParalogyFmsDTO(paralogyData);
 	}
 
-	public List<Long> getAllParalogyPairIdsBySubjectGeneDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getAllParalogyPairIdsBySubjectGeneDataProvider(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.SUBJECT_GENE_DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put(EntityFieldConstants.SUBJECT_GENE_DATA_PROVIDER, species.getDataProvider().getAbbreviation());
 
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.SUBJECT_GENE_TAXON, dataProvider.canonicalTaxonCurie);
+		if (StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD") || StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB")) {
+			params.put(EntityFieldConstants.SUBJECT_GENE_TAXON, species.getTaxon().getCurie());
 		}
 
 		List<Long> annotationIds = geneToGeneParalogyDAO.findIdsByParams(params);

--- a/src/main/java/org/alliancegenome/curation_api/services/GenomeAssemblyService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GenomeAssemblyService.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.GenomeAssemblyDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.GenomeAssembly;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
@@ -31,20 +31,20 @@ public class GenomeAssemblyService extends BaseEntityCrudService<GenomeAssembly,
 		setSQLDao(genomeAssemblyDAO);
 	}
 	
-	public GenomeAssembly getOrCreate(String assemblyName, BackendBulkDataProvider dataProvider) {
+	public GenomeAssembly getOrCreate(String assemblyName, Species species) {
 
 		if (StringUtils.isNotBlank(assemblyName)) {
 			Map<String, Object> params = new HashMap<>();
 			params.put("primaryExternalId", assemblyName);
-			params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
-			params.put(EntityFieldConstants.TAXON, dataProvider.canonicalTaxonCurie);
+			params.put(EntityFieldConstants.DATA_PROVIDER, species.getDataProvider().getAbbreviation());
+			params.put(EntityFieldConstants.TAXON, species.getTaxon().getCurie());
 	
 			SearchResponse<GenomeAssembly> resp = genomeAssemblyDAO.findByParams(params);
 			if (resp == null || resp.getSingleResult() == null) {
 				GenomeAssembly assembly = new GenomeAssembly();
 				assembly.setPrimaryExternalId(assemblyName);
-				assembly.setDataProvider(organizationService.getByAbbr(dataProvider.sourceOrganization).getEntity());
-				assembly.setTaxon(ncbiTaxonTermService.getByCurie(dataProvider.canonicalTaxonCurie).getEntity());
+				assembly.setDataProvider(organizationService.getByAbbr(species.getDataProvider().getAbbreviation()).getEntity());
+				assembly.setTaxon(ncbiTaxonTermService.getByCurie(species.getTaxon().getCurie()).getEntity());
 	
 				return genomeAssemblyDAO.persist(assembly);
 			} else {

--- a/src/main/java/org/alliancegenome/curation_api/services/GenomicEntityService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GenomicEntityService.java
@@ -1,7 +1,7 @@
 package org.alliancegenome.curation_api.services;
 
 import org.alliancegenome.curation_api.dao.GenomicEntityDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.GenomicEntity;
 import org.alliancegenome.curation_api.model.ingest.dto.GenomicEntityDTO;
@@ -30,7 +30,7 @@ public class GenomicEntityService extends SubmittedObjectCrudService<GenomicEnti
 	}
 
 	@Override
-	public ObjectResponse<GenomicEntity> upsert(GenomicEntityDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public ObjectResponse<GenomicEntity> upsert(GenomicEntityDTO dto, Species species) throws ValidationException {
 		return null;
 	}
 

--- a/src/main/java/org/alliancegenome/curation_api/services/Gff3Service.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/Gff3Service.java
@@ -21,7 +21,7 @@ import org.alliancegenome.curation_api.dao.associations.TranscriptGeneAssociatio
 import org.alliancegenome.curation_api.dao.associations.TranscriptGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.dao.ontology.SoTermDAO;
 import org.alliancegenome.curation_api.dao.loads.BulkLoadFileExceptionDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
@@ -96,7 +96,7 @@ public class Gff3Service {
 	private Map<String, Transcript> transcriptCache = new HashMap<>();
 
 	@Transactional
-	public void loadExonLocationAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, BackendBulkDataProvider dataProvider, String assemblyId) throws ValidationException {
+	public void loadExonLocationAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, Species species, String assemblyId) throws ValidationException {
 		Gff3DTO gffEntry = gffEntryPair.getKey();
 
 		if (StringUtils.isBlank(assemblyId)) {
@@ -107,14 +107,14 @@ public class Gff3Service {
 			throw new ObjectValidationException(gffEntry, "Invalid Type: " + gffEntry.getType() + " for Exon Location");
 		}
 
-		String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, gffEntryPair.getValue(), dataProvider);
+		String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, gffEntryPair.getValue(), species);
 		SearchResponse<Exon> response = exonDAO.findByField("uniqueId", uniqueId);
 		if (response == null || response.getSingleResult() == null) {
 			throw new ObjectValidationException(gffEntry, "uniqueId - " + ValidationConstants.INVALID_MESSAGE + " (" + uniqueId + ")");
 		}
 		Exon exon = response.getSingleResult();
 
-		ExonGenomicLocationAssociation exonLocation = gff3DtoValidator.validateExonLocation(gffEntry, exon, assemblyId, dataProvider);
+		ExonGenomicLocationAssociation exonLocation = gff3DtoValidator.validateExonLocation(gffEntry, exon, assemblyId, species);
 		if (exonLocation != null) {
 			idsAdded.add(exonLocation.getId());
 			exonLocationService.addAssociationToSubject(exonLocation);
@@ -123,7 +123,7 @@ public class Gff3Service {
 	}
 
 	@Transactional
-	public void loadCDSLocationAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, BackendBulkDataProvider dataProvider, String assemblyId) throws ValidationException {
+	public void loadCDSLocationAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, Species species, String assemblyId) throws ValidationException {
 		Gff3DTO gffEntry = gffEntryPair.getKey();
 		Map<String, String> attributes = gffEntryPair.getValue();
 		if (StringUtils.isBlank(assemblyId)) {
@@ -134,14 +134,14 @@ public class Gff3Service {
 			throw new ObjectValidationException(gffEntry, "Invalid Type: " + gffEntry.getType() + " for CDS Location");
 		}
 
-		String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, attributes, dataProvider);
+		String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, attributes, species);
 		SearchResponse<CodingSequence> response = cdsDAO.findByField("uniqueId", uniqueId);
 		if (response == null || response.getSingleResult() == null) {
 			throw new ObjectValidationException(gffEntry, "uniqueId - " + ValidationConstants.INVALID_MESSAGE + " (" + uniqueId + ")");
 		}
 		CodingSequence cds = response.getSingleResult();
 
-		CodingSequenceGenomicLocationAssociation cdsLocation = gff3DtoValidator.validateCdsLocation(gffEntry, cds, assemblyId, dataProvider);
+		CodingSequenceGenomicLocationAssociation cdsLocation = gff3DtoValidator.validateCdsLocation(gffEntry, cds, assemblyId, species);
 		if (cdsLocation != null) {
 			idsAdded.add(cdsLocation.getId());
 			cdsLocationService.addAssociationToSubject(cdsLocation);
@@ -150,7 +150,7 @@ public class Gff3Service {
 	}
 
 	@Transactional
-	public void loadTranscriptLocationAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, BackendBulkDataProvider dataProvider, String assemblyId) throws ValidationException {
+	public void loadTranscriptLocationAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, Species species, String assemblyId) throws ValidationException {
 		Gff3DTO gffEntry = gffEntryPair.getKey();
 		Map<String, String> attributes = gffEntryPair.getValue();
 		if (StringUtils.isBlank(assemblyId)) {
@@ -170,7 +170,7 @@ public class Gff3Service {
 		}
 		Transcript transcript = response.getSingleResult();
 
-		TranscriptGenomicLocationAssociation transcriptLocation = gff3DtoValidator.validateTranscriptLocation(gffEntry, transcript, assemblyId, dataProvider);
+		TranscriptGenomicLocationAssociation transcriptLocation = gff3DtoValidator.validateTranscriptLocation(gffEntry, transcript, assemblyId, species);
 		if (transcriptLocation != null) {
 			idsAdded.add(transcriptLocation.getId());
 			transcriptLocationService.addAssociationToSubject(transcriptLocation);
@@ -178,7 +178,7 @@ public class Gff3Service {
 	}
 
 	@Transactional
-	public void loadGeneLocationAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, BackendBulkDataProvider dataProvider, String assemblyId) throws ValidationException {
+	public void loadGeneLocationAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, Species species, String assemblyId) throws ValidationException {
 		Gff3DTO gffEntry = gffEntryPair.getKey();
 		Map<String, String> attributes = gffEntryPair.getValue();
 		if (StringUtils.isBlank(assemblyId)) {
@@ -203,19 +203,10 @@ public class Gff3Service {
 		
 		Gene gene = geneService.findByIdentifierString(geneCurie);
 		if (gene == null) {
-			// SCRUM-6205: RefSeq-shaped GFFs (e.g. ZFIN GRCz12tu) carry the MOD curie only in
-			// Dbxref; the prefixed gene_id/ID match nothing. Fall back to the provider-scoped
-			// Dbxref curie before skipping. Existing files resolve above and never reach here.
-			String dbxrefCurie = Gff3AttributesHelper.getModCurieFromDbxref(attributes, dataProvider);
-			if (dbxrefCurie != null) {
-				gene = geneService.findByIdentifierString(dbxrefCurie);
-			}
-		}
-		if (gene == null) {
 			throw new KnownIssueValidationException(ValidationConstants.UNRECOGNIZED_MESSAGE + " (" + attributes.get(identifyingAttribute) + ")");
 		}
 
-		GeneGenomicLocationAssociation geneLocation = gff3DtoValidator.validateGeneLocation(gffEntry, gene, assemblyId, dataProvider);
+		GeneGenomicLocationAssociation geneLocation = gff3DtoValidator.validateGeneLocation(gffEntry, gene, assemblyId, species);
 		if (geneLocation != null) {
 			idsAdded.add(geneLocation.getId());
 			geneLocationService.addAssociationToSubject(geneLocation);
@@ -223,7 +214,7 @@ public class Gff3Service {
 	}
 
 	@Transactional
-	public void loadExonParentChildAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public void loadExonParentChildAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, Species species) throws ValidationException {
 		Gff3DTO gffEntry = gffEntryPair.getKey();
 
 		if (!StringUtils.equals(gffEntry.getType(), "exon") && !StringUtils.equals(gffEntry.getType(), "noncoding_exon")) {
@@ -231,7 +222,7 @@ public class Gff3Service {
 		}
 
 		Map<String, String> attributes = gffEntryPair.getValue();
-		String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, attributes, dataProvider);
+		String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, attributes, species);
 		SearchResponse<Exon> response = exonDAO.findByField("uniqueId", uniqueId);
 		if (response == null || response.getSingleResult() == null) {
 			throw new ObjectValidationException(gffEntry, "uniqueId - " + ValidationConstants.INVALID_MESSAGE + " (" + uniqueId + ")");
@@ -247,7 +238,7 @@ public class Gff3Service {
 	}
 
 	@Transactional
-	public void loadCDSParentChildAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public void loadCDSParentChildAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, Species species) throws ValidationException {
 		Gff3DTO gffEntry = gffEntryPair.getKey();
 		Map<String, String> attributes = gffEntryPair.getValue();
 
@@ -255,7 +246,7 @@ public class Gff3Service {
 			throw new ObjectValidationException(gffEntry, "Invalid Type: " + gffEntry.getType() + " for CDS Transcript Associations");
 		}
 
-		String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, attributes, dataProvider);
+		String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, attributes, species);
 		SearchResponse<CodingSequence> response = cdsDAO.findByField("uniqueId", uniqueId);
 		if (response == null || response.getSingleResult() == null) {
 			throw new ObjectValidationException(gffEntry, "uniqueId - " + ValidationConstants.INVALID_MESSAGE + " (" + uniqueId + ")");
@@ -270,7 +261,7 @@ public class Gff3Service {
 	}
 
 	@Transactional
-	public void loadGeneParentChildAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, BackendBulkDataProvider dataProvider, Map<String, String> geneIdCurieMap) throws ValidationException {
+	public void loadGeneParentChildAssociations(ImmutablePair<Gff3DTO, Map<String, String>> gffEntryPair, List<Long> idsAdded, Species species, Map<String, String> geneIdCurieMap) throws ValidationException {
 		Gff3DTO gffEntry = gffEntryPair.getKey();
 		if (!Gff3Constants.TRANSCRIPT_TYPES.contains(gffEntry.getType())) {
 			throw new ObjectValidationException(gffEntry, "Invalid Type: " + gffEntry.getType() + " for Gene Transcript Associations");
@@ -300,7 +291,7 @@ public class Gff3Service {
 			List<Long> entityIdsAdded,
 			List<Long> locationIdsAdded,
 			List<Long> associationIdsAdded,
-			BackendBulkDataProvider dataProvider,
+			Species species,
 			String assemblyId,
 			BulkLoadFileHistory history,
 			ProcessDisplayHelper ph) {
@@ -311,7 +302,7 @@ public class Gff3Service {
 		Set<String> uniqueIds = new HashSet<>();
 		Set<String> parentIds = new HashSet<>();
 		for (ImmutablePair<Gff3DTO, Map<String, String>> pair : batch) {
-			uniqueIds.add(Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(pair.getKey(), pair.getValue(), dataProvider));
+			uniqueIds.add(Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(pair.getKey(), pair.getValue(), species));
 			String parent = pair.getValue().get("Parent");
 			if (parent != null && !transcriptCache.containsKey(parent)) {
 				parentIds.add(parent);
@@ -339,7 +330,7 @@ public class Gff3Service {
 		for (ImmutablePair<Gff3DTO, Map<String, String>> pair : batch) {
 			Gff3DTO gffEntry = pair.getKey();
 			Map<String, String> attributes = pair.getValue();
-			String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, attributes, dataProvider);
+			String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, attributes, species);
 
 			// Phase 1: Entity
 			Exon exon = null;
@@ -358,8 +349,8 @@ public class Gff3Service {
 					exon.setName(attributes.get("Name"));
 				}
 
-				exon.setDataProvider(organizationService.getByAbbr(dataProvider.sourceOrganization).getEntity());
-				exon.setTaxon(ncbiTaxonTermService.getByCurie(dataProvider.canonicalTaxonCurie).getEntity());
+				exon.setDataProvider(organizationService.getByAbbr(species.getDataProvider().getAbbreviation()).getEntity());
+				exon.setTaxon(ncbiTaxonTermService.getByCurie(species.getTaxon().getCurie()).getEntity());
 
 				exon = exonDAO.persist(exon);
 				entityIdsAdded.add(exon.getId());
@@ -379,7 +370,7 @@ public class Gff3Service {
 			if (exon != null && assemblyId != null) {
 				try {
 					ExonGenomicLocationAssociation existingLocation = locationAssocMap.get(exon.getId());
-					ExonGenomicLocationAssociation exonLocation = gff3DtoValidator.validateExonLocation(gffEntry, exon, assemblyId, dataProvider, existingLocation);
+					ExonGenomicLocationAssociation exonLocation = gff3DtoValidator.validateExonLocation(gffEntry, exon, assemblyId, species, existingLocation);
 					if (exonLocation != null) {
 						locationIdsAdded.add(exonLocation.getId());
 					}
@@ -431,7 +422,7 @@ public class Gff3Service {
 			List<Long> entityIdsAdded,
 			List<Long> locationIdsAdded,
 			List<Long> associationIdsAdded,
-			BackendBulkDataProvider dataProvider,
+			Species species,
 			String assemblyId,
 			BulkLoadFileHistory history,
 			ProcessDisplayHelper ph) {
@@ -442,7 +433,7 @@ public class Gff3Service {
 		Set<String> uniqueIds = new HashSet<>();
 		Set<String> parentIds = new HashSet<>();
 		for (ImmutablePair<Gff3DTO, Map<String, String>> pair : batch) {
-			uniqueIds.add(Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(pair.getKey(), pair.getValue(), dataProvider));
+			uniqueIds.add(Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(pair.getKey(), pair.getValue(), species));
 			String parent = pair.getValue().get("Parent");
 			if (parent != null && !transcriptCache.containsKey(parent)) {
 				parentIds.add(parent);
@@ -470,7 +461,7 @@ public class Gff3Service {
 		for (ImmutablePair<Gff3DTO, Map<String, String>> pair : batch) {
 			Gff3DTO gffEntry = pair.getKey();
 			Map<String, String> attributes = pair.getValue();
-			String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, attributes, dataProvider);
+			String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(gffEntry, attributes, species);
 
 			// Phase 1: Entity
 			CodingSequence cds = null;
@@ -489,8 +480,8 @@ public class Gff3Service {
 					cds.setName(attributes.get("Name"));
 				}
 
-				cds.setDataProvider(organizationService.getByAbbr(dataProvider.sourceOrganization).getEntity());
-				cds.setTaxon(ncbiTaxonTermService.getByCurie(dataProvider.canonicalTaxonCurie).getEntity());
+				cds.setDataProvider(organizationService.getByAbbr(species.getDataProvider().getAbbreviation()).getEntity());
+				cds.setTaxon(ncbiTaxonTermService.getByCurie(species.getTaxon().getCurie()).getEntity());
 
 				cds = cdsDAO.persist(cds);
 				entityIdsAdded.add(cds.getId());
@@ -510,7 +501,7 @@ public class Gff3Service {
 			if (cds != null && assemblyId != null) {
 				try {
 					CodingSequenceGenomicLocationAssociation existingLocation = locationAssocMap.get(cds.getId());
-					CodingSequenceGenomicLocationAssociation cdsLocation = gff3DtoValidator.validateCdsLocation(gffEntry, cds, assemblyId, dataProvider, existingLocation);
+					CodingSequenceGenomicLocationAssociation cdsLocation = gff3DtoValidator.validateCdsLocation(gffEntry, cds, assemblyId, species, existingLocation);
 					if (cdsLocation != null) {
 						locationIdsAdded.add(cdsLocation.getId());
 					}
@@ -569,7 +560,7 @@ public class Gff3Service {
 			List<Long> entityIdsAdded,
 			List<Long> locationIdsAdded,
 			List<Long> associationIdsAdded,
-			BackendBulkDataProvider dataProvider,
+			Species species,
 			String assemblyId,
 			Map<String, String> geneIdCurieMap,
 			BulkLoadFileHistory history,
@@ -654,8 +645,8 @@ public class Gff3Service {
 					transcript.setTranscriptId(null);
 				}
 
-				transcript.setDataProvider(organizationService.getByAbbr(dataProvider.sourceOrganization).getEntity());
-				transcript.setTaxon(ncbiTaxonTermService.getByCurie(dataProvider.canonicalTaxonCurie).getEntity());
+				transcript.setDataProvider(organizationService.getByAbbr(species.getDataProvider().getAbbreviation()).getEntity());
+				transcript.setTaxon(ncbiTaxonTermService.getByCurie(species.getTaxon().getCurie()).getEntity());
 
 				transcript = transcriptDAO.persist(transcript);
 				transcriptCache.put(attributes.get("ID"), transcript);
@@ -676,7 +667,7 @@ public class Gff3Service {
 			if (transcript != null && assemblyId != null) {
 				try {
 					TranscriptGenomicLocationAssociation existingLocation = locationAssocMap.get(transcript.getId());
-					TranscriptGenomicLocationAssociation transcriptLocation = gff3DtoValidator.validateTranscriptLocation(gffEntry, transcript, assemblyId, dataProvider, existingLocation);
+					TranscriptGenomicLocationAssociation transcriptLocation = gff3DtoValidator.validateTranscriptLocation(gffEntry, transcript, assemblyId, species, existingLocation);
 					if (transcriptLocation != null) {
 						locationIdsAdded.add(transcriptLocation.getId());
 					}
@@ -725,21 +716,14 @@ public class Gff3Service {
 		}
 	}
 
-	public Map<String, String> getGeneIdCurieMap(List<Gff3DTO> gffData, BackendBulkDataProvider dataProvider) {
+	public Map<String, String> getGeneIdCurieMap(List<Gff3DTO> gffData, Species species) {
 		Map<String, String> geneIdCurieMap = new HashMap<>();
 
 		for (Gff3DTO gffEntry : gffData) {
 			if (Gff3Constants.GENE_TYPES.contains(gffEntry.getType())) {
-				Map<String, String> attributes = Gff3AttributesHelper.getAttributes(gffEntry, dataProvider);
+				Map<String, String> attributes = Gff3AttributesHelper.getAttributes(gffEntry, species);
 				if (attributes.containsKey("gene_id") && attributes.containsKey("ID")) {
 					geneIdCurieMap.put(attributes.get("ID"), attributes.get("gene_id"));
-				} else if (attributes.containsKey("ID")) {
-					// SCRUM-6205: RefSeq genes have no gene_id; map the gene's ID (e.g. gene-rpl24)
-					// to the MOD curie from Dbxref so a transcript's Parent resolves to the gene.
-					String dbxrefCurie = Gff3AttributesHelper.getModCurieFromDbxref(attributes, dataProvider);
-					if (dbxrefCurie != null) {
-						geneIdCurieMap.put(attributes.get("ID"), dbxrefCurie);
-					}
 				}
 			}
 		}

--- a/src/main/java/org/alliancegenome/curation_api/services/HTPExpressionDatasetAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/HTPExpressionDatasetAnnotationService.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.HTPExpressionDatasetAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.HTPExpressionDatasetAnnotation;
@@ -33,13 +33,13 @@ public class HTPExpressionDatasetAnnotationService extends BaseEntityCrudService
 	}
 
 	@Override
-	public ObjectResponse<HTPExpressionDatasetAnnotation> upsert(HTPExpressionDatasetAnnotationFmsDTO htpExpressionDatasetAnnotationData, BackendBulkDataProvider backendBulkDataProvider) throws ValidationException {
-		return htpExpressionDatasetAnnotationFmsDtoValidator.validateHTPExpressionDatasetAnnotationFmsDTO(htpExpressionDatasetAnnotationData, backendBulkDataProvider);
+	public ObjectResponse<HTPExpressionDatasetAnnotation> upsert(HTPExpressionDatasetAnnotationFmsDTO htpExpressionDatasetAnnotationData, Species species) throws ValidationException {
+		return htpExpressionDatasetAnnotationFmsDtoValidator.validateHTPExpressionDatasetAnnotationFmsDTO(htpExpressionDatasetAnnotationData, species);
 	}
 
-	public List<Long> getAnnotationIdsByDataProvider(String dataProvider) {
+	public List<Long> getAnnotationIdsByDataProvider(String species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider);
+		params.put(EntityFieldConstants.DATA_PROVIDER, species);
 		List<Long> ids = htpExpressionDatasetAnnotationDAO.findIdsByParams(params);
 		ids.removeIf(Objects::isNull);
 		return ids;

--- a/src/main/java/org/alliancegenome/curation_api/services/HTPExpressionDatasetSampleAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/HTPExpressionDatasetSampleAnnotationService.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.HTPExpressionDatasetSampleAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.HTPExpressionDatasetSampleAnnotation;
@@ -34,13 +34,13 @@ public class HTPExpressionDatasetSampleAnnotationService extends BaseEntityCrudS
 	}
 	@Override
 	@Transactional
-	public ObjectResponse<HTPExpressionDatasetSampleAnnotation> upsert(HTPExpressionDatasetSampleAnnotationFmsDTO htpExpressionDatasetSampleAnnotationData, BackendBulkDataProvider backendBulkDataProvider) throws ValidationException {
-		return htpExpressionDatasetSampleAnnotationFmsDtoValidator.validateHTPExpressionDatasetSampleAnnotationFmsDTO(htpExpressionDatasetSampleAnnotationData, backendBulkDataProvider);
+	public ObjectResponse<HTPExpressionDatasetSampleAnnotation> upsert(HTPExpressionDatasetSampleAnnotationFmsDTO htpExpressionDatasetSampleAnnotationData, Species species) throws ValidationException {
+		return htpExpressionDatasetSampleAnnotationFmsDtoValidator.validateHTPExpressionDatasetSampleAnnotationFmsDTO(htpExpressionDatasetSampleAnnotationData, species);
 	}
 
-	public List<Long> getAnnotationIdsByDataProvider(String dataProvider) {
+	public List<Long> getAnnotationIdsByDataProvider(String species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider);
+		params.put(EntityFieldConstants.DATA_PROVIDER, species);
 		List<Long> ids = htpExpressionDatasetSampleAnnotationDAO.findIdsByParams(params);
 		ids.removeIf(Objects::isNull);
 		return ids;

--- a/src/main/java/org/alliancegenome/curation_api/services/MoleculeService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/MoleculeService.java
@@ -8,7 +8,7 @@ import org.alliancegenome.curation_api.dao.CrossReferenceDAO;
 import org.alliancegenome.curation_api.dao.MoleculeDAO;
 import org.alliancegenome.curation_api.dao.ResourceDescriptorPageDAO;
 import org.alliancegenome.curation_api.dao.SynonymDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
@@ -64,7 +64,7 @@ public class MoleculeService extends BaseEntityCrudService<Molecule, MoleculeDAO
 
 	@Override
 	@Transactional
-	public ObjectResponse<Molecule> upsert(MoleculeFmsDTO dto, BackendBulkDataProvider backendBulkDataProvider) throws ValidationException {
+	public ObjectResponse<Molecule> upsert(MoleculeFmsDTO dto, Species species) throws ValidationException {
 		log.debug("processUpdate Molecule: ");
 
 		if (StringUtils.isBlank(dto.getId())) {

--- a/src/main/java/org/alliancegenome/curation_api/services/PhenotypeAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/PhenotypeAnnotationService.java
@@ -14,7 +14,7 @@ import org.alliancegenome.curation_api.dao.GenePhenotypeAnnotationDAO;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.PhenotypeAnnotationDAO;
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.AGMPhenotypeAnnotation;
@@ -81,30 +81,30 @@ public class PhenotypeAnnotationService extends BaseAnnotationCrudService<Phenot
 		return getAllReferencedConditionRelationIds(phenotypeAnnotationDAO);
 	}
 
-	public List<Long> getAnnotationIdsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getAnnotationIdsBySpecies(Species species) {
 		List<Long> existingPhenotypeAnnotationIds = new ArrayList<>();
-		existingPhenotypeAnnotationIds.addAll(getAnnotationIdsByDataProvider(agmPhenotypeAnnotationDAO, dataProvider));
-		existingPhenotypeAnnotationIds.addAll(getAnnotationIdsByDataProvider(genePhenotypeAnnotationDAO, dataProvider));
-		existingPhenotypeAnnotationIds.addAll(getAnnotationIdsByDataProvider(allelePhenotypeAnnotationDAO, dataProvider));
+		existingPhenotypeAnnotationIds.addAll(getAnnotationIdsBySpecies(agmPhenotypeAnnotationDAO, species));
+		existingPhenotypeAnnotationIds.addAll(getAnnotationIdsBySpecies(genePhenotypeAnnotationDAO, species));
+		existingPhenotypeAnnotationIds.addAll(getAnnotationIdsBySpecies(allelePhenotypeAnnotationDAO, species));
 		return existingPhenotypeAnnotationIds;
 	}
 
-	protected <D extends BaseSQLDAO<?>> List<Long> getAnnotationIdsByDataProvider(D dao, BackendBulkDataProvider dataProvider) {
+	protected <D extends BaseSQLDAO<?>> List<Long> getAnnotationIdsBySpecies(D dao, Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put(EntityFieldConstants.DATA_PROVIDER, species.getDataProvider().getAbbreviation());
 
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.PA_SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
+		if (StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD") || StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB")) {
+			params.put(EntityFieldConstants.PA_SUBJECT_TAXON, species.getTaxon().getCurie());
 		}
 
 		List<Long> annotationIds = dao.findIdsByParams(params);
 		return annotationIds;
 	}
 
-	public void preloadUniqueIds(BackendBulkDataProvider dataProvider) {
-		existingUniqueIds = phenotypeAnnotationDAO.findUniqueIdsByDataProvider(dataProvider.sourceOrganization);
-		Map<String, Long> inferredGeneIds = phenotypeAnnotationDAO.findInferredGeneIdsByDataProvider(dataProvider.sourceOrganization);
-		Map<String, Long> inferredAlleleIds = phenotypeAnnotationDAO.findInferredAlleleIdsByDataProvider(dataProvider.sourceOrganization);
+	public void preloadUniqueIds(Species species) {
+		existingUniqueIds = phenotypeAnnotationDAO.findUniqueIdsByDataProvider(species.getDataProvider().getAbbreviation());
+		Map<String, Long> inferredGeneIds = phenotypeAnnotationDAO.findInferredGeneIdsByDataProvider(species.getDataProvider().getAbbreviation());
+		Map<String, Long> inferredAlleleIds = phenotypeAnnotationDAO.findInferredAlleleIdsByDataProvider(species.getDataProvider().getAbbreviation());
 		genePhenotypeAnnotationFmsDtoValidator.setExistingUniqueIds(existingUniqueIds);
 		allelePhenotypeAnnotationFmsDtoValidator.setExistingUniqueIds(existingUniqueIds);
 		allelePhenotypeAnnotationFmsDtoValidator.setInferredGeneIds(inferredGeneIds);
@@ -121,7 +121,7 @@ public class PhenotypeAnnotationService extends BaseAnnotationCrudService<Phenot
 	}
 
 	@Transactional
-	public Long upsertPrimaryAnnotation(PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public Long upsertPrimaryAnnotation(PhenotypeFmsDTO dto, Species species) throws ValidationException {
 		if (StringUtils.isBlank(dto.getObjectId())) {
 			throw new ObjectValidationException(dto, "objectId - " + ValidationConstants.REQUIRED_MESSAGE);
 		}
@@ -150,13 +150,13 @@ public class PhenotypeAnnotationService extends BaseAnnotationCrudService<Phenot
 
 		Long annotationId;
 		if (phenotypeAnnotationSubject instanceof AffectedGenomicModel) {
-			AGMPhenotypeAnnotation annotation = agmPhenotypeAnnotationService.upsertPrimaryAnnotation((AffectedGenomicModel) phenotypeAnnotationSubject, dto, dataProvider);
+			AGMPhenotypeAnnotation annotation = agmPhenotypeAnnotationService.upsertPrimaryAnnotation((AffectedGenomicModel) phenotypeAnnotationSubject, dto, species);
 			annotationId = annotation.getId();
 		} else if (phenotypeAnnotationSubject instanceof Allele) {
-			AllelePhenotypeAnnotation annotation = allelePhenotypeAnnotationService.upsertPrimaryAnnotation((Allele) phenotypeAnnotationSubject, dto, dataProvider);
+			AllelePhenotypeAnnotation annotation = allelePhenotypeAnnotationService.upsertPrimaryAnnotation((Allele) phenotypeAnnotationSubject, dto, species);
 			annotationId = annotation.getId();
 		} else if (phenotypeAnnotationSubject instanceof Gene) {
-			GenePhenotypeAnnotation annotation = genePhenotypeAnnotationService.upsertPrimaryAnnotation((Gene) phenotypeAnnotationSubject, dto, dataProvider);
+			GenePhenotypeAnnotation annotation = genePhenotypeAnnotationService.upsertPrimaryAnnotation((Gene) phenotypeAnnotationSubject, dto, species);
 			annotationId = annotation.getId();
 		} else {
 			throw new ObjectValidationException(dto, "objectId - " + ValidationConstants.INVALID_TYPE_MESSAGE + " (" + dto.getObjectId() + ")");
@@ -186,7 +186,7 @@ public class PhenotypeAnnotationService extends BaseAnnotationCrudService<Phenot
 		return AnnotationUniqueIdHelper.getPhenotypeAnnotationUniqueId(dto, subjectIdentifier, refString);
 	}
 
-	public void addInferredOrAssertedEntities(PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider, Set<Long> idsAdded) throws ValidationException {
+	public void addInferredOrAssertedEntities(PhenotypeFmsDTO dto, Species species, Set<Long> idsAdded) throws ValidationException {
 		for (String primaryGeneticEntityCurie : dto.getPrimaryGeneticEntityIds()) {
 			GenomicEntity primaryAnnotationSubject = genomicEntityService.findByIdentifierString(primaryGeneticEntityCurie);
 			if (primaryAnnotationSubject == null) {
@@ -194,9 +194,9 @@ public class PhenotypeAnnotationService extends BaseAnnotationCrudService<Phenot
 			}
 
 			if (primaryAnnotationSubject instanceof AffectedGenomicModel) {
-				agmPhenotypeAnnotationService.addInferredOrAssertedEntities((AffectedGenomicModel) primaryAnnotationSubject, dto, dataProvider, idsAdded);
+				agmPhenotypeAnnotationService.addInferredOrAssertedEntities((AffectedGenomicModel) primaryAnnotationSubject, dto, species, idsAdded);
 			} else if (primaryAnnotationSubject instanceof Allele) {
-				allelePhenotypeAnnotationService.addInferredOrAssertedEntities((Allele) primaryAnnotationSubject, dto, dataProvider, idsAdded);
+				allelePhenotypeAnnotationService.addInferredOrAssertedEntities((Allele) primaryAnnotationSubject, dto, species, idsAdded);
 			} else {
 				throw new ObjectValidationException(dto, "primaryGeneticEntityIds - " + ValidationConstants.INVALID_TYPE_MESSAGE + " (" + primaryGeneticEntityCurie + ")");
 			}

--- a/src/main/java/org/alliancegenome/curation_api/services/PredictedVariantConsequenceService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/PredictedVariantConsequenceService.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PredictedVariantConsequenceDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.Person;
@@ -40,22 +40,22 @@ public class PredictedVariantConsequenceService extends BaseEntityCrudService<Pr
 		setSQLDao(predictedVariantConsequenceDAO);
 	}
 
-	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getIdsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put("variantTranscript." + EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD")) {
-			params.put("variantTranscript." + EntityFieldConstants.TAXON, dataProvider.canonicalTaxonCurie);
+		params.put("variantTranscript." + EntityFieldConstants.DATA_PROVIDER, species.getDataProvider().getAbbreviation());
+		if (StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD")) {
+			params.put("variantTranscript." + EntityFieldConstants.TAXON, species.getTaxon().getCurie());
 		}
 		List<Long> ids = predictedVariantConsequenceDAO.findIdsByParams(params);
 		ids.removeIf(Objects::isNull);
 		return ids;
 	}
 
-	public List<Long> getGeneLevelIdsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getGeneLevelIdsByDataProvider(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put("variantTranscript." + EntityFieldConstants.DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD")) {
-			params.put("variantTranscript." + EntityFieldConstants.TAXON, dataProvider.canonicalTaxonCurie);
+		params.put("variantTranscript." + EntityFieldConstants.DATA_PROVIDER, species.getDataProvider().getAbbreviation());
+		if (StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD")) {
+			params.put("variantTranscript." + EntityFieldConstants.TAXON, species.getTaxon().getCurie());
 		}
 		params.put("geneLevelConsequence", true);
 		List<Long> ids = predictedVariantConsequenceDAO.findIdsByParams(params);
@@ -65,8 +65,8 @@ public class PredictedVariantConsequenceService extends BaseEntityCrudService<Pr
 
 	@Override
 	@Transactional
-	public ObjectResponse<PredictedVariantConsequence> upsert(VepTxtDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return vepTranscriptFmsDtoValidator.validateTranscriptLevelConsequence(dto, dataProvider);
+	public ObjectResponse<PredictedVariantConsequence> upsert(VepTxtDTO dto, Species species) throws ValidationException {
+		return vepTranscriptFmsDtoValidator.validateTranscriptLevelConsequence(dto, species);
 	}
 
 	@Transactional

--- a/src/main/java/org/alliancegenome/curation_api/services/SequenceTargetingReagentService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/SequenceTargetingReagentService.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.SequenceTargetingReagentDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
@@ -43,8 +43,8 @@ public class SequenceTargetingReagentService extends SubmittedObjectCrudService<
 
 	@Override
 	@Transactional
-	public ObjectResponse<SequenceTargetingReagent> upsert(SequenceTargetingReagentFmsDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return strDtoValidator.validateStrFmsDTO(dto, dataProvider);
+	public ObjectResponse<SequenceTargetingReagent> upsert(SequenceTargetingReagentFmsDTO dto, Species species) throws ValidationException {
+		return strDtoValidator.validateStrFmsDTO(dto, species);
 	}
 
 	@Override
@@ -92,9 +92,9 @@ public class SequenceTargetingReagentService extends SubmittedObjectCrudService<
 		return null;
 	}
 
-	public List<Long> getIdsByDataProvider(String dataProvider) {
+	public List<Long> getIdsByDataProvider(String species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider);
+		params.put(EntityFieldConstants.DATA_PROVIDER, species);
 		List<Long> ids = strDAO.findIdsByParams(params);
 		ids.removeIf(Objects::isNull);
 		return ids;

--- a/src/main/java/org/alliancegenome/curation_api/services/SpeciesService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/SpeciesService.java
@@ -1,7 +1,7 @@
 package org.alliancegenome.curation_api.services;
 
+import java.util.Date;
 import java.util.HashMap;
-import java.util.Map;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.SpeciesDAO;
@@ -11,6 +11,7 @@ import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.base.BaseEntityCrudService;
 import org.alliancegenome.curation_api.services.validation.SpeciesValidator;
 
+import io.quarkus.logging.Log;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -22,21 +23,14 @@ public class SpeciesService extends BaseEntityCrudService<Species, SpeciesDAO> {
 	@Inject SpeciesDAO speciesDAO;
 	@Inject SpeciesValidator speciesValidator;
 
+	Date speciesRequest;
+	HashMap<String, Species> displayNameCacheMap = new HashMap<>();
+	HashMap<String, Species> taxonCurieCacheMap = new HashMap<>();
+
 	@Override
 	@PostConstruct
 	protected void init() {
 		setSQLDao(speciesDAO);
-	}
-
-	/**
-	 * Returns the Species curated for the given taxon curie (e.g. "NCBITaxon:6239"),
-	 * or null if none exists. Taxon -> Species is one-to-one, so at most one match.
-	 */
-	public Species getByTaxonCurie(String taxonCurie) {
-		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.TAXON, taxonCurie);
-		SearchResponse<Species> resp = speciesDAO.findByParams(params);
-		return resp == null ? null : resp.getSingleResult();
 	}
 
 	@Override
@@ -51,5 +45,51 @@ public class SpeciesService extends BaseEntityCrudService<Species, SpeciesDAO> {
 	public ObjectResponse<Species> create(Species uiEntity) {
 		Species dbEntity = speciesValidator.validateSpeciesCreate(uiEntity);
 		return new ObjectResponse<>(speciesDAO.persist(dbEntity));
+	}
+
+	public Species getByDisplayName(String displayName) {
+		if (displayName == null) {
+			return null;
+		}
+
+		if (speciesRequest != null) {
+			if (displayNameCacheMap.containsKey(displayName)) {
+				return displayNameCacheMap.get(displayName);
+			}
+		} else {
+			speciesRequest = new Date();
+		}
+
+		Log.debug("Species not cached, caching species: (" + displayName + ")");
+		SearchResponse<Species> response = speciesDAO.findByField("displayName", displayName);
+		Species species = null;
+		if (response != null) {
+			species = response.getSingleResult();
+		}
+		displayNameCacheMap.put(displayName, species);
+		return species;
+	}
+
+	public Species getByTaxonCurie(String taxonCurie) {
+		if (taxonCurie == null) {
+			return null;
+		}
+
+		if (speciesRequest != null) {
+			if (taxonCurieCacheMap.containsKey(taxonCurie)) {
+				return taxonCurieCacheMap.get(taxonCurie);
+			}
+		} else {
+			speciesRequest = new Date();
+		}
+
+		Log.debug("Species not cached by taxon, caching species: (" + taxonCurie + ")");
+		SearchResponse<Species> response = speciesDAO.findByField(EntityFieldConstants.TAXON, taxonCurie);
+		Species species = null;
+		if (response != null) {
+			species = response.getSingleResult();
+		}
+		taxonCurieCacheMap.put(taxonCurie, species);
+		return species;
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/TranscriptService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/TranscriptService.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.alliancegenome.curation_api.dao.TranscriptDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.Note;
 import org.alliancegenome.curation_api.model.entities.Transcript;
@@ -35,14 +35,14 @@ public class TranscriptService extends BaseEntityCrudService<Transcript, Transcr
 		setSQLDao(transcriptDAO);
 	}
 
-	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
-		return transcriptDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	public List<Long> getIdsBySpecies(Species species) {
+		String taxon = needsTaxonFilter(species) ? species.getTaxon().getCurie() : null;
+		return transcriptDAO.findIdsByDataProvider(species.getDataProvider().getAbbreviation(), taxon);
 	}
 
-	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
-		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
-			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
+	private boolean needsTaxonFilter(Species species) {
+		return StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD")
+			|| StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB");
 	}
 
 	public ObjectResponse<Transcript> deleteByIdentifier(String identifierString) {

--- a/src/main/java/org/alliancegenome/curation_api/services/VariantService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/VariantService.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.VariantDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.Note;
@@ -59,8 +59,8 @@ public class VariantService extends SubmittedObjectCrudService<Variant, VariantD
 	}
 
 	@Override
-	public ObjectResponse<Variant> upsert(VariantDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return variantDtoValidator.validateVariantDTO(dto, dataProvider);
+	public ObjectResponse<Variant> upsert(VariantDTO dto, Species species) throws ValidationException {
+		return variantDtoValidator.validateVariantDTO(dto, species);
 	}
 
 	@Override
@@ -109,9 +109,9 @@ public class VariantService extends SubmittedObjectCrudService<Variant, VariantD
 		return null;
 	}
 
-	public List<Long> getIdsByDataProvider(String dataProvider) {
+	public List<Long> getIdsByDataProvider(String species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.DATA_PROVIDER, dataProvider);
+		params.put(EntityFieldConstants.DATA_PROVIDER, species);
 		List<Long> ids = variantDAO.findIdsByParams(params);
 		ids.removeIf(Objects::isNull);
 		return ids;

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/AgmAgmAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/AgmAgmAssociationService.java
@@ -12,7 +12,7 @@ import org.alliancegenome.curation_api.dao.NoteDAO;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.SequenceTargetingReagentDAO;
 import org.alliancegenome.curation_api.dao.associations.AgmAgmAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
@@ -55,13 +55,13 @@ public class AgmAgmAssociationService extends BaseAssociationDTOCrudService<AgmA
 
 	@Override
 	@Transactional
-	public ObjectResponse<AgmAgmAssociation> upsert(AgmAgmAssociationDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return agmAgmAssociationDtoValidator.validateAgmAgmAssociationDTO(dto, dataProvider);
+	public ObjectResponse<AgmAgmAssociation> upsert(AgmAgmAssociationDTO dto, Species species) throws ValidationException {
+		return agmAgmAssociationDtoValidator.validateAgmAgmAssociationDTO(dto, species);
 	}
 
-	public List<Long> getAssociationsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getAssociationsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.AGM_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put(EntityFieldConstants.AGM_ASSOCIATION_SUBJECT_DATA_PROVIDER, species.getDataProvider().getAbbreviation());
 		List<Long> associationIds = agmAgmAssociationDAO.findIdsByParams(params);
 		associationIds.removeIf(Objects::isNull);
 

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/AgmAlleleAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/AgmAlleleAssociationService.java
@@ -11,7 +11,7 @@ import org.alliancegenome.curation_api.dao.AlleleDAO;
 import org.alliancegenome.curation_api.dao.NoteDAO;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.AgmAlleleAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.associations.AgmAlleleAssociation;
@@ -46,18 +46,18 @@ public class AgmAlleleAssociationService extends BaseAssociationDTOCrudService<A
 
 	@Override
 	@Transactional
-	public ObjectResponse<AgmAlleleAssociation> upsert(AgmAlleleAssociationDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return agmAlleleAssociationDtoValidator.validateAgmAlleleAssociationDTO(dto, dataProvider);
+	public ObjectResponse<AgmAlleleAssociation> upsert(AgmAlleleAssociationDTO dto, Species species) throws ValidationException {
+		return agmAlleleAssociationDtoValidator.validateAgmAlleleAssociationDTO(dto, species);
 	}
 
-	public void preloadAssociationKeys(BackendBulkDataProvider dataProvider) {
-		Map<String, Long>[] keys = agmAlleleAssociationDAO.findAssociationKeysByDataProvider(dataProvider.sourceOrganization);
+	public void preloadAssociationKeys(Species species) {
+		Map<String, Long>[] keys = agmAlleleAssociationDAO.findAssociationKeysByDataProvider(species.getDataProvider().getAbbreviation());
 		agmAlleleAssociationDtoValidator.preloadAssociationKeys(keys[0], keys[1]);
 	}
 
-	public List<Long> getAssociationsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getAssociationsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.AGM_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put(EntityFieldConstants.AGM_ASSOCIATION_SUBJECT_DATA_PROVIDER, species.getDataProvider().getAbbreviation());
 		List<Long> associationIds = agmAlleleAssociationDAO.findIdsByParams(params);
 		associationIds.removeIf(Objects::isNull);
 		return associationIds;

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/AgmStrAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/AgmStrAssociationService.java
@@ -12,7 +12,7 @@ import org.alliancegenome.curation_api.dao.NoteDAO;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.SequenceTargetingReagentDAO;
 import org.alliancegenome.curation_api.dao.associations.AgmSequenceTargetingReagentAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
@@ -49,13 +49,13 @@ public class AgmStrAssociationService extends BaseAssociationDTOCrudService<AgmS
 
 	@Override
 	@Transactional
-	public ObjectResponse<AgmSequenceTargetingReagentAssociation> upsert(AgmSequenceTargetingReagentAssociationDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return agmStrAssociationDtoValidator.validateAgmSequenceTargetingReagentAssociationDTO(dto, dataProvider);
+	public ObjectResponse<AgmSequenceTargetingReagentAssociation> upsert(AgmSequenceTargetingReagentAssociationDTO dto, Species species) throws ValidationException {
+		return agmStrAssociationDtoValidator.validateAgmSequenceTargetingReagentAssociationDTO(dto, species);
 	}
 
-	public List<Long> getAssociationsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getAssociationsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.AGM_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put(EntityFieldConstants.AGM_ASSOCIATION_SUBJECT_DATA_PROVIDER, species.getDataProvider().getAbbreviation());
 		List<Long> associationIds = agmStrAssociationDAO.findIdsByParams(params);
 		associationIds.removeIf(Objects::isNull);
 

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/AlleleConstructAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/AlleleConstructAssociationService.java
@@ -11,7 +11,7 @@ import org.alliancegenome.curation_api.dao.AlleleDAO;
 import org.alliancegenome.curation_api.dao.NoteDAO;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.AlleleConstructAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
@@ -72,13 +72,13 @@ public class AlleleConstructAssociationService extends BaseAssociationDTOCrudSer
 
 	@Override
 	@Transactional
-	public ObjectResponse<AlleleConstructAssociation> upsert(AlleleConstructAssociationDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return alleleConstructAssociationDtoValidator.validateAlleleConstructAssociationDTO(dto, dataProvider);
+	public ObjectResponse<AlleleConstructAssociation> upsert(AlleleConstructAssociationDTO dto, Species species) throws ValidationException {
+		return alleleConstructAssociationDtoValidator.validateAlleleConstructAssociationDTO(dto, species);
 	}
 
-	public List<Long> getAssociationsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getAssociationsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.ALLELE_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put(EntityFieldConstants.ALLELE_ASSOCIATION_SUBJECT_DATA_PROVIDER, species.getDataProvider().getAbbreviation());
 		List<Long> associationIds = alleleConstructAssociationDAO.findIdsByParams(params);
 		associationIds.removeIf(Objects::isNull);
 

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/AlleleGeneAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/AlleleGeneAssociationService.java
@@ -12,7 +12,7 @@ import org.alliancegenome.curation_api.dao.GeneDAO;
 import org.alliancegenome.curation_api.dao.NoteDAO;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.AlleleGeneAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
@@ -67,18 +67,18 @@ public class AlleleGeneAssociationService extends BaseAssociationDTOCrudService<
 
 	@Override
 	@Transactional
-	public ObjectResponse<AlleleGeneAssociation> upsert(AlleleGeneAssociationDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return alleleGeneAssociationDtoValidator.validateAlleleGeneAssociationDTO(dto, dataProvider);
+	public ObjectResponse<AlleleGeneAssociation> upsert(AlleleGeneAssociationDTO dto, Species species) throws ValidationException {
+		return alleleGeneAssociationDtoValidator.validateAlleleGeneAssociationDTO(dto, species);
 	}
 	
 	@Transactional
-	public ObjectResponse<AlleleGeneAssociation> upsert(AlleleGeneAssociationDTO dto, BackendBulkDataProvider dataProvider, Map<Long, Long> isAlleleOfAssociationMap, boolean isFullLoad) throws ValidationException {
-		return alleleGeneAssociationDtoValidator.validateAlleleGeneAssociationDTO(dto, dataProvider, isAlleleOfAssociationMap, isFullLoad);
+	public ObjectResponse<AlleleGeneAssociation> upsert(AlleleGeneAssociationDTO dto, Species species, Map<Long, Long> isAlleleOfAssociationMap, boolean isFullLoad) throws ValidationException {
+		return alleleGeneAssociationDtoValidator.validateAlleleGeneAssociationDTO(dto, species, isAlleleOfAssociationMap, isFullLoad);
 	}
 
-	public List<Long> getAssociationsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getAssociationsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.ALLELE_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put(EntityFieldConstants.ALLELE_ASSOCIATION_SUBJECT_DATA_PROVIDER, species.getDataProvider().getAbbreviation());
 		List<Long> associationIds = alleleGeneAssociationDAO.findIdsByParams(params);
 		associationIds.removeIf(Objects::isNull);
 

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/AlleleVariantAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/AlleleVariantAssociationService.java
@@ -14,7 +14,7 @@ import org.alliancegenome.curation_api.dao.NoteDAO;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.VariantDAO;
 import org.alliancegenome.curation_api.dao.associations.AlleleVariantAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.Allele;
 import org.alliancegenome.curation_api.model.entities.Variant;
@@ -69,9 +69,9 @@ public class AlleleVariantAssociationService extends BaseEntityCrudService<Allel
 		return new ObjectResponse<AlleleVariantAssociation>(aga);
 	}
 
-	public List<Long> getAssociationsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getAssociationsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.ALLELE_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put(EntityFieldConstants.ALLELE_ASSOCIATION_SUBJECT_DATA_PROVIDER, species.getDataProvider().getAbbreviation());
 		List<Long> associationIds = alleleVariantAssociationDAO.findIdsByParams(params);
 		associationIds.removeIf(Objects::isNull);
 

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/CodingSequenceGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/CodingSequenceGenomicLocationAssociationService.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.CodingSequenceGenomicLocationAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.CodingSequence;
 import org.alliancegenome.curation_api.model.entities.associations.CodingSequenceGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -35,14 +35,14 @@ public class CodingSequenceGenomicLocationAssociationService extends BaseEntityC
 	}
 
 
-	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
-		return codingSequenceGenomicLocationAssociationDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	public List<Long> getIdsBySpecies(Species species) {
+		String taxon = needsTaxonFilter(species) ? species.getTaxon().getCurie() : null;
+		return codingSequenceGenomicLocationAssociationDAO.findIdsByDataProvider(species.getDataProvider().getAbbreviation(), taxon);
 	}
 
-	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
-		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
-			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
+	private boolean needsTaxonFilter(Species species) {
+		return StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD")
+			|| StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB");
 	}
 
 	public ObjectResponse<CodingSequenceGenomicLocationAssociation> getLocationAssociation(Long codingSequenceId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/ConstructGenomicEntityAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/ConstructGenomicEntityAssociationService.java
@@ -12,7 +12,7 @@ import org.alliancegenome.curation_api.dao.ConstructDAO;
 import org.alliancegenome.curation_api.dao.GenomicEntityDAO;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.ConstructGenomicEntityAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.Construct;
@@ -72,13 +72,13 @@ public class ConstructGenomicEntityAssociationService extends BaseAssociationDTO
 
 	@Override
 	@Transactional
-	public ObjectResponse<ConstructGenomicEntityAssociation> upsert(ConstructGenomicEntityAssociationDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
-		return constructGenomicEntityAssociationDtoValidator.validateConstructGenomicEntityAssociationDTO(dto, dataProvider);
+	public ObjectResponse<ConstructGenomicEntityAssociation> upsert(ConstructGenomicEntityAssociationDTO dto, Species species) throws ValidationException {
+		return constructGenomicEntityAssociationDtoValidator.validateConstructGenomicEntityAssociationDTO(dto, species);
 	}
 
-	public List<Long> getAssociationsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getAssociationsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.CONSTRUCT_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put(EntityFieldConstants.CONSTRUCT_ASSOCIATION_SUBJECT_DATA_PROVIDER, species.getDataProvider().getAbbreviation());
 		List<Long> associationIds = constructGenomicEntityAssociationDAO.findIdsByParams(params);
 		associationIds.removeIf(Objects::isNull);
 

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/CuratedVariantGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/CuratedVariantGenomicLocationAssociationService.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.CuratedVariantGenomicLocationAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.model.entities.Variant;
 import org.alliancegenome.curation_api.model.entities.associations.CuratedVariantGenomicLocationAssociation;
@@ -44,11 +44,11 @@ public class CuratedVariantGenomicLocationAssociationService extends BaseEntityC
 	}
 
 
-	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getIdsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.VARIANT_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD")) {
-			params.put(EntityFieldConstants.VARIANT_ASSOCIATION_SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
+		params.put(EntityFieldConstants.VARIANT_ASSOCIATION_SUBJECT_DATA_PROVIDER, species.getDataProvider().getAbbreviation());
+		if (StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD")) {
+			params.put(EntityFieldConstants.VARIANT_ASSOCIATION_SUBJECT_TAXON, species.getTaxon().getCurie());
 		}
 		List<Long> associationIds = curatedVariantGenomicLocationAssociationDAO.findIdsByParams(params);
 		associationIds.removeIf(Objects::isNull);

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/ExonGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/ExonGenomicLocationAssociationService.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.ExonGenomicLocationAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.Exon;
 import org.alliancegenome.curation_api.model.entities.associations.ExonGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -35,14 +35,14 @@ public class ExonGenomicLocationAssociationService extends BaseEntityCrudService
 	}
 
 
-	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
-		return exonGenomicLocationAssociationDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	public List<Long> getIdsBySpecies(Species species) {
+		String taxon = needsTaxonFilter(species) ? species.getTaxon().getCurie() : null;
+		return exonGenomicLocationAssociationDAO.findIdsByDataProvider(species.getDataProvider().getAbbreviation(), taxon);
 	}
 
-	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
-		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
-			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
+	private boolean needsTaxonFilter(Species species) {
+		return StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD")
+			|| StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB");
 	}
 
 	public ObjectResponse<ExonGenomicLocationAssociation> getLocationAssociation(Long exonId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/GeneGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/GeneGenomicLocationAssociationService.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.GeneGenomicLocationAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.associations.GeneGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -37,11 +37,11 @@ public class GeneGenomicLocationAssociationService extends BaseEntityCrudService
 	}
 
 
-	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getIdsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.GENE_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.GENE_ASSOCIATION_SUBJECT_TAXON, dataProvider.canonicalTaxonCurie);
+		params.put(EntityFieldConstants.GENE_ASSOCIATION_SUBJECT_DATA_PROVIDER, species.getDataProvider().getAbbreviation());
+		if (StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD") || StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB")) {
+			params.put(EntityFieldConstants.GENE_ASSOCIATION_SUBJECT_TAXON, species.getTaxon().getCurie());
 		}
 		List<Long> associationIds = geneGenomicLocationAssociationDAO.findIdsByParams(params);
 		associationIds.removeIf(Objects::isNull);

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/SequenceTargetingReagentGeneAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/SequenceTargetingReagentGeneAssociationService.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.associations.SequenceTargetingReagentGeneAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.SequenceTargetingReagent;
@@ -40,10 +40,10 @@ public class SequenceTargetingReagentGeneAssociationService extends BaseEntityCr
 	}
 
 	@Transactional
-	public List<Long> loadGeneAssociations(SequenceTargetingReagentFmsDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public List<Long> loadGeneAssociations(SequenceTargetingReagentFmsDTO dto) throws ValidationException {
 
 		List<SequenceTargetingReagentGeneAssociation> associations = sequenceTargetingReagentGeneAssociationFmsDTOValidator
-				.validateSQTRGeneAssociationFmsDTO(dto, dataProvider);
+				.validateSQTRGeneAssociationFmsDTO(dto);
 
 		for (SequenceTargetingReagentGeneAssociation association : associations) {
 			if (association != null) {
@@ -95,9 +95,9 @@ public class SequenceTargetingReagentGeneAssociationService extends BaseEntityCr
 
 	}
 
-	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getIdsBySpecies(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.SQTR_ASSOCIATION_SUBJECT_DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put(EntityFieldConstants.SQTR_ASSOCIATION_SUBJECT_DATA_PROVIDER, species.getDataProvider().getAbbreviation());
 		List<Long> ids = sequenceTargetingReagentGeneAssociationDAO.findIdsByParams(params);
 		ids.removeIf(Objects::isNull);
 		return ids;

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptCodingSequenceAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptCodingSequenceAssociationService.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.TranscriptCodingSequenceAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.CodingSequence;
 import org.alliancegenome.curation_api.model.entities.Transcript;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptCodingSequenceAssociation;
@@ -37,14 +37,14 @@ public class TranscriptCodingSequenceAssociationService extends BaseEntityCrudSe
 	}
 
 
-	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
-		return transcriptCodingSequenceAssociationDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	public List<Long> getIdsBySpecies(Species species) {
+		String taxon = needsTaxonFilter(species) ? species.getTaxon().getCurie() : null;
+		return transcriptCodingSequenceAssociationDAO.findIdsByDataProvider(species.getDataProvider().getAbbreviation(), taxon);
 	}
 
-	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
-		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
-			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
+	private boolean needsTaxonFilter(Species species) {
+		return StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD")
+			|| StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB");
 	}
 
 	public ObjectResponse<TranscriptCodingSequenceAssociation> getLocationAssociation(Long transcriptId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptExonAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptExonAssociationService.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.TranscriptExonAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.Exon;
 import org.alliancegenome.curation_api.model.entities.Transcript;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptExonAssociation;
@@ -37,14 +37,14 @@ public class TranscriptExonAssociationService extends BaseEntityCrudService<Tran
 	}
 
 
-	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
-		return transcriptExonAssociationDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	public List<Long> getIdsBySpecies(Species species) {
+		String taxon = needsTaxonFilter(species) ? species.getTaxon().getCurie() : null;
+		return transcriptExonAssociationDAO.findIdsByDataProvider(species.getDataProvider().getAbbreviation(), taxon);
 	}
 
-	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
-		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
-			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
+	private boolean needsTaxonFilter(Species species) {
+		return StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD")
+			|| StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB");
 	}
 
 	public ObjectResponse<TranscriptExonAssociation> getLocationAssociation(Long transcriptId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptGeneAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptGeneAssociationService.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.TranscriptGeneAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.Transcript;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptGeneAssociation;
@@ -37,14 +37,14 @@ public class TranscriptGeneAssociationService extends BaseEntityCrudService<Tran
 	}
 
 
-	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
-		return transcriptGeneAssociationDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	public List<Long> getIdsBySpecies(Species species) {
+		String taxon = needsTaxonFilter(species) ? species.getTaxon().getCurie() : null;
+		return transcriptGeneAssociationDAO.findIdsByDataProvider(species.getDataProvider().getAbbreviation(), taxon);
 	}
 
-	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
-		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
-			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
+	private boolean needsTaxonFilter(Species species) {
+		return StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD")
+			|| StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB");
 	}
 
 	public ObjectResponse<TranscriptGeneAssociation> getLocationAssociation(Long transcriptId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptGenomicLocationAssociationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/associations/TranscriptGenomicLocationAssociationService.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.PersonDAO;
 import org.alliancegenome.curation_api.dao.associations.TranscriptGenomicLocationAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.Transcript;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -37,14 +37,14 @@ public class TranscriptGenomicLocationAssociationService extends BaseEntityCrudS
 	}
 
 
-	public List<Long> getIdsByDataProvider(BackendBulkDataProvider dataProvider) {
-		String taxon = needsTaxonFilter(dataProvider) ? dataProvider.canonicalTaxonCurie : null;
-		return transcriptGenomicLocationAssociationDAO.findIdsByDataProvider(dataProvider.sourceOrganization, taxon);
+	public List<Long> getIdsBySpecies(Species species) {
+		String taxon = needsTaxonFilter(species) ? species.getTaxon().getCurie() : null;
+		return transcriptGenomicLocationAssociationDAO.findIdsByDataProvider(species.getDataProvider().getAbbreviation(), taxon);
 	}
 
-	private boolean needsTaxonFilter(BackendBulkDataProvider dataProvider) {
-		return StringUtils.equals(dataProvider.sourceOrganization, "RGD")
-			|| StringUtils.equals(dataProvider.sourceOrganization, "XB");
+	private boolean needsTaxonFilter(Species species) {
+		return StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD")
+			|| StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB");
 	}
 
 	public ObjectResponse<TranscriptGenomicLocationAssociation> getLocationAssociation(Long transcriptId, Long assemblyComponentId) {

--- a/src/main/java/org/alliancegenome/curation_api/services/base/BaseDTOCrudService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/base/BaseDTOCrudService.java
@@ -1,8 +1,8 @@
 package org.alliancegenome.curation_api.services.base;
 
 import org.alliancegenome.curation_api.dao.base.BaseEntityDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
 import org.alliancegenome.curation_api.model.ingest.dto.base.BaseDTO;
 
@@ -10,6 +10,6 @@ public abstract class BaseDTOCrudService<E extends AuditedObject, T extends Base
 
 	protected abstract void init();
 
-	public abstract E upsert(T dto, BackendBulkDataProvider dataProvider) throws ValidationException;
+	public abstract E upsert(T dto, Species species) throws ValidationException;
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/GenePhenotypeAnnotationXrefHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/GenePhenotypeAnnotationXrefHelper.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.alliancegenome.curation_api.dao.GeneDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.CrossReference;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.ResourceDescriptorPage;
@@ -24,9 +24,9 @@ public class GenePhenotypeAnnotationXrefHelper {
 	@Inject GeneDAO geneDAO;
 	
 	@Transactional
-	public Gene addGenePhenotypeCrossReference(BackendBulkDataProvider dataProvider, Gene gene) {
-	
-		if (Objects.equals("HUMAN", dataProvider.name()) || gene.getIdentifier().startsWith("HGNC:")) {
+	public Gene addGenePhenotypeCrossReference(Species species, Gene gene) {
+
+		if (Objects.equals("HUMAN", species.getDisplayName()) || gene.getIdentifier().startsWith("HGNC:")) {
 			return gene;
 		}
 

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/Gff3AttributesHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/Gff3AttributesHelper.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.alliancegenome.curation_api.constants.Gff3Constants;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.Gff3DTO;
 import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
 import org.apache.commons.collections.CollectionUtils;
@@ -15,7 +15,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 
 public class Gff3AttributesHelper {
 
-	public static Map<String, String> getAttributes(Gff3DTO dto, BackendBulkDataProvider dataProvider) {
+	public static Map<String, String> getAttributes(Gff3DTO dto, Species species) {
 		Map<String, String> attributes = new HashMap<String, String>();
 		if (CollectionUtils.isNotEmpty(dto.getAttributes())) {
 			for (String keyValue : dto.getAttributes()) {
@@ -30,7 +30,7 @@ public class Gff3AttributesHelper {
 		for (String key : List.of("ID", "Parent", "gene_id")) {
 			if (attributes.containsKey(key)) {
 				String idsString = attributes.get(key);
-				if (StringUtils.equals(dataProvider.sourceOrganization, "WB")) {
+				if (StringUtils.equals(species.getDataProvider().getAbbreviation(), "WB")) {
 					// Remove prefixes like Gene: and Transcript: from WB identifiers
 					idsString = idsString.replaceAll("Gene:", "");
 					idsString = idsString.replaceAll("Transcript:", "");
@@ -42,7 +42,7 @@ public class Gff3AttributesHelper {
 				for (String id : idsList) {
 					String[] idParts = id.split(":");
 					if (idParts.length == 1) {
-						id = dataProvider.name() + ':' + idParts[0];
+						id = species.getDisplayName() + ':' + idParts[0];
 					}
 					processedIdList.add(id);
 				}
@@ -52,38 +52,14 @@ public class Gff3AttributesHelper {
 		
 		return attributes;
 	}
-
-	/**
-	 * SCRUM-6205: returns the MOD curie carried in the GFF {@code Dbxref} attribute, i.e. the
-	 * first comma-separated token whose prefix matches the load's data provider
-	 * ({@code dataProvider.name() + ":"}, e.g. {@code ZFIN:}), or null if there is none.
-	 *
-	 * NCBI RefSeq-shaped GFFs (e.g. the ZFIN GRCz12tu file) keep the real MOD curie only in
-	 * {@code Dbxref=GeneID:192301,ZFIN:ZDB-GENE-020419-25}, while {@code ID}/{@code gene_id}
-	 * hold RefSeq-style values that match nothing in our store. This is a provider-scoped
-	 * fallback only — {@code GeneID:}/{@code GenBank:} tokens are never adopted as the curie.
-	 */
-	public static String getModCurieFromDbxref(Map<String, String> attributes, BackendBulkDataProvider dataProvider) {
-		String dbxref = attributes.get("Dbxref");
-		if (StringUtils.isBlank(dbxref)) {
-			return null;
-		}
-		String prefix = dataProvider.name() + ":";
-		for (String token : dbxref.split(",")) {
-			if (token.startsWith(prefix)) {
-				return token;
-			}
-		}
-		return null;
-	}
-
-	public static List<ImmutablePair<Gff3DTO, Map<String, String>>> getExonGffData(List<Gff3DTO> gffData, BackendBulkDataProvider dataProvider) {
+	
+	public static List<ImmutablePair<Gff3DTO, Map<String, String>>> getExonGffData(List<Gff3DTO> gffData, Species species) {
 		List<ImmutablePair<Gff3DTO, Map<String, String>>> retGffData = new ArrayList<>();
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
-		ph.startProcess("GFF Exon pre-processing for " + dataProvider.name(), gffData.size());
+		ph.startProcess("GFF Exon pre-processing for " + species.getDisplayName(), gffData.size());
 		for (Gff3DTO originalGffEntry : gffData) {
 			if (StringUtils.equals(originalGffEntry.getType(), "exon") || StringUtils.equals(originalGffEntry.getType(), "noncoding_exon")) {
-				processGffEntry(originalGffEntry, retGffData, dataProvider);
+				processGffEntry(originalGffEntry, retGffData, species);
 			}
 			ph.progressProcess();
 		}
@@ -91,13 +67,13 @@ public class Gff3AttributesHelper {
 		return retGffData;
 	}
 	
-	public static List<ImmutablePair<Gff3DTO, Map<String, String>>> getCDSGffData(List<Gff3DTO> gffData, BackendBulkDataProvider dataProvider) {
+	public static List<ImmutablePair<Gff3DTO, Map<String, String>>> getCDSGffData(List<Gff3DTO> gffData, Species species) {
 		List<ImmutablePair<Gff3DTO, Map<String, String>>> retGffData = new ArrayList<>();
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
-		ph.startProcess("GFF CDS pre-processing for " + dataProvider.name(), gffData.size());
+		ph.startProcess("GFF CDS pre-processing for " + species.getDisplayName(), gffData.size());
 		for (Gff3DTO originalGffEntry : gffData) {
 			if (StringUtils.equals(originalGffEntry.getType(), "CDS")) {
-				processGffEntry(originalGffEntry, retGffData, dataProvider);
+				processGffEntry(originalGffEntry, retGffData, species);
 			}
 			ph.progressProcess();
 		}
@@ -106,16 +82,16 @@ public class Gff3AttributesHelper {
 	}
 	
 	
-	public static List<ImmutablePair<Gff3DTO, Map<String, String>>> getTranscriptGffData(List<Gff3DTO> gffData, BackendBulkDataProvider dataProvider) {
+	public static List<ImmutablePair<Gff3DTO, Map<String, String>>> getTranscriptGffData(List<Gff3DTO> gffData, Species species) {
 		List<ImmutablePair<Gff3DTO, Map<String, String>>> retGffData = new ArrayList<>();
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
-		ph.startProcess("GFF Transcript pre-processing for " + dataProvider.name(), gffData.size());
+		ph.startProcess("GFF Transcript pre-processing for " + species.getDisplayName(), gffData.size());
 		for (Gff3DTO originalGffEntry : gffData) {
 			if (StringUtils.equals(originalGffEntry.getType(), "lnc_RNA")) {
 				originalGffEntry.setType("lncRNA");
 			}
 			if (Gff3Constants.TRANSCRIPT_TYPES.contains(originalGffEntry.getType())) {
-				processGffEntry(originalGffEntry, retGffData, dataProvider);
+				processGffEntry(originalGffEntry, retGffData, species);
 			}
 			ph.progressProcess();
 		}
@@ -124,13 +100,13 @@ public class Gff3AttributesHelper {
 	}
 	
 	
-	public static List<ImmutablePair<Gff3DTO, Map<String, String>>> getGeneGffData(List<Gff3DTO> gffData, BackendBulkDataProvider dataProvider) {
+	public static List<ImmutablePair<Gff3DTO, Map<String, String>>> getGeneGffData(List<Gff3DTO> gffData, Species species) {
 		List<ImmutablePair<Gff3DTO, Map<String, String>>> retGffData = new ArrayList<>();
 		ProcessDisplayHelper ph = new ProcessDisplayHelper();
-		ph.startProcess("GFF Gene pre-processing for " + dataProvider.name(), gffData.size());
+		ph.startProcess("GFF Gene pre-processing for " + species.getDisplayName(), gffData.size());
 		for (Gff3DTO originalGffEntry : gffData) {
 			if (Gff3Constants.GENE_TYPES.contains(originalGffEntry.getType())) {
-				processGffEntry(originalGffEntry, retGffData, dataProvider);
+				processGffEntry(originalGffEntry, retGffData, species);
 			}
 			ph.progressProcess();
 		}
@@ -138,8 +114,8 @@ public class Gff3AttributesHelper {
 		return retGffData;
 	}
 
-	private static void processGffEntry(Gff3DTO originalGffEntry, List<ImmutablePair<Gff3DTO, Map<String, String>>> retGffData, BackendBulkDataProvider dataProvider) {
-		Map<String, String> attributes = getAttributes(originalGffEntry, dataProvider);
+	private static void processGffEntry(Gff3DTO originalGffEntry, List<ImmutablePair<Gff3DTO, Map<String, String>>> retGffData, Species species) {
+		Map<String, String> attributes = getAttributes(originalGffEntry, species);
 		if (attributes.containsKey("Parent")) {
 			if (attributes.get("Parent").indexOf(",") > -1) {
 				for (String parent : attributes.get("Parent").split(",")) {
@@ -148,7 +124,7 @@ public class Gff3AttributesHelper {
 						attributesCopy.putAll(attributes);
 						String[] parentIdParts = parent.split(":");
 						if (parentIdParts.length == 1) {
-							parent = dataProvider.name() + ':' + parentIdParts[0];
+							parent = species.getDisplayName() + ':' + parentIdParts[0];
 						}
 						attributesCopy.put("Parent", parent);
 						retGffData.add(new ImmutablePair<>(originalGffEntry, attributesCopy));

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/Gff3UniqueIdHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/Gff3UniqueIdHelper.java
@@ -2,7 +2,7 @@ package org.alliancegenome.curation_api.services.helpers;
 
 import java.util.Map;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.ingest.dto.fms.Gff3DTO;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -10,7 +10,7 @@ import jakarta.enterprise.context.RequestScoped;
 @RequestScoped
 public class Gff3UniqueIdHelper {
 
-	public static String getExonOrCodingSequenceUniqueId(Gff3DTO dto, Map<String, String> attributes, BackendBulkDataProvider dataProvider) {
+	public static String getExonOrCodingSequenceUniqueId(Gff3DTO dto, Map<String, String> attributes, Species species) {
 		UniqueIdGeneratorHelper uniqueId = new UniqueIdGeneratorHelper();
 		
 		if (attributes.containsKey("curie")) {

--- a/src/main/java/org/alliancegenome/curation_api/services/orthology/GeneToGeneOrthologyGeneratedService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/orthology/GeneToGeneOrthologyGeneratedService.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.dao.orthology.GeneToGeneOrthologyGeneratedDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.interfaces.crud.BaseUpsertServiceInterface;
 import org.alliancegenome.curation_api.model.entities.orthology.GeneToGeneOrthologyGenerated;
@@ -33,7 +33,7 @@ public class GeneToGeneOrthologyGeneratedService extends BaseEntityCrudService<G
 	}
 
 	@Override
-	public ObjectResponse<GeneToGeneOrthologyGenerated> upsert(OrthologyFmsDTO orthoPair, BackendBulkDataProvider backendBulkDataProvider) throws ValidationException {
+	public ObjectResponse<GeneToGeneOrthologyGenerated> upsert(OrthologyFmsDTO orthoPair, Species species) throws ValidationException {
 		return orthologyFmsDtoValidator.validateOrthologyFmsDTO(orthoPair);
 	}
 
@@ -45,12 +45,12 @@ public class GeneToGeneOrthologyGeneratedService extends BaseEntityCrudService<G
 		return geneToGeneOrthologyGeneratedDAO.findByIds(ids);
 	}
 
-	public List<Long> getAllOrthologyPairIdsBySubjectGeneDataProvider(BackendBulkDataProvider dataProvider) {
+	public List<Long> getAllOrthologyPairIdsBySubjectGeneDataProvider(Species species) {
 		Map<String, Object> params = new HashMap<>();
-		params.put(EntityFieldConstants.SUBJECT_GENE_DATA_PROVIDER, dataProvider.sourceOrganization);
+		params.put(EntityFieldConstants.SUBJECT_GENE_DATA_PROVIDER, species.getDataProvider().getAbbreviation());
 
-		if (StringUtils.equals(dataProvider.sourceOrganization, "RGD") || StringUtils.equals(dataProvider.sourceOrganization, "XB")) {
-			params.put(EntityFieldConstants.SUBJECT_GENE_TAXON, dataProvider.canonicalTaxonCurie);
+		if (StringUtils.equals(species.getDataProvider().getAbbreviation(), "RGD") || StringUtils.equals(species.getDataProvider().getAbbreviation(), "XB")) {
+			params.put(EntityFieldConstants.SUBJECT_GENE_TAXON, species.getTaxon().getCurie());
 		}
 
 		List<Long> annotationIds = geneToGeneOrthologyGeneratedDAO.findIdsByParams(params);

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AGMDiseaseAnnotationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AGMDiseaseAnnotationDTOValidator.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.AGMDiseaseAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.AGMDiseaseAnnotation;
@@ -39,7 +39,7 @@ public class AGMDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOValida
 	@Inject
 	AlleleService alleleService;
 
-	public ObjectResponse<AGMDiseaseAnnotation> validateAGMDiseaseAnnotationDTO(AGMDiseaseAnnotationDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public ObjectResponse<AGMDiseaseAnnotation> validateAGMDiseaseAnnotationDTO(AGMDiseaseAnnotationDTO dto, Species species) throws ValidationException {
 		response = new ObjectResponse<AGMDiseaseAnnotation>();
 		
 		AGMDiseaseAnnotation annotation = new AGMDiseaseAnnotation();
@@ -58,10 +58,10 @@ public class AGMDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOValida
 			annotation.setDiseaseAnnotationSubject(agm);
 			UniqueIdentifierHelper.setObsoleteAndInternal(dto, annotation);
 
-			if (dataProvider != null
-					&& (dataProvider.name().equals("RGD") || dataProvider.name().equals("HUMAN"))
-					&& (!agm.getTaxon().getCurie().equals(dataProvider.canonicalTaxonCurie) || !dataProvider.sourceOrganization.equals(agm.getDataProvider().getAbbreviation()))) {
-				response.addErrorMessage("agm_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAgmIdentifier() + ") for " + dataProvider.name() + " load");
+			if (species != null
+					&& (species.getDisplayName().equals("RGD") || species.getDisplayName().equals("HUMAN"))
+					&& (!agm.getTaxon().getCurie().equals(species.getTaxon().getCurie()) || !species.getDataProvider().getAbbreviation().equals(agm.getDataProvider().getAbbreviation()))) {
+				response.addErrorMessage("agm_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAgmIdentifier() + ") for " + species.getDisplayName() + " load");
 			}
 		}
 		annotation.setEvidenceItem(reference);

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AffectedGenomicModelDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AffectedGenomicModelDTOValidator.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.AffectedGenomicModelDAO;
 import org.alliancegenome.curation_api.dao.SynonymDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
@@ -44,7 +44,7 @@ public class AffectedGenomicModelDTOValidator extends GenomicEntityDTOValidator<
 	@Inject AgmSecondaryIdSlotAnnotationDTOValidator agmSecondaryIdDtoValidator;
 
 	@Transactional
-	public ObjectResponse<AffectedGenomicModel> validateAffectedGenomicModelDTO(AffectedGenomicModelDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public ObjectResponse<AffectedGenomicModel> validateAffectedGenomicModelDTO(AffectedGenomicModelDTO dto, Species species) throws ValidationException {
 		response = new ObjectResponse<AffectedGenomicModel>();
 		
 		AffectedGenomicModel agm = findDatabaseObject(affectedGenomicModelDAO, "primaryExternalId", "primary_external_id", dto.getPrimaryExternalId());
@@ -52,7 +52,7 @@ public class AffectedGenomicModelDTOValidator extends GenomicEntityDTOValidator<
 			agm = new AffectedGenomicModel();
 		}
 		
-		agm = validateGenomicEntityDTO(agm, dto, dataProvider, VocabularyConstants.AGM_NOTE_TYPES_VOCABULARY_TERM_SET);
+		agm = validateGenomicEntityDTO(agm, dto, species, VocabularyConstants.AGM_NOTE_TYPES_VOCABULARY_TERM_SET);
 
 		AgmFullNameSlotAnnotation fullName = validateAgmFullName(agm, dto);
 		agm.setAgmFullName(fullName);

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AlleleDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AlleleDTOValidator.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.AlleleDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.Allele;
@@ -84,7 +84,7 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 	ReferenceService referenceService;
 
 	@Transactional
-	public ObjectResponse<Allele> validateAlleleDTO(AlleleDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public ObjectResponse<Allele> validateAlleleDTO(AlleleDTO dto, Species species) throws ValidationException {
 		response = new ObjectResponse<>();
 
 		Allele allele = findDatabaseObject(alleleDAO, "primaryExternalId", "primary_external_id", dto.getPrimaryExternalId());
@@ -92,7 +92,7 @@ public class AlleleDTOValidator extends GenomicEntityDTOValidator<Allele, Allele
 			allele = new Allele();
 		}
 
-		allele = validateGenomicEntityDTO(allele, dto, dataProvider, VocabularyConstants.ALLELE_NOTE_TYPES_VOCABULARY_TERM_SET);
+		allele = validateGenomicEntityDTO(allele, dto, species, VocabularyConstants.ALLELE_NOTE_TYPES_VOCABULARY_TERM_SET);
 
 		VocabularyTerm inCollection = validateTermInVocabulary("in_collection_name", dto.getInCollectionName(), VocabularyConstants.ALLELE_COLLECTION_VOCABULARY);
 		allele.setInCollection(inCollection);

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AlleleDiseaseAnnotationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/AlleleDiseaseAnnotationDTOValidator.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.AlleleDiseaseAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.Allele;
@@ -32,7 +32,7 @@ public class AlleleDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOVal
 	@Inject AlleleService alleleService;
 	@Inject GeneService geneService;
 
-	public ObjectResponse<AlleleDiseaseAnnotation> validateAlleleDiseaseAnnotationDTO(AlleleDiseaseAnnotationDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public ObjectResponse<AlleleDiseaseAnnotation> validateAlleleDiseaseAnnotationDTO(AlleleDiseaseAnnotationDTO dto, Species species) throws ValidationException {
 		response = new ObjectResponse<AlleleDiseaseAnnotation>();
 		
 		AlleleDiseaseAnnotation annotation = new AlleleDiseaseAnnotation();
@@ -50,10 +50,10 @@ public class AlleleDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOVal
 			annotation.setDiseaseAnnotationSubject(allele);
 			UniqueIdentifierHelper.setObsoleteAndInternal(dto, annotation);
 
-			if (dataProvider != null
-					&& (dataProvider.name().equals("RGD") || dataProvider.name().equals("HUMAN"))
-					&& (!allele.getTaxon().getCurie().equals(dataProvider.canonicalTaxonCurie) || !dataProvider.sourceOrganization.equals(allele.getDataProvider().getAbbreviation()))) {
-				response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAlleleIdentifier() + ") for " + dataProvider.name() + " load");
+			if (species != null
+					&& (species.getDisplayName().equals("RGD") || species.getDisplayName().equals("HUMAN"))
+					&& (!allele.getTaxon().getCurie().equals(species.getTaxon().getCurie()) || !species.getDataProvider().getAbbreviation().equals(allele.getDataProvider().getAbbreviation()))) {
+				response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAlleleIdentifier() + ") for " + species.getDisplayName() + " load");
 			}
 		}
 		annotation.setEvidenceItem(reference);

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/ConstructDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/ConstructDTOValidator.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.ConstructDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.Construct;
@@ -55,7 +55,7 @@ public class ConstructDTOValidator extends ReagentDTOValidator<Construct, Constr
 	ReferenceService referenceService;
 
 	@Transactional
-	public ObjectResponse<Construct> validateConstructDTO(ConstructDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public ObjectResponse<Construct> validateConstructDTO(ConstructDTO dto, Species species) throws ValidationException {
 
 		response = new ObjectResponse<Construct>();
 

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDTOValidator.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.GeneDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.CrossReference;
@@ -54,7 +54,7 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 	@Inject SoTermService soTermService;
 
 	@Transactional
-	public ObjectResponse<Gene> validateGeneDTO(GeneDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public ObjectResponse<Gene> validateGeneDTO(GeneDTO dto, Species species) throws ValidationException {
 		response = new ObjectResponse<Gene>();
 		
 		Gene gene = findDatabaseObject(geneDAO, "primaryExternalId", "primary_external_id", dto.getPrimaryExternalId());
@@ -62,7 +62,7 @@ public class GeneDTOValidator extends GenomicEntityDTOValidator<Gene, GeneDTO> {
 			gene = new Gene();
 		}
 
-		gene = validateGenomicEntityDTO(gene, dto, dataProvider, VocabularyConstants.GENE_NOTE_TYPES_VOCABULARY_TERM_SET);
+		gene = validateGenomicEntityDTO(gene, dto, species, VocabularyConstants.GENE_NOTE_TYPES_VOCABULARY_TERM_SET);
 		
 		GeneSymbolSlotAnnotation symbol = validateGeneSymbol(gene, dto);
 		gene.setGeneSymbol(symbol);

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDiseaseAnnotationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/GeneDiseaseAnnotationDTOValidator.java
@@ -3,7 +3,7 @@ package org.alliancegenome.curation_api.services.validation.dto;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.GeneDiseaseAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
 import org.alliancegenome.curation_api.model.entities.Gene;
@@ -27,7 +27,7 @@ public class GeneDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOValid
 	@Inject GeneDiseaseAnnotationDAO geneDiseaseAnnotationDAO;
 	@Inject AffectedGenomicModelService affectedGenomicModelService;
 
-	public ObjectResponse<GeneDiseaseAnnotation> validateGeneDiseaseAnnotationDTO(GeneDiseaseAnnotationDTO dto, BackendBulkDataProvider dataProvider) throws ObjectValidationException {
+	public ObjectResponse<GeneDiseaseAnnotation> validateGeneDiseaseAnnotationDTO(GeneDiseaseAnnotationDTO dto, Species species) throws ObjectValidationException {
 		response = new ObjectResponse<GeneDiseaseAnnotation>();
 		
 		GeneDiseaseAnnotation annotation = new GeneDiseaseAnnotation();
@@ -45,10 +45,10 @@ public class GeneDiseaseAnnotationDTOValidator extends DiseaseAnnotationDTOValid
 			annotation.setDiseaseAnnotationSubject(gene);
 			UniqueIdentifierHelper.setObsoleteAndInternal(dto, annotation);
 
-			if (dataProvider != null
-					&& (dataProvider.name().equals("RGD") || dataProvider.name().equals("HUMAN"))
-					&& (!gene.getTaxon().getCurie().equals(dataProvider.canonicalTaxonCurie) || !dataProvider.sourceOrganization.equals(gene.getDataProvider().getAbbreviation()))) {
-				response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getGeneIdentifier() + ") for " + dataProvider.name() + " load");
+			if (species != null
+					&& (species.getDisplayName().equals("RGD") || species.getDisplayName().equals("HUMAN"))
+					&& (!gene.getTaxon().getCurie().equals(species.getTaxon().getCurie()) || !species.getDataProvider().getAbbreviation().equals(gene.getDataProvider().getAbbreviation()))) {
+				response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getGeneIdentifier() + ") for " + species.getDisplayName() + " load");
 			}
 		}
 		annotation.setEvidenceItem(reference);

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/Gff3DtoValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/Gff3DtoValidator.java
@@ -19,7 +19,7 @@ import org.alliancegenome.curation_api.dao.associations.TranscriptExonAssociatio
 import org.alliancegenome.curation_api.dao.associations.TranscriptGeneAssociationDAO;
 import org.alliancegenome.curation_api.dao.associations.TranscriptGenomicLocationAssociationDAO;
 import org.alliancegenome.curation_api.dao.ontology.SoTermDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.AssemblyComponent;
@@ -75,7 +75,7 @@ public class Gff3DtoValidator {
 	@Inject OrganizationService organizationService;
 	
 	@Transactional
-	public void validateExonEntry(Gff3DTO dto, Map<String, String> attributes, List<Long> idsAdded, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public void validateExonEntry(Gff3DTO dto, Map<String, String> attributes, List<Long> idsAdded, Species species) throws ValidationException {
 
 		Exon exon = null;
 
@@ -83,7 +83,7 @@ public class Gff3DtoValidator {
 			throw new ObjectValidationException(dto, "Invalid Type: " + dto.getType() + " for Exon Entity");
 		}
 		
-		String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(dto, attributes, dataProvider);
+		String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(dto, attributes, species);
 		SearchResponse<Exon> searchResponse = exonDAO.findByField("uniqueId", uniqueId);
 		if (searchResponse != null && searchResponse.getSingleResult() != null) {
 			exon = searchResponse.getSingleResult();
@@ -96,7 +96,7 @@ public class Gff3DtoValidator {
 			exon.setName(attributes.get("Name"));
 		}
 		
-		ObjectResponse<Exon> exonResponse = validateGenomicEntity(exon, dto, attributes, dataProvider);
+		ObjectResponse<Exon> exonResponse = validateGenomicEntity(exon, dto, attributes, species);
 	
 		if (exonResponse.hasErrors()) {
 			throw new ObjectValidationException(dto, exonResponse.errorMessagesString());
@@ -109,7 +109,7 @@ public class Gff3DtoValidator {
 	}
 	
 	@Transactional
-	public void validateCdsEntry(Gff3DTO dto, Map<String, String> attributes, List<Long> idsAdded, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public void validateCdsEntry(Gff3DTO dto, Map<String, String> attributes, List<Long> idsAdded, Species species) throws ValidationException {
 
 		CodingSequence cds = null;
 		
@@ -117,7 +117,7 @@ public class Gff3DtoValidator {
 			throw new ObjectValidationException(dto, "Invalid Type: " + dto.getType() + " for CDS Entity");
 		}
 		
-		String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(dto, attributes, dataProvider);
+		String uniqueId = Gff3UniqueIdHelper.getExonOrCodingSequenceUniqueId(dto, attributes, species);
 		SearchResponse<CodingSequence> searchResponse = codingSequenceDAO.findByField("uniqueId", uniqueId);
 		if (searchResponse != null && searchResponse.getSingleResult() != null) {
 			cds = searchResponse.getSingleResult();
@@ -130,7 +130,7 @@ public class Gff3DtoValidator {
 			cds.setName(attributes.get("Name"));
 		}
 		
-		ObjectResponse<CodingSequence> cdsResponse = validateGenomicEntity(cds, dto, attributes, dataProvider);
+		ObjectResponse<CodingSequence> cdsResponse = validateGenomicEntity(cds, dto, attributes, species);
 	
 		if (cdsResponse.hasErrors()) {
 			throw new ObjectValidationException(dto, cdsResponse.errorMessagesString());
@@ -143,7 +143,7 @@ public class Gff3DtoValidator {
 	}
 	
 	@Transactional
-	public void validateTranscriptEntry(Gff3DTO dto, Map<String, String> attributes, List<Long> idsAdded, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public void validateTranscriptEntry(Gff3DTO dto, Map<String, String> attributes, List<Long> idsAdded, Species species) throws ValidationException {
 
 		if (!Gff3Constants.TRANSCRIPT_TYPES.contains(dto.getType())) {
 			throw new ObjectValidationException(dto, "Invalid Type: " + dto.getType() + " for Transcript Entity");
@@ -171,7 +171,7 @@ public class Gff3DtoValidator {
 			transcript.setName(null);
 		}
 		
-		ObjectResponse<Transcript> transcriptResponse = validateGenomicEntity(transcript, dto, attributes, dataProvider);
+		ObjectResponse<Transcript> transcriptResponse = validateGenomicEntity(transcript, dto, attributes, species);
 		if (!attributes.containsKey("ID")) {
 			transcriptResponse.addErrorMessage("attributes - ID", ValidationConstants.REQUIRED_MESSAGE);
 		}
@@ -192,11 +192,11 @@ public class Gff3DtoValidator {
 		}
 	}
 	
-	private <E extends GenomicEntity> ObjectResponse<E> validateGenomicEntity(E entity, Gff3DTO dto, Map<String, String> attributes, BackendBulkDataProvider dataProvider) {
+	private <E extends GenomicEntity> ObjectResponse<E> validateGenomicEntity(E entity, Gff3DTO dto, Map<String, String> attributes, Species species) {
 		ObjectResponse<E> geResponse = new ObjectResponse<E>();
 		
-		entity.setDataProvider(organizationService.getByAbbr(dataProvider.sourceOrganization).getEntity());
-		entity.setTaxon(ncbiTaxonTermService.getByCurie(dataProvider.canonicalTaxonCurie).getEntity());
+		entity.setDataProvider(organizationService.getByAbbr(species.getDataProvider().getAbbreviation()).getEntity());
+		entity.setTaxon(ncbiTaxonTermService.getByCurie(species.getTaxon().getCurie()).getEntity());
 		
 		geResponse.setEntity(entity);
 		
@@ -204,11 +204,11 @@ public class Gff3DtoValidator {
 	}
 
 	@Transactional
-	public CodingSequenceGenomicLocationAssociation validateCdsLocation(Gff3DTO gffEntry, CodingSequence cds, String assemblyId, BackendBulkDataProvider dataProvider) throws ObjectValidationException {
+	public CodingSequenceGenomicLocationAssociation validateCdsLocation(Gff3DTO gffEntry, CodingSequence cds, String assemblyId, Species species) throws ObjectValidationException {
 		AssemblyComponent assemblyComponent = null;
 		CodingSequenceGenomicLocationAssociation locationAssociation = new CodingSequenceGenomicLocationAssociation();
 		if (StringUtils.isNotBlank(gffEntry.getSeqId())) {
-			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, dataProvider.canonicalTaxonCurie, dataProvider);
+			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, species.getTaxon().getCurie(), species);
 			Map<String, Object> params = new HashMap<>();
 			params.put(EntityFieldConstants.CODING_SEQUENCE_ASSOCIATION_SUBJECT + ".id", cds.getId());
 			params.put(EntityFieldConstants.CODING_SEQUENCE_GENOMIC_LOCATION_ASSOCIATION_OBJECT + ".name", assemblyComponent.getName());
@@ -232,11 +232,11 @@ public class Gff3DtoValidator {
 	}
 
 	@Transactional
-	public CodingSequenceGenomicLocationAssociation validateCdsLocation(Gff3DTO gffEntry, CodingSequence cds, String assemblyId, BackendBulkDataProvider dataProvider, CodingSequenceGenomicLocationAssociation existingAssociation) throws ObjectValidationException {
+	public CodingSequenceGenomicLocationAssociation validateCdsLocation(Gff3DTO gffEntry, CodingSequence cds, String assemblyId, Species species, CodingSequenceGenomicLocationAssociation existingAssociation) throws ObjectValidationException {
 		AssemblyComponent assemblyComponent = null;
 		CodingSequenceGenomicLocationAssociation locationAssociation = existingAssociation != null ? existingAssociation : new CodingSequenceGenomicLocationAssociation();
 		if (StringUtils.isNotBlank(gffEntry.getSeqId())) {
-			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, dataProvider.canonicalTaxonCurie, dataProvider);
+			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, species.getTaxon().getCurie(), species);
 			locationAssociation.setCodingSequenceGenomicLocationAssociationObject(assemblyComponent);
 		}
 		locationAssociation.setCodingSequenceAssociationSubject(cds);
@@ -252,11 +252,11 @@ public class Gff3DtoValidator {
 	}
 
 	@Transactional
-	public ExonGenomicLocationAssociation validateExonLocation(Gff3DTO gffEntry, Exon exon, String assemblyId, BackendBulkDataProvider dataProvider) throws ObjectValidationException {
+	public ExonGenomicLocationAssociation validateExonLocation(Gff3DTO gffEntry, Exon exon, String assemblyId, Species species) throws ObjectValidationException {
 		AssemblyComponent assemblyComponent = null;
 		ExonGenomicLocationAssociation locationAssociation = new ExonGenomicLocationAssociation();
 		if (StringUtils.isNotBlank(gffEntry.getSeqId())) {
-			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, dataProvider.canonicalTaxonCurie, dataProvider);
+			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, species.getTaxon().getCurie(), species);
 			Map<String, Object> params = new HashMap<>();
 			params.put(EntityFieldConstants.EXON_ASSOCIATION_SUBJECT + ".id", exon.getId());
 			params.put(EntityFieldConstants.EXON_GENOMIC_LOCATION_ASSOCIATION_OBJECT + ".name", assemblyComponent.getName());
@@ -279,11 +279,11 @@ public class Gff3DtoValidator {
 	}
 
 	@Transactional
-	public ExonGenomicLocationAssociation validateExonLocation(Gff3DTO gffEntry, Exon exon, String assemblyId, BackendBulkDataProvider dataProvider, ExonGenomicLocationAssociation existingAssociation) throws ObjectValidationException {
+	public ExonGenomicLocationAssociation validateExonLocation(Gff3DTO gffEntry, Exon exon, String assemblyId, Species species, ExonGenomicLocationAssociation existingAssociation) throws ObjectValidationException {
 		AssemblyComponent assemblyComponent = null;
 		ExonGenomicLocationAssociation locationAssociation = existingAssociation != null ? existingAssociation : new ExonGenomicLocationAssociation();
 		if (StringUtils.isNotBlank(gffEntry.getSeqId())) {
-			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, dataProvider.canonicalTaxonCurie, dataProvider);
+			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, species.getTaxon().getCurie(), species);
 			locationAssociation.setExonGenomicLocationAssociationObject(assemblyComponent);
 		}
 		locationAssociation.setExonAssociationSubject(exon);
@@ -298,11 +298,11 @@ public class Gff3DtoValidator {
 	}
 
 	@Transactional
-	public TranscriptGenomicLocationAssociation validateTranscriptLocation(Gff3DTO gffEntry, Transcript transcript, String assemblyId, BackendBulkDataProvider dataProvider) throws ObjectValidationException {
+	public TranscriptGenomicLocationAssociation validateTranscriptLocation(Gff3DTO gffEntry, Transcript transcript, String assemblyId, Species species) throws ObjectValidationException {
 		AssemblyComponent assemblyComponent = null;
 		TranscriptGenomicLocationAssociation locationAssociation = new TranscriptGenomicLocationAssociation();
 		if (StringUtils.isNotBlank(gffEntry.getSeqId())) {
-			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, dataProvider.canonicalTaxonCurie, dataProvider);
+			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, species.getTaxon().getCurie(), species);
 			Map<String, Object> params = new HashMap<>();
 			params.put(EntityFieldConstants.TRANSCRIPT_ASSOCIATION_SUBJECT + ".id", transcript.getId());
 			params.put(EntityFieldConstants.TRANSCRIPT_GENOMIC_LOCATION_ASSOCIATION_OBJECT_ASSEMBLY, assemblyId);
@@ -325,11 +325,11 @@ public class Gff3DtoValidator {
 	}
 
 	@Transactional
-	public TranscriptGenomicLocationAssociation validateTranscriptLocation(Gff3DTO gffEntry, Transcript transcript, String assemblyId, BackendBulkDataProvider dataProvider, TranscriptGenomicLocationAssociation existingAssociation) throws ObjectValidationException {
+	public TranscriptGenomicLocationAssociation validateTranscriptLocation(Gff3DTO gffEntry, Transcript transcript, String assemblyId, Species species, TranscriptGenomicLocationAssociation existingAssociation) throws ObjectValidationException {
 		AssemblyComponent assemblyComponent = null;
 		TranscriptGenomicLocationAssociation locationAssociation = existingAssociation != null ? existingAssociation : new TranscriptGenomicLocationAssociation();
 		if (StringUtils.isNotBlank(gffEntry.getSeqId())) {
-			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, dataProvider.canonicalTaxonCurie, dataProvider);
+			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, species.getTaxon().getCurie(), species);
 			locationAssociation.setTranscriptGenomicLocationAssociationObject(assemblyComponent);
 		}
 		locationAssociation.setTranscriptAssociationSubject(transcript);
@@ -367,11 +367,11 @@ public class Gff3DtoValidator {
 	}
 
 	@Transactional
-	public GeneGenomicLocationAssociation validateGeneLocation(Gff3DTO gffEntry, Gene gene, String assemblyId, BackendBulkDataProvider dataProvider) throws ObjectValidationException {
+	public GeneGenomicLocationAssociation validateGeneLocation(Gff3DTO gffEntry, Gene gene, String assemblyId, Species species) throws ObjectValidationException {
 		AssemblyComponent assemblyComponent = null;
 		GeneGenomicLocationAssociation locationAssociation = new GeneGenomicLocationAssociation();
 		if (StringUtils.isNotBlank(gffEntry.getSeqId())) {
-			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, dataProvider.canonicalTaxonCurie, dataProvider);
+			assemblyComponent = assemblyComponentService.fetchOrCreate(gffEntry.getSeqId(), assemblyId, species.getTaxon().getCurie(), species);
 			Map<String, Object> params = new HashMap<>();
 			params.put(EntityFieldConstants.GENE_ASSOCIATION_SUBJECT + ".id", gene.getId());
 			params.put(EntityFieldConstants.GENE_GENOMIC_LOCATION_ASSOCIATION_OBJECT_ASSEMBLY, assemblyId);

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/VariantDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/VariantDTOValidator.java
@@ -3,7 +3,7 @@ package org.alliancegenome.curation_api.services.validation.dto;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.VariantDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.Variant;
@@ -26,7 +26,7 @@ public class VariantDTOValidator extends GenomicEntityDTOValidator<Variant, Vari
 	@Inject SoTermService soTermService;
 
 	@Transactional
-	public ObjectResponse<Variant> validateVariantDTO(VariantDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public ObjectResponse<Variant> validateVariantDTO(VariantDTO dto, Species species) throws ValidationException {
 		response = new ObjectResponse<Variant>();
 		
 		Variant variant = null;
@@ -46,7 +46,7 @@ public class VariantDTOValidator extends GenomicEntityDTOValidator<Variant, Vari
 			variant = new Variant();
 		}
 
-		variant = validateGenomicEntityDTO(variant, dto, dataProvider, VocabularyConstants.VARIANT_NOTE_TYPES_VOCABULARY_TERM_SET);
+		variant = validateGenomicEntityDTO(variant, dto, species, VocabularyConstants.VARIANT_NOTE_TYPES_VOCABULARY_TERM_SET);
 		
 		SOTerm variantType = validateRequiredOntologyTerm(soTermService, "variant_type_curie", dto.getVariantTypeCurie());
 		variant.setVariantType(variantType);

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/AgmAgmAssociationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/AgmAgmAssociationDTOValidator.java
@@ -7,7 +7,7 @@ import org.alliancegenome.curation_api.constants.EntityFieldConstants;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.associations.AgmAgmAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
@@ -29,7 +29,7 @@ public class AgmAgmAssociationDTOValidator extends AuditedObjectDTOValidator<Agm
 	@Inject AgmAgmAssociationDAO agmAgmAssociationDAO;
 	@Inject AffectedGenomicModelService agmService;
 
-	public ObjectResponse<AgmAgmAssociation> validateAgmAgmAssociationDTO(AgmAgmAssociationDTO dto, BackendBulkDataProvider beDataProvider) throws ValidationException {
+	public ObjectResponse<AgmAgmAssociation> validateAgmAgmAssociationDTO(AgmAgmAssociationDTO dto, Species beSpecies) throws ValidationException {
 		response = new ObjectResponse<AgmAgmAssociation>();
 
 		List<Long> subjectIds = null;
@@ -78,8 +78,8 @@ public class AgmAgmAssociationDTOValidator extends AuditedObjectDTOValidator<Agm
 			AffectedGenomicModel subject = agmService.findByIdentifierString(dto.getAgmSubjectIdentifier());
 			if (subject == null) {
 				response.addErrorMessage("agm_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAgmSubjectIdentifier() + ")");
-			} else if (beDataProvider != null && !subject.getDataProvider().getAbbreviation().equals(beDataProvider.sourceOrganization)) {
-				response.addErrorMessage("agm_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beDataProvider.name() + " load (" + dto.getAgmSubjectIdentifier() + ")");
+			} else if (beSpecies != null && !subject.getDataProvider().getAbbreviation().equals(beSpecies.getDataProvider().getAbbreviation())) {
+				response.addErrorMessage("agm_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beSpecies.getDisplayName() + " load (" + dto.getAgmSubjectIdentifier() + ")");
 			} else {
 				association.setAgmAssociationSubject(subject);
 			}
@@ -90,8 +90,8 @@ public class AgmAgmAssociationDTOValidator extends AuditedObjectDTOValidator<Agm
 			AffectedGenomicModel object = agmService.findByIdentifierString(dto.getAgmObjectIdentifier());
 			if (object == null) {
 				response.addErrorMessage("agm_object_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAgmObjectIdentifier() + ")");
-			} else if (beDataProvider != null && !object.getDataProvider().getAbbreviation().equals(beDataProvider.sourceOrganization)) {
-				response.addErrorMessage("agm_object_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beDataProvider.name() + " load (" + dto.getAgmObjectIdentifier() + ")");
+			} else if (beSpecies != null && !object.getDataProvider().getAbbreviation().equals(beSpecies.getDataProvider().getAbbreviation())) {
+				response.addErrorMessage("agm_object_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beSpecies.getDisplayName() + " load (" + dto.getAgmObjectIdentifier() + ")");
 			} else {
 				association.setAgmAgmAssociationObject(object);
 			}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/AgmAlleleAssociationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/AgmAlleleAssociationDTOValidator.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.associations.AgmAlleleAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
@@ -52,7 +52,7 @@ public class AgmAlleleAssociationDTOValidator extends AuditedObjectDTOValidator<
 		this.existingFullStateKeys = fullStateKeys;
 	}
 
-	public ObjectResponse<AgmAlleleAssociation> validateAgmAlleleAssociationDTO(AgmAlleleAssociationDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public ObjectResponse<AgmAlleleAssociation> validateAgmAlleleAssociationDTO(AgmAlleleAssociationDTO dto, Species species) throws ValidationException {
 		response = new ObjectResponse<AgmAlleleAssociation>();
 
 		List<Long> subjectIds = null;
@@ -120,8 +120,8 @@ public class AgmAlleleAssociationDTOValidator extends AuditedObjectDTOValidator<
 					AffectedGenomicModel subject = agmCache.computeIfAbsent(dto.getAgmSubjectIdentifier(), agmService::findByIdentifierString);
 					if (subject == null) {
 						response.addErrorMessage("agm_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAgmSubjectIdentifier() + ")");
-					} else if (dataProvider != null && !subject.getDataProvider().getAbbreviation().equals(dataProvider.sourceOrganization)) {
-						response.addErrorMessage("agm_identifier", ValidationConstants.INVALID_MESSAGE + " for " + dataProvider.name() + " load (" + dto.getAgmSubjectIdentifier() + ")");
+					} else if (species != null && !subject.getDataProvider().getAbbreviation().equals(species.getDataProvider().getAbbreviation())) {
+						response.addErrorMessage("agm_identifier", ValidationConstants.INVALID_MESSAGE + " for " + species.getDisplayName() + " load (" + dto.getAgmSubjectIdentifier() + ")");
 					} else {
 						association.setAgmAssociationSubject(subject);
 					}
@@ -132,8 +132,8 @@ public class AgmAlleleAssociationDTOValidator extends AuditedObjectDTOValidator<
 					Allele object = alleleCache.computeIfAbsent(dto.getAlleleIdentifier(), alleleService::findByIdentifierString);
 					if (object == null) {
 						response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAlleleIdentifier() + ")");
-					} else if (dataProvider != null && !object.getDataProvider().getAbbreviation().equals(dataProvider.sourceOrganization)) {
-						response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " for " + dataProvider.name() + " load (" + dto.getAlleleIdentifier() + ")");
+					} else if (species != null && !object.getDataProvider().getAbbreviation().equals(species.getDataProvider().getAbbreviation())) {
+						response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " for " + species.getDisplayName() + " load (" + dto.getAlleleIdentifier() + ")");
 					} else {
 						association.setAgmAlleleAssociationObject(object);
 					}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/AgmSequenceTargetingReagentAssociationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/AgmSequenceTargetingReagentAssociationDTOValidator.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.associations.AgmSequenceTargetingReagentAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
@@ -31,7 +31,7 @@ public class AgmSequenceTargetingReagentAssociationDTOValidator extends AuditedO
 	@Inject AffectedGenomicModelService agmService;
 	@Inject SequenceTargetingReagentService strService;
 
-	public ObjectResponse<AgmSequenceTargetingReagentAssociation> validateAgmSequenceTargetingReagentAssociationDTO(AgmSequenceTargetingReagentAssociationDTO dto, BackendBulkDataProvider beDataProvider) throws ValidationException {
+	public ObjectResponse<AgmSequenceTargetingReagentAssociation> validateAgmSequenceTargetingReagentAssociationDTO(AgmSequenceTargetingReagentAssociationDTO dto, Species beSpecies) throws ValidationException {
 		response = new ObjectResponse<AgmSequenceTargetingReagentAssociation>();
 		
 		List<Long> subjectIds = null;
@@ -79,8 +79,8 @@ public class AgmSequenceTargetingReagentAssociationDTOValidator extends AuditedO
 			AffectedGenomicModel subject = agmService.findByIdentifierString(dto.getAgmSubjectIdentifier());
 			if (subject == null) {
 				response.addErrorMessage("agm_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAgmSubjectIdentifier() + ")");
-			} else if (beDataProvider != null && !subject.getDataProvider().getAbbreviation().equals(beDataProvider.sourceOrganization)) {
-				response.addErrorMessage("agm_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beDataProvider.name() + " load (" + dto.getAgmSubjectIdentifier() + ")");
+			} else if (beSpecies != null && !subject.getDataProvider().getAbbreviation().equals(beSpecies.getDataProvider().getAbbreviation())) {
+				response.addErrorMessage("agm_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beSpecies.getDisplayName() + " load (" + dto.getAgmSubjectIdentifier() + ")");
 			} else {
 				association.setAgmAssociationSubject(subject);
 			}
@@ -91,8 +91,8 @@ public class AgmSequenceTargetingReagentAssociationDTOValidator extends AuditedO
 			SequenceTargetingReagent object = strService.findByIdentifierString(dto.getSequenceTargetingReagentIdentifier());
 			if (object == null) {
 				response.addErrorMessage("str_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getSequenceTargetingReagentIdentifier() + ")");
-			} else if (beDataProvider != null && !object.getDataProvider().getAbbreviation().equals(beDataProvider.sourceOrganization)) {
-				response.addErrorMessage("str_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beDataProvider.name() + " load (" + dto.getSequenceTargetingReagentIdentifier() + ")");
+			} else if (beSpecies != null && !object.getDataProvider().getAbbreviation().equals(beSpecies.getDataProvider().getAbbreviation())) {
+				response.addErrorMessage("str_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beSpecies.getDisplayName() + " load (" + dto.getSequenceTargetingReagentIdentifier() + ")");
 			} else {
 				association.setAgmSequenceTargetingReagentAssociationObject(object);
 			}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/AlleleConstructAssociationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/AlleleConstructAssociationDTOValidator.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.associations.AlleleConstructAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.Allele;
@@ -27,7 +27,7 @@ public class AlleleConstructAssociationDTOValidator extends AlleleGenomicEntityA
 	@Inject AlleleConstructAssociationDAO alleleConstructAssociationDAO;
 	@Inject AlleleService alleleService;
 	@Inject ConstructService constructService;
-	public ObjectResponse<AlleleConstructAssociation> validateAlleleConstructAssociationDTO(AlleleConstructAssociationDTO dto, BackendBulkDataProvider beDataProvider) throws ValidationException {
+	public ObjectResponse<AlleleConstructAssociation> validateAlleleConstructAssociationDTO(AlleleConstructAssociationDTO dto, Species beSpecies) throws ValidationException {
 		
 		response = new ObjectResponse<AlleleConstructAssociation>();
 

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/AlleleGeneAssociationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/AlleleGeneAssociationDTOValidator.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.associations.AlleleGeneAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.Allele;
@@ -31,11 +31,11 @@ public class AlleleGeneAssociationDTOValidator extends AlleleGenomicEntityAssoci
 	@Inject AlleleService alleleService;
 	@Inject GeneService geneService;
 	
-	public ObjectResponse<AlleleGeneAssociation> validateAlleleGeneAssociationDTO(AlleleGeneAssociationDTO dto, BackendBulkDataProvider beDataProvider) throws ValidationException {
-		return validateAlleleGeneAssociationDTO(dto, beDataProvider, null, false);
+	public ObjectResponse<AlleleGeneAssociation> validateAlleleGeneAssociationDTO(AlleleGeneAssociationDTO dto, Species beSpecies) throws ValidationException {
+		return validateAlleleGeneAssociationDTO(dto, beSpecies, null, false);
 	}
 	
-	public ObjectResponse<AlleleGeneAssociation> validateAlleleGeneAssociationDTO(AlleleGeneAssociationDTO dto, BackendBulkDataProvider beDataProvider, Map<Long, Long> isAlleleOfAssociationMap, boolean isFullLoad) throws ValidationException {
+	public ObjectResponse<AlleleGeneAssociation> validateAlleleGeneAssociationDTO(AlleleGeneAssociationDTO dto, Species beSpecies, Map<Long, Long> isAlleleOfAssociationMap, boolean isFullLoad) throws ValidationException {
 		response = new ObjectResponse<AlleleGeneAssociation>();
 		
 		List<Long> subjectIds = null;
@@ -95,8 +95,8 @@ public class AlleleGeneAssociationDTOValidator extends AlleleGenomicEntityAssoci
 			Allele subject = alleleService.findByIdentifierString(dto.getAlleleIdentifier());
 			if (subject == null) {
 				response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAlleleIdentifier() + ")");
-			} else if (beDataProvider != null && !subject.getDataProvider().getAbbreviation().equals(beDataProvider.sourceOrganization)) {
-				response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beDataProvider.name() + " load (" + dto.getAlleleIdentifier() + ")");
+			} else if (beSpecies != null && !subject.getDataProvider().getAbbreviation().equals(beSpecies.getDataProvider().getAbbreviation())) {
+				response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beSpecies.getDisplayName() + " load (" + dto.getAlleleIdentifier() + ")");
 			} else {
 				association.setAlleleAssociationSubject(subject);
 			}
@@ -113,8 +113,8 @@ public class AlleleGeneAssociationDTOValidator extends AlleleGenomicEntityAssoci
 			Gene object = geneService.findByIdentifierString(dto.getGeneIdentifier());
 			if (object == null) {
 				response.addErrorMessage("gene_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getGeneIdentifier() + ")");
-			} else if (beDataProvider != null && !object.getDataProvider().getAbbreviation().equals(beDataProvider.sourceOrganization)) {
-				response.addErrorMessage("gene_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beDataProvider.name() + " load (" + dto.getGeneIdentifier() + ")");
+			} else if (beSpecies != null && !object.getDataProvider().getAbbreviation().equals(beSpecies.getDataProvider().getAbbreviation())) {
+				response.addErrorMessage("gene_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beSpecies.getDisplayName() + " load (" + dto.getGeneIdentifier() + ")");
 			} else {
 				association.setAlleleGeneAssociationObject(object);
 			}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/AlleleVariantAssociationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/AlleleVariantAssociationDTOValidator.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.associations.AlleleVariantAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.Allele;
@@ -29,7 +29,7 @@ public class AlleleVariantAssociationDTOValidator extends AlleleGenomicEntityAss
 	@Inject AlleleService alleleService;
 	@Inject VariantService variantService;
 
-	public AlleleVariantAssociation validateAlleleVariantAssociationDTO(AlleleVariantAssociationDTO dto, BackendBulkDataProvider beDataProvider) throws ValidationException {
+	public AlleleVariantAssociation validateAlleleVariantAssociationDTO(AlleleVariantAssociationDTO dto, Species beSpecies) throws ValidationException {
 		response = new ObjectResponse<AlleleVariantAssociation>();
 		
 		List<Long> subjectIds = null;
@@ -77,8 +77,8 @@ public class AlleleVariantAssociationDTOValidator extends AlleleGenomicEntityAss
 			Allele subject = alleleService.findByIdentifierString(dto.getAlleleIdentifier());
 			if (subject == null) {
 				response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getAlleleIdentifier() + ")");
-			} else if (beDataProvider != null && !subject.getDataProvider().getAbbreviation().equals(beDataProvider.sourceOrganization)) {
-				response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beDataProvider.name() + " load (" + dto.getAlleleIdentifier() + ")");
+			} else if (beSpecies != null && !subject.getDataProvider().getAbbreviation().equals(beSpecies.getDataProvider().getAbbreviation())) {
+				response.addErrorMessage("allele_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beSpecies.getDisplayName() + " load (" + dto.getAlleleIdentifier() + ")");
 			} else {
 				association.setAlleleAssociationSubject(subject);
 			}
@@ -89,8 +89,8 @@ public class AlleleVariantAssociationDTOValidator extends AlleleGenomicEntityAss
 			Variant object = variantService.findByIdentifierString(dto.getVariantIdentifier());
 			if (object == null) {
 				response.addErrorMessage("variant_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getVariantIdentifier() + ")");
-			} else if (beDataProvider != null && !object.getDataProvider().getAbbreviation().equals(beDataProvider.sourceOrganization)) {
-				response.addErrorMessage("variant_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beDataProvider.name() + " load (" + dto.getVariantIdentifier() + ")");
+			} else if (beSpecies != null && !object.getDataProvider().getAbbreviation().equals(beSpecies.getDataProvider().getAbbreviation())) {
+				response.addErrorMessage("variant_identifier", ValidationConstants.INVALID_MESSAGE + " for " + beSpecies.getDisplayName() + " load (" + dto.getVariantIdentifier() + ")");
 			} else {
 				association.setAlleleVariantAssociationObject(object);
 			}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/ConstructGenomicEntityAssociationDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/associations/ConstructGenomicEntityAssociationDTOValidator.java
@@ -7,7 +7,7 @@ import java.util.List;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.associations.ConstructGenomicEntityAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.Construct;
@@ -36,7 +36,7 @@ public class ConstructGenomicEntityAssociationDTOValidator extends EvidenceAssoc
 	@Inject
 	ConstructGenomicEntityAssociationDAO constructGenomicEntityAssociationDAO;
 
-	public ObjectResponse<ConstructGenomicEntityAssociation> validateConstructGenomicEntityAssociationDTO(ConstructGenomicEntityAssociationDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public ObjectResponse<ConstructGenomicEntityAssociation> validateConstructGenomicEntityAssociationDTO(ConstructGenomicEntityAssociationDTO dto, Species species) throws ValidationException {
 		response = new ObjectResponse<ConstructGenomicEntityAssociation>();
 
 		List<Long> subjectIds = null;
@@ -82,8 +82,8 @@ public class ConstructGenomicEntityAssociationDTOValidator extends EvidenceAssoc
 					Construct subject = constructService.findByIdentifierString(dto.getConstructIdentifier());
 					if (subject == null) {
 						response.addErrorMessage("construct_identifier", ValidationConstants.INVALID_MESSAGE + " (" + dto.getConstructIdentifier() + ")");
-					} else if (dataProvider != null && !subject.getDataProvider().getAbbreviation().equals(dataProvider.sourceOrganization)) {
-						response.addErrorMessage("construct_identifier", ValidationConstants.INVALID_MESSAGE + " for " + dataProvider.name() + " load (" + dto.getConstructIdentifier() + ")");
+					} else if (species != null && !subject.getDataProvider().getAbbreviation().equals(species.getDataProvider().getAbbreviation())) {
+						response.addErrorMessage("construct_identifier", ValidationConstants.INVALID_MESSAGE + " for " + species.getDisplayName() + " load (" + dto.getConstructIdentifier() + ")");
 					} else {
 						association.setConstructAssociationSubject(subject);
 					}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/base/BiologicalEntityDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/base/BiologicalEntityDTOValidator.java
@@ -3,20 +3,20 @@ package org.alliancegenome.curation_api.services.validation.dto.base;
 import java.util.Objects;
 
 import org.alliancegenome.curation_api.constants.ValidationConstants;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.model.entities.BiologicalEntity;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.ontology.NCBITaxonTerm;
 import org.alliancegenome.curation_api.model.ingest.dto.BiologicalEntityDTO;
 
 public class BiologicalEntityDTOValidator<E extends BiologicalEntity, D extends BiologicalEntityDTO> extends SubmittedObjectDTOValidator<E, D> {
 
-	public E validateBiologicalEntityDTO(E entity, D dto, BackendBulkDataProvider beDataProvider, String noteTypeVocabularyTermSet) {
+	public E validateBiologicalEntityDTO(E entity, D dto, Species beSpecies, String noteTypeVocabularyTermSet) {
 
 		entity = validateSubmittedObjectDTO(entity, dto, noteTypeVocabularyTermSet);
-		
+
 		NCBITaxonTerm taxon = validateRequiredTaxon("taxon_curie", dto.getTaxonCurie());
-		if (beDataProvider != null && (beDataProvider.name().equals("RGD") || beDataProvider.name().equals("HUMAN")) && !Objects.equals(taxon.getCurie(), beDataProvider.canonicalTaxonCurie)) {
-			response.addErrorMessage("taxon_curie", ValidationConstants.INVALID_MESSAGE + " (" + dto.getTaxonCurie() + ") for " + beDataProvider.name() + " load");
+		if (beSpecies != null && (beSpecies.getDisplayName().equals("RGD") || beSpecies.getDisplayName().equals("HUMAN")) && !Objects.equals(taxon.getCurie(), beSpecies.getTaxon().getCurie())) {
+			response.addErrorMessage("taxon_curie", ValidationConstants.INVALID_MESSAGE + " (" + dto.getTaxonCurie() + ") for " + beSpecies.getDisplayName() + " load");
 		}
 		entity.setTaxon(taxon);
 

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/base/GenomicEntityDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/base/GenomicEntityDTOValidator.java
@@ -3,9 +3,9 @@ package org.alliancegenome.curation_api.services.validation.dto.base;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.model.entities.CrossReference;
 import org.alliancegenome.curation_api.model.entities.GenomicEntity;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.ingest.dto.CrossReferenceDTO;
 import org.alliancegenome.curation_api.model.ingest.dto.GenomicEntityDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
@@ -20,9 +20,9 @@ public class GenomicEntityDTOValidator<E extends GenomicEntity, D extends Genomi
 	@Inject CrossReferenceDTOValidator crossReferenceDtoValidator;
 	@Inject CrossReferenceService crossReferenceService;
 
-	public E validateGenomicEntityDTO(E entity, D dto, BackendBulkDataProvider dataProvider, String noteTypeVocabularyTermSet) {
+	public E validateGenomicEntityDTO(E entity, D dto, Species species, String noteTypeVocabularyTermSet) {
 
-		entity = validateBiologicalEntityDTO(entity, dto, dataProvider, noteTypeVocabularyTermSet);
+		entity = validateBiologicalEntityDTO(entity, dto, species, noteTypeVocabularyTermSet);
 		
 		List<CrossReference> validatedXrefs = new ArrayList<>();
 		if (CollectionUtils.isNotEmpty(dto.getCrossReferenceDtos())) {

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/AGMPhenotypeAnnotationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/AGMPhenotypeAnnotationFmsDTOValidator.java
@@ -7,7 +7,7 @@ import java.util.Set;
 
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.dao.AGMPhenotypeAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
@@ -40,7 +40,7 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 
 	private HashMap<String, Long> genomicEntityIdCache = new HashMap<>();
 
-	public AGMPhenotypeAnnotation validatePrimaryAnnotation(AffectedGenomicModel subject, PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider) throws ObjectValidationException {
+	public AGMPhenotypeAnnotation validatePrimaryAnnotation(AffectedGenomicModel subject, PhenotypeFmsDTO dto, Species species) throws ObjectValidationException {
 
 		ObjectResponse<AGMPhenotypeAnnotation> apaResponse = new ObjectResponse<AGMPhenotypeAnnotation>();
 		AGMPhenotypeAnnotation annotation = new AGMPhenotypeAnnotation();
@@ -67,7 +67,7 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 		annotation.setInferredAllele(null);
 		annotation.setInferredGene(null);
 
-		ObjectResponse<AGMPhenotypeAnnotation> paResponse = validatePhenotypeAnnotation(annotation, dto, dataProvider);
+		ObjectResponse<AGMPhenotypeAnnotation> paResponse = validatePhenotypeAnnotation(annotation, dto, species);
 		apaResponse.addErrorMessages(paResponse.getErrorMessages());
 		annotation = paResponse.getEntity();
 
@@ -79,7 +79,7 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 
 	}
 
-	public List<AGMPhenotypeAnnotation> validateInferredOrAssertedEntities(AffectedGenomicModel primaryAnnotationSubject, PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider, Set<Long> idsAdded) throws ValidationException {
+	public List<AGMPhenotypeAnnotation> validateInferredOrAssertedEntities(AffectedGenomicModel primaryAnnotationSubject, PhenotypeFmsDTO dto, Species species, Set<Long> idsAdded) throws ValidationException {
 		// Fast skip: check if the inferred gene/allele is already set using pre-loaded maps only
 		if (existingUniqueIds != null && StringUtils.isNotBlank(dto.getObjectId())) {
 			ObjectResponse<InformationContentEntity> quickRefResponse = validateReference(dto);
@@ -93,10 +93,10 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 					});
 					if (objectEntityId != null) {
 						boolean alreadySet = false;
-						if (dataProvider.hasInferredGenePhenotypeAnnotations && inferredGeneIds != null) {
+						if (species.getDataProvider().getHasInferredGenePhenotypeAnnotations() && inferredGeneIds != null) {
 							Long existingId = inferredGeneIds.get(uniqueId);
 							alreadySet = existingId != null && existingId.equals(objectEntityId);
-						} else if (dataProvider.hasInferredAllelePhenotypeAnnotations && inferredAlleleIds != null) {
+						} else if (species.getDataProvider().getHasInferredAllelePhenotypeAnnotations() && inferredAlleleIds != null) {
 							Long existingId = inferredAlleleIds.get(uniqueId);
 							alreadySet = existingId != null && existingId.equals(objectEntityId);
 						}
@@ -122,7 +122,7 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 		if (CollectionUtils.isEmpty(primaryAnnotations)) {
 			PhenotypeFmsDTO inferredPrimaryDTO = createPrimaryAnnotationDTO(dto, primaryAnnotationSubject.getIdentifier());
 			try {
-				Long createdPrimaryAnnotationId = phenotypeAnnotationService.upsertPrimaryAnnotation(inferredPrimaryDTO, dataProvider);
+				Long createdPrimaryAnnotationId = phenotypeAnnotationService.upsertPrimaryAnnotation(inferredPrimaryDTO, species);
 				idsAdded.add(createdPrimaryAnnotationId);
 				AGMPhenotypeAnnotation primaryAnnotation = agmPhenotypeAnnotationDAO.find(createdPrimaryAnnotationId);
 				primaryAnnotations = List.of(primaryAnnotation);
@@ -142,12 +142,12 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 			} else if (inferredOrAssertedEntity instanceof Gene) {
 				boolean alreadySet = true;
 				for (AGMPhenotypeAnnotation primaryAnnotation : primaryAnnotations) {
-					if (dataProvider.hasInferredGenePhenotypeAnnotations) {
+					if (species.getDataProvider().getHasInferredGenePhenotypeAnnotations()) {
 						if (primaryAnnotation.getInferredGene() == null || !primaryAnnotation.getInferredGene().getId().equals(inferredOrAssertedEntity.getId())) {
 							alreadySet = false;
 							break;
 						}
-					} else if (dataProvider.hasAssertedGenePhenotypeAnnotations) {
+					} else if (species.getDataProvider().getHasAssertedGenePhenotypeAnnotations()) {
 						if (primaryAnnotation.getAssertedGenes() == null || primaryAnnotation.getAssertedGenes().stream().noneMatch(g -> g.getId().equals(inferredOrAssertedEntity.getId()))) {
 							alreadySet = false;
 							break;
@@ -157,11 +157,11 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 				if (alreadySet) {
 					return new ArrayList<>();
 				}
-				Gene inferredOrAssertedGene = xrefHelper.addGenePhenotypeCrossReference(dataProvider, (Gene) inferredOrAssertedEntity);
+				Gene inferredOrAssertedGene = xrefHelper.addGenePhenotypeCrossReference(species, (Gene) inferredOrAssertedEntity);
 				for (AGMPhenotypeAnnotation primaryAnnotation : primaryAnnotations) {
-					if (dataProvider.hasInferredGenePhenotypeAnnotations) {
+					if (species.getDataProvider().getHasInferredGenePhenotypeAnnotations()) {
 						primaryAnnotation.setInferredGene(inferredOrAssertedGene);
-					} else if (dataProvider.hasAssertedGenePhenotypeAnnotations) {
+					} else if (species.getDataProvider().getHasAssertedGenePhenotypeAnnotations()) {
 						List<Gene> assertedGenes = primaryAnnotation.getAssertedGenes();
 						if (assertedGenes == null) {
 							assertedGenes = new ArrayList<>();
@@ -175,12 +175,12 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 			} else if (inferredOrAssertedEntity instanceof Allele) {
 				boolean alreadySet = true;
 				for (AGMPhenotypeAnnotation primaryAnnotation : primaryAnnotations) {
-					if (dataProvider.hasInferredAllelePhenotypeAnnotations) {
+					if (species.getDataProvider().getHasInferredAllelePhenotypeAnnotations()) {
 						if (primaryAnnotation.getInferredAllele() == null || !primaryAnnotation.getInferredAllele().getId().equals(inferredOrAssertedEntity.getId())) {
 							alreadySet = false;
 							break;
 						}
-					} else if (dataProvider.hasAssertedAllelePhenotypeAnnotations) {
+					} else if (species.getDataProvider().getHasAssertedAllelePhenotypeAnnotations()) {
 						if (primaryAnnotation.getAssertedAlleles() == null || primaryAnnotation.getAssertedAlleles().stream().noneMatch(a -> a.getId().equals(inferredOrAssertedEntity.getId()))) {
 							alreadySet = false;
 							break;
@@ -192,9 +192,9 @@ public class AGMPhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationFm
 				}
 				for (AGMPhenotypeAnnotation primaryAnnotation : primaryAnnotations) {
 					Allele inferredOrInsertedAllele = (Allele) inferredOrAssertedEntity;
-					if (dataProvider.hasInferredAllelePhenotypeAnnotations) {
+					if (species.getDataProvider().getHasInferredAllelePhenotypeAnnotations()) {
 						primaryAnnotation.setInferredAllele(inferredOrInsertedAllele);
-					} else if (dataProvider.hasAssertedAllelePhenotypeAnnotations) {
+					} else if (species.getDataProvider().getHasAssertedAllelePhenotypeAnnotations()) {
 						List<Allele> assertedAlleles = primaryAnnotation.getAssertedAlleles();
 						if (assertedAlleles == null) {
 							assertedAlleles = new ArrayList<>();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/AllelePhenotypeAnnotationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/AllelePhenotypeAnnotationFmsDTOValidator.java
@@ -7,7 +7,7 @@ import java.util.Set;
 
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.dao.AllelePhenotypeAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
@@ -39,7 +39,7 @@ public class AllelePhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotatio
 
 	private HashMap<String, Long> genomicEntityIdCache = new HashMap<>();
 
-	public AllelePhenotypeAnnotation validatePrimaryAnnotation(Allele subject, PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider) throws ObjectValidationException {
+	public AllelePhenotypeAnnotation validatePrimaryAnnotation(Allele subject, PhenotypeFmsDTO dto, Species species) throws ObjectValidationException {
 
 		ObjectResponse<AllelePhenotypeAnnotation> apaResponse = new ObjectResponse<AllelePhenotypeAnnotation>();
 		AllelePhenotypeAnnotation annotation = new AllelePhenotypeAnnotation();
@@ -64,7 +64,7 @@ public class AllelePhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotatio
 		annotation.setAssertedGenes(null);
 		annotation.setInferredGene(null);
 
-		ObjectResponse<AllelePhenotypeAnnotation> paResponse = validatePhenotypeAnnotation(annotation, dto, dataProvider);
+		ObjectResponse<AllelePhenotypeAnnotation> paResponse = validatePhenotypeAnnotation(annotation, dto, species);
 		apaResponse.addErrorMessages(paResponse.getErrorMessages());
 		annotation = paResponse.getEntity();
 
@@ -76,9 +76,9 @@ public class AllelePhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotatio
 
 	}
 
-	public List<AllelePhenotypeAnnotation> validateInferredOrAssertedEntities(Allele primaryAnnotationSubject, PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider, Set<Long> idsAdded) throws ValidationException {
+	public List<AllelePhenotypeAnnotation> validateInferredOrAssertedEntities(Allele primaryAnnotationSubject, PhenotypeFmsDTO dto, Species species, Set<Long> idsAdded) throws ValidationException {
 		// Fast skip: check if the inferred gene is already set using pre-loaded maps only
-		if (existingUniqueIds != null && inferredGeneIds != null && dataProvider.hasInferredGenePhenotypeAnnotations && StringUtils.isNotBlank(dto.getObjectId())) {
+		if (existingUniqueIds != null && inferredGeneIds != null && species.getDataProvider().getHasInferredGenePhenotypeAnnotations() && StringUtils.isNotBlank(dto.getObjectId())) {
 			ObjectResponse<InformationContentEntity> quickRefResponse = validateReference(dto);
 			if (!quickRefResponse.hasErrors()) {
 				String quickRefString = quickRefResponse.getEntity() != null ? quickRefResponse.getEntity().getCurie() : null;
@@ -111,7 +111,7 @@ public class AllelePhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotatio
 
 			PhenotypeFmsDTO inferredPrimaryDTO = createPrimaryAnnotationDTO(dto, primaryAnnotationSubject.getIdentifier());
 			try {
-				Long createdPrimaryAnnotationId = phenotypeAnnotationService.upsertPrimaryAnnotation(inferredPrimaryDTO, dataProvider);
+				Long createdPrimaryAnnotationId = phenotypeAnnotationService.upsertPrimaryAnnotation(inferredPrimaryDTO, species);
 				idsAdded.add(createdPrimaryAnnotationId);
 				AllelePhenotypeAnnotation primaryAnnotation = allelePhenotypeAnnotationDAO.find(createdPrimaryAnnotationId);
 				primaryAnnotations = List.of(primaryAnnotation);
@@ -131,12 +131,12 @@ public class AllelePhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotatio
 			} else if (inferredOrAssertedEntity instanceof Gene) {
 				boolean alreadySet = true;
 				for (AllelePhenotypeAnnotation primaryAnnotation : primaryAnnotations) {
-					if (dataProvider.hasInferredGenePhenotypeAnnotations) {
+					if (species.getDataProvider().getHasInferredGenePhenotypeAnnotations()) {
 						if (primaryAnnotation.getInferredGene() == null || !primaryAnnotation.getInferredGene().getId().equals(inferredOrAssertedEntity.getId())) {
 							alreadySet = false;
 							break;
 						}
-					} else if (dataProvider.hasAssertedGenePhenotypeAnnotations) {
+					} else if (species.getDataProvider().getHasAssertedGenePhenotypeAnnotations()) {
 						if (primaryAnnotation.getAssertedGenes() == null || primaryAnnotation.getAssertedGenes().stream().noneMatch(g -> g.getId().equals(inferredOrAssertedEntity.getId()))) {
 							alreadySet = false;
 							break;
@@ -146,11 +146,11 @@ public class AllelePhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotatio
 				if (alreadySet) {
 					return new ArrayList<>();
 				}
-				Gene inferredOrAssertedGene = xrefHelper.addGenePhenotypeCrossReference(dataProvider, (Gene) inferredOrAssertedEntity);
+				Gene inferredOrAssertedGene = xrefHelper.addGenePhenotypeCrossReference(species, (Gene) inferredOrAssertedEntity);
 				for (AllelePhenotypeAnnotation primaryAnnotation : primaryAnnotations) {
-					if (dataProvider.hasInferredGenePhenotypeAnnotations) {
+					if (species.getDataProvider().getHasInferredGenePhenotypeAnnotations()) {
 						primaryAnnotation.setInferredGene(inferredOrAssertedGene);
-					} else if (dataProvider.hasAssertedGenePhenotypeAnnotations) {
+					} else if (species.getDataProvider().getHasAssertedGenePhenotypeAnnotations()) {
 						List<Gene> assertedGenes = primaryAnnotation.getAssertedGenes();
 						if (assertedGenes == null) {
 							assertedGenes = new ArrayList<>();

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GeneExpressionAnnotationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GeneExpressionAnnotationFmsDTOValidator.java
@@ -11,7 +11,7 @@ import java.util.Set;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.GeneExpressionAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.AnatomicalSite;
@@ -70,7 +70,7 @@ public class GeneExpressionAnnotationFmsDTOValidator {
 	@Inject OntologyTermService ontologyTermService;
 	@Inject CrossReferenceFmsDTOValidator crossReferenceFmsDTOValidator;
 
-	public ObjectResponse<GeneExpressionAnnotation> validateAnnotation(ConsolidatedGeneExpressionFmsDTO consolidatedGeneExpressionFmsDTO, BackendBulkDataProvider dataProvider, Map<String, Set<String>> experiments, Map<String, Set<CrossReferenceFmsDTO>> crossReferences) throws ValidationException {
+	public ObjectResponse<GeneExpressionAnnotation> validateAnnotation(ConsolidatedGeneExpressionFmsDTO consolidatedGeneExpressionFmsDTO, Species species, Map<String, Set<String>> experiments, Map<String, Set<CrossReferenceFmsDTO>> crossReferences) throws ValidationException {
 		ObjectResponse<GeneExpressionAnnotation> response = new ObjectResponse<>();
 		GeneExpressionAnnotation geneExpressionAnnotation = new GeneExpressionAnnotation();
 		String uniqueId = "empty";
@@ -95,7 +95,7 @@ public class GeneExpressionAnnotationFmsDTOValidator {
 			geneExpressionAnnotation.setExpressionPattern(new ExpressionPattern());
 		}
 
-		if (dataProvider.name().equals("ZFIN")) {
+		if (species.getDisplayName().equals("ZFIN")) {
 			if (ObjectUtils.isNotEmpty(consolidatedGeneExpressionFmsDTO.getCrossReferences())) {
 				Set<CrossReference> validatedCrossRefs = new HashSet<>();
 				for (CrossReferenceFmsDTO crossRefDto : consolidatedGeneExpressionFmsDTO.getCrossReferences()) {
@@ -168,7 +168,7 @@ public class GeneExpressionAnnotationFmsDTOValidator {
 			geneExpressionAnnotation.getExpressionPattern().setWhenExpressed(temporalContext);
 		}
 
-		geneExpressionAnnotation.setDataProvider(organizationService.getByAbbr(dataProvider.sourceOrganization).getEntity());
+		geneExpressionAnnotation.setDataProvider(organizationService.getByAbbr(species.getDataProvider().getAbbreviation()).getEntity());
 		geneExpressionAnnotation.setRelation(vocabularyTermService.getTermInVocabulary(VocabularyConstants.GENE_EXPRESSION_VOCABULARY, VocabularyConstants.GENE_EXPRESSION_RELATION_TERM).getEntity());
 		geneExpressionAnnotation.setObsolete(false);
 		geneExpressionAnnotation.setInternal(false);
@@ -184,7 +184,7 @@ public class GeneExpressionAnnotationFmsDTOValidator {
 			expressionIds.add(uniqueId);
 			experiments.put(experimentId, expressionIds);
 		}
-		if (dataProvider.name().equals("WB") || dataProvider.name().equals("MGI")) {
+		if (species.getDisplayName().equals("WB") || species.getDisplayName().equals("MGI")) {
 			if (crossReferences.containsKey(experimentId)) {
 				crossReferences.get(experimentId).addAll(consolidatedGeneExpressionFmsDTO.getCrossReferences());
 			} else {

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GeneInteractionFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GeneInteractionFmsDTOValidator.java
@@ -10,7 +10,6 @@ import java.util.Objects;
 
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.dao.CrossReferenceDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.enums.PsiMiTabPrefixEnum;
 import org.alliancegenome.curation_api.model.entities.CrossReference;
 import org.alliancegenome.curation_api.model.entities.Gene;
@@ -206,8 +205,9 @@ public class GeneInteractionFmsDTOValidator extends BaseDTOValidator {
 				if (searchResponse != null) {
 					for (Gene searchResult : searchResponse.getResults()) {
 						if (!searchResult.getObsolete()) {
-							String resultDataProviderCoreGenus = BackendBulkDataProvider.getCoreGenus(searchResult.getDataProvider().getAbbreviation());
-							if (taxon.getName().startsWith(resultDataProviderCoreGenus + " ")) {
+							String resultGeneTaxonGenus = searchResult.getTaxon() != null && searchResult.getTaxon().getName() != null
+								? searchResult.getTaxon().getName().substring(0, searchResult.getTaxon().getName().indexOf(" ")) : null;
+							if (resultGeneTaxonGenus != null && taxon.getName().startsWith(resultGeneTaxonGenus + " ")) {
 								allianceGene = searchResult;
 								break;
 							}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GenePhenotypeAnnotationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/GenePhenotypeAnnotationFmsDTOValidator.java
@@ -1,7 +1,7 @@
 package org.alliancegenome.curation_api.services.validation.dto.fms;
 
 import org.alliancegenome.curation_api.dao.GenePhenotypeAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.Gene;
@@ -28,7 +28,7 @@ public class GenePhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationF
 	@Inject GenePhenotypeAnnotationXrefHelper xrefHelper;
 	
 	@Transactional
-	public GenePhenotypeAnnotation validatePrimaryAnnotation(Gene subject, PhenotypeFmsDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public GenePhenotypeAnnotation validatePrimaryAnnotation(Gene subject, PhenotypeFmsDTO dto, Species species) throws ValidationException {
 
 		ObjectResponse<GenePhenotypeAnnotation> apaResponse = new ObjectResponse<GenePhenotypeAnnotation>();
 		GenePhenotypeAnnotation annotation = new GenePhenotypeAnnotation();
@@ -45,13 +45,13 @@ public class GenePhenotypeAnnotationFmsDTOValidator extends PhenotypeAnnotationF
 			annotation = annotationSearch.getSingleResult();
 		}
 
-		subject = xrefHelper.addGenePhenotypeCrossReference(dataProvider, subject);
+		subject = xrefHelper.addGenePhenotypeCrossReference(species, subject);
 		
 		annotation.setUniqueId(uniqueId);
 		annotation.setEvidenceItem(reference);
 		annotation.setPhenotypeAnnotationSubject(subject);
 
-		ObjectResponse<GenePhenotypeAnnotation> paResponse = validatePhenotypeAnnotation(annotation, dto, dataProvider);
+		ObjectResponse<GenePhenotypeAnnotation> paResponse = validatePhenotypeAnnotation(annotation, dto, species);
 		apaResponse.addErrorMessages(paResponse.getErrorMessages());
 		annotation = paResponse.getEntity();
 

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/HTPExpressionDatasetAnnotationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/HTPExpressionDatasetAnnotationFmsDTOValidator.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.HTPExpressionDatasetAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.ExternalDataBaseEntity;
@@ -43,7 +43,7 @@ public class HTPExpressionDatasetAnnotationFmsDTOValidator {
 	@Inject OrganizationService organizationService;
 	
 	@Transactional
-	public ObjectResponse<HTPExpressionDatasetAnnotation> validateHTPExpressionDatasetAnnotationFmsDTO(HTPExpressionDatasetAnnotationFmsDTO dto, BackendBulkDataProvider backendBulkDataProvider) throws ValidationException {
+	public ObjectResponse<HTPExpressionDatasetAnnotation> validateHTPExpressionDatasetAnnotationFmsDTO(HTPExpressionDatasetAnnotationFmsDTO dto, Species species) throws ValidationException {
 		ObjectResponse<HTPExpressionDatasetAnnotation> htpAnnotationResponse = new ObjectResponse<>();
 
 		HTPExpressionDatasetAnnotation htpannotation;
@@ -164,7 +164,7 @@ public class HTPExpressionDatasetAnnotationFmsDTOValidator {
 			htpannotation.setRelatedNote(null);
 		}
 
-		htpannotation.setDataProvider(organizationService.getByAbbr(backendBulkDataProvider.sourceOrganization).getEntity());
+		htpannotation.setDataProvider(organizationService.getByAbbr(species.getDataProvider().getAbbreviation()).getEntity());
 
 		if (htpAnnotationResponse.hasErrors()) {
 			throw new ObjectValidationException(dto, htpAnnotationResponse.errorMessagesString());

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/HTPExpressionDatasetSampleAnnotationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/HTPExpressionDatasetSampleAnnotationFmsDTOValidator.java
@@ -9,7 +9,7 @@ import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.AnatomicalSiteDAO;
 import org.alliancegenome.curation_api.dao.HTPExpressionDatasetSampleAnnotationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
@@ -64,7 +64,7 @@ public class HTPExpressionDatasetSampleAnnotationFmsDTOValidator {
 	@Inject AnatomicalSiteDAO anatomicalSiteDAO;
 
 	@Transactional
-	public ObjectResponse<HTPExpressionDatasetSampleAnnotation> validateHTPExpressionDatasetSampleAnnotationFmsDTO(HTPExpressionDatasetSampleAnnotationFmsDTO dto, BackendBulkDataProvider backendBulkDataProvider) throws ValidationException {
+	public ObjectResponse<HTPExpressionDatasetSampleAnnotation> validateHTPExpressionDatasetSampleAnnotationFmsDTO(HTPExpressionDatasetSampleAnnotationFmsDTO dto, Species species) throws ValidationException {
 		ObjectResponse<HTPExpressionDatasetSampleAnnotation> htpSampleAnnotationResponse = new ObjectResponse<>();
 		HTPExpressionDatasetSampleAnnotation htpSampleAnnotation;
 
@@ -242,8 +242,8 @@ public class HTPExpressionDatasetSampleAnnotationFmsDTOValidator {
 
 		if (StringUtils.isNotEmpty(dto.getTaxonId())) {
 			ObjectResponse<NCBITaxonTerm> taxonResponse = ncbiTaxonTermService.getByCurie(dto.getTaxonId());
-			if (taxonResponse.getEntity() == null || backendBulkDataProvider != null && (backendBulkDataProvider.name().equals("RGD") || backendBulkDataProvider.name().equals("HUMAN")) && !taxonResponse.getEntity().getCurie().equals(backendBulkDataProvider.canonicalTaxonCurie)) {
-				htpSampleAnnotationResponse.addErrorMessage("taxonId", ValidationConstants.INVALID_MESSAGE + " (" + dto.getTaxonId() + ") for " + backendBulkDataProvider.name() + " load");
+			if (taxonResponse.getEntity() == null || species != null && (species.getDisplayName().equals("RGD") || species.getDisplayName().equals("HUMAN")) && !taxonResponse.getEntity().getCurie().equals(species.getTaxon().getCurie())) {
+				htpSampleAnnotationResponse.addErrorMessage("taxonId", ValidationConstants.INVALID_MESSAGE + " (" + dto.getTaxonId() + ") for " + species.getDisplayName() + " load");
 			}
 			htpSampleAnnotation.setTaxon(taxonResponse.getEntity());
 		}
@@ -269,7 +269,7 @@ public class HTPExpressionDatasetSampleAnnotationFmsDTOValidator {
 			htpSampleAnnotation.setRelatedNotes(relatedNotes);
 		}
 		
-		htpSampleAnnotation.setDataProvider(organizationService.getByAbbr(backendBulkDataProvider.sourceOrganization).getEntity());
+		htpSampleAnnotation.setDataProvider(organizationService.getByAbbr(species.getDataProvider().getAbbreviation()).getEntity());
 
 		if (htpSampleAnnotationResponse.hasErrors()) {
 			throw new ObjectValidationException(dto, htpSampleAnnotationResponse.errorMessagesString());

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/OrthologyFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/OrthologyFmsDTOValidator.java
@@ -9,7 +9,7 @@ import java.util.Set;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.orthology.GeneToGeneOrthologyGeneratedDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
@@ -21,6 +21,7 @@ import org.alliancegenome.curation_api.model.ingest.dto.fms.OrthologyFmsDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.GeneService;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.alliancegenome.curation_api.services.VocabularyTermService;
 import org.alliancegenome.curation_api.services.ontology.NcbiTaxonTermService;
 import org.apache.commons.collections.CollectionUtils;
@@ -55,6 +56,7 @@ public class OrthologyFmsDTOValidator {
 	@Inject GeneToGeneOrthologyGeneratedDAO generatedOrthologyDAO;
 	@Inject GeneService geneService;
 	@Inject NcbiTaxonTermService ncbiTaxonTermService;
+	@Inject SpeciesService speciesService;
 	@Inject VocabularyTermService vocabularyTermService;
 
 	@Transactional
@@ -255,7 +257,8 @@ public class OrthologyFmsDTOValidator {
 	private String convertToModCurie(String curie, Integer taxonId) {
 		curie = curie.replaceFirst("^DRSC:", "");
 		if (curie.indexOf(":") == -1) {
-			String prefix = BackendBulkDataProvider.getCuriePrefixFromTaxonId(taxonId);
+			Species sp = speciesService.getByTaxonCurie("NCBITaxon:" + taxonId);
+			String prefix = (sp != null) ? sp.getDataProvider().getAbbreviation() + ":" : null;
 			if (prefix != null) {
 				curie = prefix + curie;
 			}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/ParalogyFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/ParalogyFmsDTOValidator.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.GeneToGeneParalogyDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.Gene;
@@ -19,6 +19,7 @@ import org.alliancegenome.curation_api.model.ingest.dto.fms.ParalogyFmsDTO;
 import org.alliancegenome.curation_api.response.ObjectResponse;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.GeneService;
+import org.alliancegenome.curation_api.services.SpeciesService;
 import org.alliancegenome.curation_api.services.VocabularyTermService;
 import org.alliancegenome.curation_api.services.ontology.NcbiTaxonTermService;
 import org.apache.commons.collections.CollectionUtils;
@@ -34,6 +35,7 @@ public class ParalogyFmsDTOValidator {
 	@Inject GeneToGeneParalogyDAO genetoGeneParalogyDAO;
 	@Inject GeneService geneService;
 	@Inject NcbiTaxonTermService ncbiTaxonTermService;
+	@Inject SpeciesService speciesService;
 	@Inject VocabularyTermService vocabularyTermService;
 
 	@Transactional
@@ -193,7 +195,8 @@ public class ParalogyFmsDTOValidator {
 	private String convertToModCurie(String curie, Integer taxonId) {
 		curie = curie.replaceFirst("^DRSC:", "");
 		if (curie.indexOf(":") == -1) {
-			String prefix = BackendBulkDataProvider.getCuriePrefixFromTaxonId(taxonId);
+			Species sp = speciesService.getByTaxonCurie("NCBITaxon:" + taxonId);
+			String prefix = (sp != null) ? sp.getDataProvider().getAbbreviation() + ":" : null;
 			if (prefix != null) {
 				curie = prefix + curie;
 			}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/PhenotypeAnnotationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/PhenotypeAnnotationFmsDTOValidator.java
@@ -14,7 +14,7 @@ import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.ConditionRelationDAO;
 import org.alliancegenome.curation_api.dao.ExternalDatabaseReferenceDAO;
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.ConditionRelation;
 import org.alliancegenome.curation_api.model.entities.ExternalDatabaseReference;
 import org.alliancegenome.curation_api.model.entities.InformationContentEntity;
@@ -66,7 +66,7 @@ public class PhenotypeAnnotationFmsDTOValidator {
 		this.inferredAlleleIds = inferredAlleleIds;
 	}
 
-	public <E extends PhenotypeAnnotation> ObjectResponse<E> validatePhenotypeAnnotation(E annotation, PhenotypeFmsDTO dto, BackendBulkDataProvider beDataProvider) {
+	public <E extends PhenotypeAnnotation> ObjectResponse<E> validatePhenotypeAnnotation(E annotation, PhenotypeFmsDTO dto, Species beSpecies) {
 
 		ObjectResponse<E> paResponse = new ObjectResponse<E>();
 
@@ -105,7 +105,7 @@ public class PhenotypeAnnotationFmsDTOValidator {
 			annotation.setConditionRelations(null);
 		}
 
-		annotation.setDataProvider(organizationService.getByAbbr(beDataProvider.sourceOrganization).getEntity());
+		annotation.setDataProvider(organizationService.getByAbbr(beSpecies.getDataProvider().getAbbreviation()).getEntity());
 		annotation.setRelation(vocabularyTermService.getTermInVocabulary(VocabularyConstants.PHENOTYPE_RELATION_VOCABULARY, "has_phenotype").getEntity());
 
 		OffsetDateTime creationDate = null;

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/SequenceTargetingReagentFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/SequenceTargetingReagentFmsDTOValidator.java
@@ -2,7 +2,7 @@ package org.alliancegenome.curation_api.services.validation.dto.fms;
 
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.dao.SequenceTargetingReagentDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
 import org.alliancegenome.curation_api.model.entities.SequenceTargetingReagent;
@@ -36,7 +36,7 @@ public class SequenceTargetingReagentFmsDTOValidator {
 	@Inject VocabularyTermService vocabularyTermService;
 
 
-	public ObjectResponse<SequenceTargetingReagent> validateStrFmsDTO(SequenceTargetingReagentFmsDTO dto, BackendBulkDataProvider beDataProvider) throws ValidationException {
+	public ObjectResponse<SequenceTargetingReagent> validateStrFmsDTO(SequenceTargetingReagentFmsDTO dto, Species beSpecies) throws ValidationException {
 		ObjectResponse<SequenceTargetingReagent> sqtrResponse = new ObjectResponse<>();
 		
 		SequenceTargetingReagent sqtr;
@@ -68,8 +68,8 @@ public class SequenceTargetingReagentFmsDTOValidator {
 			if (taxonResponse.getEntity() == null) {
 				sqtrResponse.addErrorMessage("taxonId", ValidationConstants.INVALID_MESSAGE + " (" + dto.getTaxonId() + ")");
 			}
-			if (beDataProvider != null && (beDataProvider.name().equals("RGD") || beDataProvider.name().equals("HUMAN")) && !taxonResponse.getEntity().getCurie().equals(beDataProvider.canonicalTaxonCurie)) {
-				sqtrResponse.addErrorMessage("taxonId", ValidationConstants.INVALID_MESSAGE + " (" + dto.getTaxonId() + ") for " + beDataProvider.name() + " load");
+			if (beSpecies != null && (beSpecies.getDisplayName().equals("RGD") || beSpecies.getDisplayName().equals("HUMAN")) && !taxonResponse.getEntity().getCurie().equals(beSpecies.getTaxon().getCurie())) {
+				sqtrResponse.addErrorMessage("taxonId", ValidationConstants.INVALID_MESSAGE + " (" + dto.getTaxonId() + ") for " + beSpecies.getDisplayName() + " load");
 			}
 			sqtr.setTaxon(taxonResponse.getEntity());
 		}
@@ -86,8 +86,8 @@ public class SequenceTargetingReagentFmsDTOValidator {
 			sqtr.setSecondaryIdentifiers(null);
 		}
 		
-		if (beDataProvider != null) {
-			sqtr.setDataProvider(organizationService.getByAbbr(beDataProvider.sourceOrganization).getEntity());
+		if (beSpecies != null) {
+			sqtr.setDataProvider(beSpecies.getDataProvider());
 		}
 		
 		if (sqtrResponse.hasErrors()) {

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/SequenceTargetingReagentGeneAssociationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/SequenceTargetingReagentGeneAssociationFmsDTOValidator.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.alliancegenome.curation_api.constants.ValidationConstants;
 import org.alliancegenome.curation_api.dao.SequenceTargetingReagentDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.SequenceTargetingReagent;
@@ -29,7 +28,7 @@ public class SequenceTargetingReagentGeneAssociationFmsDTOValidator {
 	@Inject
 	GeneService geneService;
 
-	public List<SequenceTargetingReagentGeneAssociation> validateSQTRGeneAssociationFmsDTO(SequenceTargetingReagentFmsDTO dto, BackendBulkDataProvider beDataProvider) throws ObjectValidationException {
+	public List<SequenceTargetingReagentGeneAssociation> validateSQTRGeneAssociationFmsDTO(SequenceTargetingReagentFmsDTO dto) throws ObjectValidationException {
 		List<SequenceTargetingReagentGeneAssociation> strGeneAssociations = new ArrayList<>();
 		ObjectResponse<SequenceTargetingReagent> sqtrResponse = new ObjectResponse<>();
 

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/VariantFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/VariantFmsDTOValidator.java
@@ -15,7 +15,7 @@ import org.alliancegenome.curation_api.dao.NoteDAO;
 import org.alliancegenome.curation_api.dao.VariantDAO;
 import org.alliancegenome.curation_api.dao.associations.AlleleVariantAssociationDAO;
 import org.alliancegenome.curation_api.dao.associations.CuratedVariantGenomicLocationAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.enums.ChromosomeAccessionEnum;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
@@ -76,7 +76,7 @@ public class VariantFmsDTOValidator {
 	@Inject ReferenceService referenceService;
 
 	@Transactional
-	public Long validateVariant(VariantFmsDTO dto, List<Long> idsAdded, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public Long validateVariant(VariantFmsDTO dto, List<Long> idsAdded, Species species) throws ValidationException {
 
 		ObjectResponse<Variant> variantResponse = new ObjectResponse<Variant>();
 		Variant variant = new Variant();
@@ -128,8 +128,8 @@ public class VariantFmsDTOValidator {
 
 		variant.setModInternalId(modInternalId);
 		variant.setVariantType(variantType);
-		variant.setDataProvider(organizationService.getByAbbr(dataProvider.name()).getEntity());
-		variant.setTaxon(ncbiTaxonTermService.getByCurie(dataProvider.canonicalTaxonCurie).getEntity());
+		variant.setDataProvider(organizationService.getByAbbr(species.getDisplayName()).getEntity());
+		variant.setTaxon(ncbiTaxonTermService.getByCurie(species.getTaxon().getCurie()).getEntity());
 
 		SOTerm consequence = null;
 		if (StringUtils.isNotBlank(dto.getConsequence())) {

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/VepTranscriptFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/VepTranscriptFmsDTOValidator.java
@@ -13,7 +13,7 @@ import org.alliancegenome.curation_api.constants.VocabularyConstants;
 import org.alliancegenome.curation_api.dao.PredictedVariantConsequenceDAO;
 import org.alliancegenome.curation_api.dao.TranscriptDAO;
 import org.alliancegenome.curation_api.dao.associations.CuratedVariantGenomicLocationAssociationDAO;
-import org.alliancegenome.curation_api.enums.BackendBulkDataProvider;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.exceptions.KnownIssueValidationException;
 import org.alliancegenome.curation_api.exceptions.ObjectValidationException;
 import org.alliancegenome.curation_api.exceptions.ValidationException;
@@ -49,7 +49,7 @@ public class VepTranscriptFmsDTOValidator {
 	private static final Pattern PATHOGENICITY_PREDICTION_RESULT = Pattern.compile("^([\\w]+)\\(([\\d\\.]+)\\)$");
 	private static final Pattern POSITION_STRING = Pattern.compile("^[\\d\\?\\-]+$");
 	
-	public ObjectResponse<PredictedVariantConsequence> validateTranscriptLevelConsequence(VepTxtDTO dto, BackendBulkDataProvider dataProvider) throws ValidationException {
+	public ObjectResponse<PredictedVariantConsequence> validateTranscriptLevelConsequence(VepTxtDTO dto, Species species) throws ValidationException {
 		ObjectResponse<PredictedVariantConsequence> response = new ObjectResponse<>();
 		PredictedVariantConsequence predictedVariantConsequence = new PredictedVariantConsequence();
 

--- a/src/test/java/org/alliancegenome/curation_api/IT_0101_GeneBulkUploadITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_0101_GeneBulkUploadITCase.java
@@ -74,6 +74,16 @@ public class IT_0101_GeneBulkUploadITCase extends BaseITCase {
 		Vocabulary noteTypeVocab = getVocabulary("note_type");
 		noteTypeVocabTerm = getVocabularyTerm(noteTypeVocab, noteType);
 		createVocabularyTermSet(VocabularyConstants.GENE_NOTE_TYPES_VOCABULARY_TERM_SET, noteTypeVocab, List.of(noteTypeVocabTerm));
+		createNCBITaxonTerm("NCBITaxon:6239", "Caenorhabditis elegans", false);
+		createNCBITaxonTerm("NCBITaxon:10116", "Rattus norvegicus", false);
+		createNCBITaxonTerm("NCBITaxon:9606", "Homo sapiens", false);
+		createNCBITaxonTerm("NCBITaxon:7955", "Danio rerio", false);
+		createNCBITaxonTerm("NCBITaxon:7227", "Drosophila melanogaster", false);
+		createSpecies("WB", "NCBITaxon:6239", "WB");
+		createSpecies("RGD", "NCBITaxon:10116", "RGD");
+		createSpecies("HUMAN", "NCBITaxon:9606", "RGD");
+		createSpecies("ZFIN", "NCBITaxon:7955", "ZFIN");
+		createSpecies("FB", "NCBITaxon:7227", "FB");
 	}
 
 	@Test

--- a/src/test/java/org/alliancegenome/curation_api/IT_0603_PhenotypeAnnotationBulkUploadFmsITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_0603_PhenotypeAnnotationBulkUploadFmsITCase.java
@@ -215,7 +215,7 @@ public class IT_0603_PhenotypeAnnotationBulkUploadFmsITCase extends BaseITCase {
 	public void agmPhenotypeAnnotationAddSecondaryAnnotationFields() throws Exception {
 		// Tests that secondary annotations are added to primary annotations as
 		// asserted/inferred entities
-		// as dictated by rules in BackendBulkDataProvider
+		// as dictated by rules in Species entity configuration
 		checkSuccessfulBulkLoad(phenotypeAnnotationBulkPostEndpoint, phenotypeAnnotationTestFilePath
 				+ "AS_01_add_secondary_allele_annotation_to_primary_agm_annotation.json", 3);
 

--- a/src/test/java/org/alliancegenome/curation_api/base/BaseITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/base/BaseITCase.java
@@ -36,6 +36,7 @@ import org.alliancegenome.curation_api.model.entities.Reference;
 import org.alliancegenome.curation_api.model.entities.ResourceDescriptor;
 import org.alliancegenome.curation_api.model.entities.ResourceDescriptorPage;
 import org.alliancegenome.curation_api.model.entities.SequenceTargetingReagent;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.Variant;
 import org.alliancegenome.curation_api.model.entities.Vocabulary;
 import org.alliancegenome.curation_api.model.entities.VocabularyTerm;
@@ -835,6 +836,32 @@ public class BaseITCase {
 		return response.getEntity();
 	}
 
+	public Species createSpecies(String displayName, String taxonCurie, String organizationAbbreviation) {
+		NCBITaxonTerm taxon = new NCBITaxonTerm();
+		taxon.setCurie(taxonCurie);
+
+		Organization dataProvider = getOrganization(organizationAbbreviation);
+
+		Species species = new Species();
+		species.setDisplayName(displayName);
+		species.setFullName(displayName);
+		species.setAbbreviation(displayName);
+		species.setPhylogeneticOrder(0);
+		species.setTaxon(taxon);
+		species.setDataProvider(dataProvider);
+
+		ObjectResponse<Species> response = RestAssured.given().
+				contentType("application/json").
+				body(species).
+				when().
+				post("/api/species").
+				then().
+				statusCode(200).
+				extract().body().as(getObjectResponseTypeRefSpecies());
+
+		return response.getEntity();
+	}
+
 	public SOTerm createSoTerm(String curie, String name, Boolean obsolete) {
 		SOTerm term = new SOTerm();
 		term.setCurie(curie);
@@ -1341,6 +1368,11 @@ public class BaseITCase {
 
 	private TypeRef<ObjectResponse<SequenceTargetingReagent>> getObjectResponseTypeRefSequenceTargetingReagent() {
 		return new TypeRef<ObjectResponse<SequenceTargetingReagent>>() {
+		};
+	}
+
+	private TypeRef<ObjectResponse<Species>> getObjectResponseTypeRefSpecies() {
+		return new TypeRef<ObjectResponse<Species>>() {
 		};
 	}
 


### PR DESCRIPTION
Change BaseUpsertServiceInterface, LoadFileExecutor, BaseDTOCrudService, and all validator base classes from BackendBulkDataProvider to Species. Update all ~31 service upsert implementations, ~32 validators, and all executor execLoad methods to use bulkLoad.getSpecies() instead of BackendBulkDataProvider.valueOf(). DQMSubmissionController and BulkLoadManualProcessor now use Species from SpeciesService.

The BackendBulkDataProvider enum is kept for now and will be removed in a subsequent cleanup PR.