### PR TITLE
SCRUM-6220: fix and narrow disease-annotation autocompletes

### DIFF
--- a/src/main/cliapp/src/components/Editors/autocomplete/agm/utils.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/agm/utils.jsx
@@ -1,4 +1,4 @@
-import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/utils';
+import { buildAutocompleteFilter, autocompleteSearch, buildCuratorSpeciesFilter } from '../../../../utils/utils';
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
 import { SubjectAutocompleteTemplate } from '../base/templates/SubjectAutocompleteTemplate';
@@ -12,7 +12,8 @@ export const sgdStrainBackgroundSearchConfig = {
 	endpoint: Endpoints.Entity.AGM,
 	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig),
 	filterName: 'sgdStrainBackgroundFilter',
-	otherFilters: { taxonFilter: { 'taxon.name': { queryString: 'Saccharomyces cerevisiae' } } },
+	// SGD strain background is always S. cerevisiae S288C; match by taxon curie.
+	otherFilters: { taxonFilter: { 'taxon.curie': { queryString: 'NCBITaxon:559292', useKeywordFields: true } } },
 	valueDisplay: agmValueDisplay,
 };
 
@@ -20,6 +21,7 @@ export const diseaseGeneticModifierAgmsSearchConfig = {
 	endpoint: Endpoints.Entity.AGM,
 	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig),
 	filterName: 'geneticModifierAgmsFilter',
+	otherFilters: () => buildCuratorSpeciesFilter(),
 	valueDisplay: agmValueDisplay,
 };
 
@@ -27,7 +29,8 @@ const buildSearchFn = (config) => (event, setFiltered, setInputValue) => {
 	const searchService = new SearchService();
 	setInputValue(event.query);
 	const filter = buildAutocompleteFilter(event, config.autocompleteFields);
-	autocompleteSearch(searchService, config.endpoint, config.filterName, filter, setFiltered, config.otherFilters);
+	const otherFilters = typeof config.otherFilters === 'function' ? config.otherFilters() : config.otherFilters;
+	autocompleteSearch(searchService, config.endpoint, config.filterName, filter, setFiltered, otherFilters);
 };
 
 export const sgdStrainBackgroundSearch = buildSearchFn(sgdStrainBackgroundSearchConfig);

--- a/src/main/cliapp/src/components/Editors/autocomplete/allele/utils.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/allele/utils.jsx
@@ -1,4 +1,4 @@
-import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/utils';
+import { buildAutocompleteFilter, autocompleteSearch, buildCuratorSpeciesFilter } from '../../../../utils/utils';
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
 import { SubjectAutocompleteTemplate } from '../base/templates/SubjectAutocompleteTemplate';
@@ -12,6 +12,7 @@ export const assertedAllelesSearchConfig = {
 	endpoint: Endpoints.Entity.ALLELE,
 	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig),
 	filterName: 'assertedAllelesFilter',
+	otherFilters: () => buildCuratorSpeciesFilter(),
 	valueDisplay: alleleValueDisplay,
 };
 
@@ -19,6 +20,7 @@ export const diseaseGeneticModifierAllelesSearchConfig = {
 	endpoint: Endpoints.Entity.ALLELE,
 	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig),
 	filterName: 'geneticModifierAllelesFilter',
+	otherFilters: () => buildCuratorSpeciesFilter(),
 	valueDisplay: alleleValueDisplay,
 };
 
@@ -26,7 +28,8 @@ const buildSearchFn = (config) => (event, setFiltered, setInputValue) => {
 	const searchService = new SearchService();
 	setInputValue(event.query);
 	const filter = buildAutocompleteFilter(event, config.autocompleteFields);
-	autocompleteSearch(searchService, config.endpoint, config.filterName, filter, setFiltered, config.otherFilters);
+	const otherFilters = typeof config.otherFilters === 'function' ? config.otherFilters() : config.otherFilters;
+	autocompleteSearch(searchService, config.endpoint, config.filterName, filter, setFiltered, otherFilters);
 };
 
 export const assertedAllelesSearch = buildSearchFn(assertedAllelesSearchConfig);

--- a/src/main/cliapp/src/components/Editors/autocomplete/biologicalEntity/BiologicalEntityTableEditor.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/biologicalEntity/BiologicalEntityTableEditor.jsx
@@ -1,5 +1,5 @@
 import { AutocompleteSingleTableEditor } from '../base/AutocompleteSingleTableEditor';
-import { getIdentifier } from '../../../../utils/utils';
+import { getIdentifier, buildCuratorSpeciesFilter } from '../../../../utils/utils';
 import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../../constants/FilterFields';
 import { getBiologicalEntityEndpoint, biologicalEntityValueDisplay } from './utils';
 
@@ -9,8 +9,9 @@ export const BiologicalEntityTableEditor = ({ editorOptions, errorMessagesRef, u
 		field="diseaseAnnotationSubject"
 		subField="primaryExternalId"
 		endpoint={getBiologicalEntityEndpoint(editorOptions.rowData)}
-		autocompleteFields={getAutocompleteFields(AUTOCOMPLETE_CONFIGS.diseaseAnnotationSubjectAutocompleteConfig)}
+		autocompleteFields={getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig)}
 		filterName="diseaseAnnotationSubjectFilter"
+		otherFilters={buildCuratorSpeciesFilter}
 		initialValue={getIdentifier(editorOptions.rowData.diseaseAnnotationSubject)}
 		valueDisplay={biologicalEntityValueDisplay}
 		errorMessagesRef={errorMessagesRef}

--- a/src/main/cliapp/src/components/Editors/autocomplete/gene/utils.jsx
+++ b/src/main/cliapp/src/components/Editors/autocomplete/gene/utils.jsx
@@ -1,4 +1,4 @@
-import { buildAutocompleteFilter, autocompleteSearch } from '../../../../utils/utils';
+import { buildAutocompleteFilter, autocompleteSearch, buildCuratorSpeciesFilter } from '../../../../utils/utils';
 import { SearchService } from '../../../../service/SearchService';
 import { Endpoints } from '../../../../constants/Endpoints';
 import { SubjectAutocompleteTemplate } from '../base/templates/SubjectAutocompleteTemplate';
@@ -10,7 +10,7 @@ const geneValueDisplay = (item, setAutocompleteHoverItem, op, query) => (
 
 export const withSearchConfig = {
 	endpoint: Endpoints.Entity.GENE,
-	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig),
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.geneAutocompleteConfig),
 	filterName: 'withFilter',
 	otherFilters: { taxonFilter: { 'taxon.curie': { queryString: 'NCBITaxon:9606' } } },
 	valueDisplay: geneValueDisplay,
@@ -20,13 +20,15 @@ export const assertedGenesSearchConfig = {
 	endpoint: Endpoints.Entity.GENE,
 	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.assertedGenesAutocompleteConfig),
 	filterName: 'assertedGenesFilter',
+	otherFilters: () => buildCuratorSpeciesFilter(),
 	valueDisplay: geneValueDisplay,
 };
 
 export const diseaseGeneticModifierGenesSearchConfig = {
 	endpoint: Endpoints.Entity.GENE,
-	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig),
+	autocompleteFields: getAutocompleteFields(AUTOCOMPLETE_CONFIGS.geneAutocompleteConfig),
 	filterName: 'geneticModifierGenesFilter',
+	otherFilters: () => buildCuratorSpeciesFilter(),
 	valueDisplay: geneValueDisplay,
 };
 
@@ -34,7 +36,8 @@ const buildSearchFn = (config) => (event, setFiltered, setInputValue) => {
 	const searchService = new SearchService();
 	setInputValue(event.query);
 	const filter = buildAutocompleteFilter(event, config.autocompleteFields);
-	autocompleteSearch(searchService, config.endpoint, config.filterName, filter, setFiltered, config.otherFilters);
+	const otherFilters = typeof config.otherFilters === 'function' ? config.otherFilters() : config.otherFilters;
+	autocompleteSearch(searchService, config.endpoint, config.filterName, filter, setFiltered, otherFilters);
 };
 
 export const withSearch = buildSearchFn(withSearchConfig);

--- a/src/main/cliapp/src/components/Editors/legacyForm/GeneEditor.jsx
+++ b/src/main/cliapp/src/components/Editors/legacyForm/GeneEditor.jsx
@@ -9,7 +9,7 @@ import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../../../constants/
 
 const geneSearch = (event, setFiltered, setInputValue) => {
 	const searchService = new SearchService();
-	const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig);
+	const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.geneAutocompleteConfig);
 	const endpoint = Endpoints.Entity.GENE;
 	const filterName = 'objectFilter';
 	const filter = buildAutocompleteFilter(event, autocompleteFields);

--- a/src/main/cliapp/src/constants/FilterFields.js
+++ b/src/main/cliapp/src/constants/FilterFields.js
@@ -253,6 +253,15 @@ export const FIELD_SETS = Object.freeze({
 			'crossReferences.referencedCurie',
 		],
 	},
+	// Ontology-term indexes embed crossReferences with @IndexedEmbedded(includeDepth=1),
+	// so the depth-2 path crossReferences.resourceDescriptorPage.name is NOT indexed
+	// (biological-entity indexes include it explicitly via includePaths). Searching it
+	// throws a Hibernate Search "Unknown field" on /doterm and the other ontology
+	// endpoints (SCRUM-6220), so ontology autocompletes use this depth-1-only variant.
+	ontologyCrossReferencesFieldSet: {
+		filterName: 'crossReferencesFilter',
+		fields: ['crossReferences.displayName', 'crossReferences.referencedCurie'],
+	},
 	daConditionRelationsHandleFieldSet: {
 		filterName: 'daConditionRelationHandleFilter',
 		fields: ['conditionRelations.handle', 'conditionRelations.conditions.conditionSummary'],
@@ -1329,6 +1338,15 @@ export const FILTER_CONFIGS = Object.freeze({
 // single set of bridge fields routes to gene fields on Gene docs, allele fields
 // on Allele docs, etc.
 export const AUTOCOMPLETE_CONFIGS = Object.freeze({
+	// Bridged-only field set. Every path here exists on the index of every
+	// BiologicalEntity subtype: curie/primaryExternalId/modInternalId are native,
+	// crossReferences.* is native via GenomicEntity, and name/symbol/synonyms/
+	// secondaryIds are declared for all subtypes by BiologicalEntityTypeBridge.
+	// Therefore this config is safe to send to the per-type /gene, /allele, /agm
+	// endpoints AND the combined /biologicalentity endpoint.
+	// Do NOT add per-type slot-annotation paths (geneSymbol.*, geneSystematicName.*,
+	// alleleSymbol.*, agm*.* etc.) here: a single-type index rejects fields it does
+	// not have with a Hibernate Search "Unknown field" error
 	biologicalEntityAutocompleteConfig: {
 		fieldSets: [
 			FIELD_SETS.curieFieldSet,
@@ -1339,37 +1357,22 @@ export const AUTOCOMPLETE_CONFIGS = Object.freeze({
 			FIELD_SETS.symbolFieldSet,
 			FIELD_SETS.synonymsFieldSet,
 			FIELD_SETS.secondaryIdsBridgedFieldSet,
-			// geneSystematicName is the only commonly-searched name component not
-			// surfaced by BiologicalEntityTypeBridge (which only writes
-			// geneSymbol/geneFullName/geneSynonyms into the flat fields). Yeast
-			// curators identify genes by systematic name (e.g. YGR240C). The path
-			// resolves to nothing on non-Gene documents, so adding it is safe.
-			FIELD_SETS.geneSystematicNameFieldSet,
 		],
 	},
-	// Used for the disease-annotation Subject picker against the BIOLOGICAL_ENTITY
-	// endpoint, which aggregates Gene/Allele/AGM/Variant/SQTR/Transcript/etc. The
-	// bridge fields would match all subtypes; we scope to Gene/Allele/AGM by
-	// listing per-type slot-annotation paths instead. Paths that don't exist on a
-	// document type silently no-op, so non-Gene/Allele/AGM docs cannot match.
-	diseaseAnnotationSubjectAutocompleteConfig: {
+	// Gene-only autocomplete: the bridged fields plus geneSystematicName, which is
+	// indexed on Gene only (yeast curators identify genes by systematic name, e.g.
+	// YGR240C). Use solely for searches targeting the /gene endpoint.
+	geneAutocompleteConfig: {
 		fieldSets: [
 			FIELD_SETS.curieFieldSet,
 			FIELD_SETS.primaryExternalIdFieldSet,
 			FIELD_SETS.modInternalIdFieldSet,
 			FIELD_SETS.crossReferencesFieldSet,
-			FIELD_SETS.geneSymbolFieldSet,
-			FIELD_SETS.geneNameFieldSet,
-			FIELD_SETS.geneSynonymsFieldSet,
+			FIELD_SETS.nameFieldSet,
+			FIELD_SETS.symbolFieldSet,
+			FIELD_SETS.synonymsFieldSet,
+			FIELD_SETS.secondaryIdsBridgedFieldSet,
 			FIELD_SETS.geneSystematicNameFieldSet,
-			FIELD_SETS.geneSecondaryIdsFieldSet,
-			FIELD_SETS.alleleSymbolFieldSet,
-			FIELD_SETS.alleleNameFieldSet,
-			FIELD_SETS.alleleSynonymsFieldSet,
-			FIELD_SETS.alleleSecondaryIdsFieldSet,
-			FIELD_SETS.agmNameFieldSet,
-			FIELD_SETS.agmSynonymsFieldSet,
-			FIELD_SETS.agmSecondaryIdsFieldSet,
 		],
 	},
 	assertedGenesAutocompleteConfig: {
@@ -1390,7 +1393,7 @@ export const AUTOCOMPLETE_CONFIGS = Object.freeze({
 		fieldSets: [
 			FIELD_SETS.curieFieldSet,
 			FIELD_SETS.nameFieldSet,
-			FIELD_SETS.crossReferencesFieldSet,
+			FIELD_SETS.ontologyCrossReferencesFieldSet,
 			FIELD_SETS.secondaryIdentifiersFieldSet,
 			FIELD_SETS.ontologySynonymsFieldSet,
 		],

--- a/src/main/cliapp/src/constants/__tests__/autocompleteConfigs.test.js
+++ b/src/main/cliapp/src/constants/__tests__/autocompleteConfigs.test.js
@@ -1,0 +1,38 @@
+import { AUTOCOMPLETE_CONFIGS, getAutocompleteFields } from '../FilterFields';
+
+// SCRUM-6220: autocomplete configs that target single-type entity endpoints
+// (/gene, /allele, /agm) must only reference fields that exist on every
+// BiologicalEntity subtype index — i.e. native fields (curie, primaryExternalId,
+// modInternalId, crossReferences.*) and the bridged flat fields (name, symbol,
+// synonyms, secondaryIds). Per-type slot-annotation paths (geneSymbol.*,
+// geneSystematicName.*, alleleSymbol.*, agmFullName.*, ...) only exist on one
+// type's index; sending them to another type's index throws a Hibernate Search
+// "Unknown field" error, which made the allele/AGM autocomplete fields return
+// nothing.
+const PER_TYPE_SLOT_PATH = /^(gene|allele|agm)[A-Z]/;
+
+describe('AUTOCOMPLETE_CONFIGS index validity (SCRUM-6220)', () => {
+	it('biologicalEntityAutocompleteConfig has no per-type slot paths (safe for /gene, /allele, /agm)', () => {
+		const fields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig);
+		expect(fields.filter((f) => PER_TYPE_SLOT_PATH.test(f))).toEqual([]);
+	});
+
+	it('assertedGenesAutocompleteConfig has no per-type slot paths', () => {
+		const fields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.assertedGenesAutocompleteConfig);
+		expect(fields.filter((f) => PER_TYPE_SLOT_PATH.test(f))).toEqual([]);
+	});
+
+	it('geneAutocompleteConfig keeps geneSystematicName (Gene-only; used only against /gene)', () => {
+		const fields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.geneAutocompleteConfig);
+		expect(fields).toContain('geneSystematicName.displayText');
+	});
+
+	// Ontology-term indexes embed crossReferences at includeDepth=1, so the depth-2
+	// path crossReferences.resourceDescriptorPage.name is not indexed and throws
+	// "Unknown field" on /doterm etc. (SCRUM-6220).
+	it('ontologyTermAutocompleteConfig omits the depth-2 crossReferences.resourceDescriptorPage.name path', () => {
+		const fields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.ontologyTermAutocompleteConfig);
+		expect(fields).not.toContain('crossReferences.resourceDescriptorPage.name');
+		expect(fields).toContain('crossReferences.referencedCurie');
+	});
+});

--- a/src/main/cliapp/src/constants/speciesTaxa.js
+++ b/src/main/cliapp/src/constants/speciesTaxa.js
@@ -1,0 +1,39 @@
+// Runtime cache of the curator-MOD -> taxon-curie mapping used to narrow the
+// disease-annotation entity autocompletes to a curator's species
+//
+// Derived from the Species table via /species: each Species links to its dataProvider (the MOD,
+// whose `abbreviation` matches the cognito `*Staff` group prefix, e.g. "RGD") and
+// to its `taxon` (curie). Populated once by useSpeciesTaxa() and read
+// synchronously by getCuratorTaxonCuries() in utils/utils.js.
+let modTaxa = {}; // e.g. { RGD: ['NCBITaxon:10116', 'NCBITaxon:9606'], XB: ['NCBITaxon:8355', 'NCBITaxon:8364'] }
+let canonicalTaxa = []; // distinct taxon curies across all canonical species (the fallback set)
+
+// Populate the cache from a /species result list. Each entry is expected to carry
+// `dataProvider.abbreviation` (MOD code) and `taxon.curie`.
+export function setSpeciesTaxaCache(speciesList) {
+	const byMod = {};
+	const all = new Set();
+	(speciesList || []).forEach((species) => {
+		const taxon = species?.taxon?.curie;
+		if (!taxon) return;
+		all.add(taxon);
+		const mod = species?.dataProvider?.abbreviation;
+		if (mod) {
+			if (!byMod[mod]) byMod[mod] = [];
+			if (!byMod[mod].includes(taxon)) byMod[mod].push(taxon);
+		}
+	});
+	modTaxa = byMod;
+	canonicalTaxa = [...all];
+}
+
+// Taxon curies for a MOD code (e.g. 'RGD'); undefined if the MOD is unknown or the
+// cache has not loaded yet.
+export function getModTaxa(mod) {
+	return modTaxa[mod];
+}
+
+// All canonical-species taxon curies. Empty until the cache is loaded.
+export function getCanonicalTaxa() {
+	return canonicalTaxa;
+}

--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/DiseaseAnnotationsPage.jsx
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/DiseaseAnnotationsPage.jsx
@@ -1,6 +1,9 @@
-import React from 'react';
 import { DiseaseAnnotationsTable } from './DiseaseAnnotationsTable';
+import { useSpeciesTaxa } from '../../service/useSpeciesTaxa';
 
 export function DiseaseAnnotationsPage() {
+	// Load the Species table once so the autocomplete species narrowing (Subject,
+	// genetic-modifier, asserted fields) can map the curator's MOD to its taxa.
+	useSpeciesTaxa();
 	return <DiseaseAnnotationsTable />;
 }

--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/NewAnnotationForm.jsx
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/NewAnnotationForm.jsx
@@ -23,6 +23,7 @@ import { AutocompleteFormEditor } from '../../components/Editors/autocomplete/ba
 import {
 	autocompleteSearch,
 	buildAutocompleteFilter,
+	buildCuratorSpeciesFilter,
 	validateRequiredFields,
 	validateFormBioEntityFields,
 	validateTable,
@@ -238,10 +239,13 @@ export const NewAnnotationForm = ({
 		const endpoint = Endpoints.Entity.AGM;
 		const filterName = 'sgdStrainBackgroundFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
+		// SGD strain background is always Saccharomyces cerevisiae S288C; match by
+		// taxon curie (exact) rather than the brittle taxon.name full-text filter.
 		const otherFilters = {
 			taxonFilter: {
-				'taxon.name': {
-					queryString: 'Saccharomyces cerevisiae',
+				'taxon.curie': {
+					queryString: 'NCBITaxon:559292',
+					useKeywordFields: true,
 				},
 			},
 		};
@@ -255,7 +259,7 @@ export const NewAnnotationForm = ({
 		const filterName = 'geneticModifierAgmsFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
 		setQuery(event.query);
-		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered);
+		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered, buildCuratorSpeciesFilter());
 	};
 
 	const geneticModifierAllelesSearch = (event, setFiltered, setQuery) => {
@@ -264,16 +268,16 @@ export const NewAnnotationForm = ({
 		const filterName = 'geneticModifierAllelesFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
 		setQuery(event.query);
-		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered);
+		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered, buildCuratorSpeciesFilter());
 	};
 
 	const geneticModifierGenesSearch = (event, setFiltered, setQuery) => {
-		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig);
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.geneAutocompleteConfig);
 		const endpoint = Endpoints.Entity.GENE;
 		const filterName = 'geneticModifierGenesFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
 		setQuery(event.query);
-		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered);
+		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered, buildCuratorSpeciesFilter());
 	};
 
 	const onSubjectChange = (event) => {
@@ -316,12 +320,12 @@ export const NewAnnotationForm = ({
 	};
 
 	const subjectSearch = (event, setFiltered, setQuery) => {
-		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.diseaseAnnotationSubjectAutocompleteConfig);
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig);
 		const endpoint = Endpoints.Entity.BIOLOGICAL_ENTITY;
 		const filterName = 'diseaseAnnotationSubjectFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
 		setQuery(event.query);
-		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered);
+		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered, buildCuratorSpeciesFilter());
 	};
 
 	const onDiseaseChange = (event) => {
@@ -406,7 +410,7 @@ export const NewAnnotationForm = ({
 	};
 
 	const withSearch = (event, setFiltered, setInputValue) => {
-		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.biologicalEntityAutocompleteConfig);
+		const autocompleteFields = getAutocompleteFields(AUTOCOMPLETE_CONFIGS.geneAutocompleteConfig);
 		const endpoint = Endpoints.Entity.GENE;
 		const filterName = 'withFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
@@ -456,7 +460,7 @@ export const NewAnnotationForm = ({
 		const filterName = 'assertedGenesFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
 		setInputValue(event.query);
-		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered);
+		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered, buildCuratorSpeciesFilter());
 	};
 
 	const assertedAllelesSearch = (event, setFiltered, setInputValue) => {
@@ -465,7 +469,7 @@ export const NewAnnotationForm = ({
 		const filterName = 'assertedAllelesFilter';
 		const filter = buildAutocompleteFilter(event, autocompleteFields);
 		setInputValue(event.query);
-		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered);
+		autocompleteSearch(searchService, endpoint, filterName, filter, setFiltered, buildCuratorSpeciesFilter());
 	};
 
 	const updateFormFields = (updatedFields) => {

--- a/src/main/cliapp/src/service/useSpeciesTaxa.js
+++ b/src/main/cliapp/src/service/useSpeciesTaxa.js
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { SearchService } from './SearchService';
+import { Endpoints } from '../constants/Endpoints';
+import { setSpeciesTaxaCache } from '../constants/speciesTaxa';
+
+// Loads the Species table once and populates the module-level speciesTaxa cache
+// that the disease-annotation autocomplete species narrowing reads (SCRUM-6220).
+// Mount once on a page that hosts those autocompletes (DiseaseAnnotationsPage).
+export function useSpeciesTaxa() {
+	const searchService = new SearchService();
+	const { data, isSuccess } = useQuery({
+		queryKey: ['speciesTaxa'],
+		// /species/find is relational (no OpenSearch index dependency); {} returns all.
+		queryFn: () => searchService.find(Endpoints.Entity.SPECIES, 100, 0, {}),
+		staleTime: Infinity, // species rarely change within a session
+		refetchOnWindowFocus: false,
+	});
+
+	useEffect(() => {
+		if (isSuccess && data?.results) {
+			setSpeciesTaxaCache(data.results);
+		}
+	}, [isSuccess, data]);
+}

--- a/src/main/cliapp/src/utils/__tests__/curatorSpeciesFilter.test.js
+++ b/src/main/cliapp/src/utils/__tests__/curatorSpeciesFilter.test.js
@@ -16,10 +16,21 @@ const SPECIES = [
 	{ dataProvider: { abbreviation: 'XB' }, taxon: { curie: 'NCBITaxon:8355' } },
 	{ dataProvider: { abbreviation: 'XB' }, taxon: { curie: 'NCBITaxon:8364' } },
 ];
-const CANONICAL = ['NCBITaxon:10116', 'NCBITaxon:9606', 'NCBITaxon:10090', 'NCBITaxon:559292', 'NCBITaxon:6239', 'NCBITaxon:8355', 'NCBITaxon:8364'];
+const CANONICAL = [
+	'NCBITaxon:10116',
+	'NCBITaxon:9606',
+	'NCBITaxon:10090',
+	'NCBITaxon:559292',
+	'NCBITaxon:6239',
+	'NCBITaxon:8355',
+	'NCBITaxon:8364',
+];
 
 const setCognitoGroups = (groups) => {
-	localStorage.setItem('cognito-token-storage', JSON.stringify({ accessToken: { payload: { 'cognito:groups': groups } } }));
+	localStorage.setItem(
+		'cognito-token-storage',
+		JSON.stringify({ accessToken: { payload: { 'cognito:groups': groups } } })
+	);
 };
 
 describe('getCuratorTaxonCuries (SCRUM-6220)', () => {
@@ -77,7 +88,9 @@ describe('buildCuratorSpeciesFilter (SCRUM-6220)', () => {
 	it('produces a multi-value OR keyword filter for a multi-taxon MOD', () => {
 		setCognitoGroups(['XBStaff']);
 		expect(buildCuratorSpeciesFilter()).toEqual({
-			speciesFilter: { 'taxon.curie': { queryString: 'NCBITaxon:8355 NCBITaxon:8364', tokenOperator: 'OR', useKeywordFields: true } },
+			speciesFilter: {
+				'taxon.curie': { queryString: 'NCBITaxon:8355 NCBITaxon:8364', tokenOperator: 'OR', useKeywordFields: true },
+			},
 		});
 	});
 

--- a/src/main/cliapp/src/utils/__tests__/curatorSpeciesFilter.test.js
+++ b/src/main/cliapp/src/utils/__tests__/curatorSpeciesFilter.test.js
@@ -1,0 +1,89 @@
+import { getCuratorTaxonCuries, buildCuratorSpeciesFilter } from '../utils';
+import { setSpeciesTaxaCache } from '../../constants/speciesTaxa';
+
+// SCRUM-6220: disease-annotation entity autocompletes are constrained to the
+// curator's MOD species. The MOD -> taxa mapping is derived at runtime from the
+// Species table (each species links to its dataProvider/MOD + taxon), cached by
+// useSpeciesTaxa(). These tests seed that cache directly.
+
+// Mirrors a /species result list (dataProvider.abbreviation = MOD, taxon.curie).
+const SPECIES = [
+	{ dataProvider: { abbreviation: 'RGD' }, taxon: { curie: 'NCBITaxon:10116' } }, // rat
+	{ dataProvider: { abbreviation: 'RGD' }, taxon: { curie: 'NCBITaxon:9606' } }, // human (RGD curates human too)
+	{ dataProvider: { abbreviation: 'MGI' }, taxon: { curie: 'NCBITaxon:10090' } },
+	{ dataProvider: { abbreviation: 'SGD' }, taxon: { curie: 'NCBITaxon:559292' } },
+	{ dataProvider: { abbreviation: 'WB' }, taxon: { curie: 'NCBITaxon:6239' } },
+	{ dataProvider: { abbreviation: 'XB' }, taxon: { curie: 'NCBITaxon:8355' } },
+	{ dataProvider: { abbreviation: 'XB' }, taxon: { curie: 'NCBITaxon:8364' } },
+];
+const CANONICAL = ['NCBITaxon:10116', 'NCBITaxon:9606', 'NCBITaxon:10090', 'NCBITaxon:559292', 'NCBITaxon:6239', 'NCBITaxon:8355', 'NCBITaxon:8364'];
+
+const setCognitoGroups = (groups) => {
+	localStorage.setItem('cognito-token-storage', JSON.stringify({ accessToken: { payload: { 'cognito:groups': groups } } }));
+};
+
+describe('getCuratorTaxonCuries (SCRUM-6220)', () => {
+	beforeEach(() => setSpeciesTaxaCache(SPECIES));
+	afterEach(() => localStorage.clear());
+
+	it('maps a single MOD Staff group to its taxon', () => {
+		setCognitoGroups(['WBStaff']);
+		expect(getCuratorTaxonCuries()).toEqual(['NCBITaxon:6239']);
+	});
+
+	it('maps RGD to both rat and human (RGD curates human)', () => {
+		setCognitoGroups(['RGDStaff']);
+		expect(getCuratorTaxonCuries().sort()).toEqual(['NCBITaxon:10116', 'NCBITaxon:9606'].sort());
+	});
+
+	it('maps XB to both Xenopus taxa', () => {
+		setCognitoGroups(['XBStaff']);
+		expect(getCuratorTaxonCuries()).toEqual(['NCBITaxon:8355', 'NCBITaxon:8364']);
+	});
+
+	it('unions taxa across multiple MOD groups (deduped)', () => {
+		setCognitoGroups(['WBStaff', 'SGDStaff']);
+		expect(getCuratorTaxonCuries().sort()).toEqual(['NCBITaxon:559292', 'NCBITaxon:6239'].sort());
+	});
+
+	it('falls back to the canonical species set when no group maps to a MOD', () => {
+		setCognitoGroups(['SomeOtherGroup']);
+		expect(getCuratorTaxonCuries().sort()).toEqual([...CANONICAL].sort());
+	});
+
+	it('falls back to canonical species when there is no cognito token', () => {
+		localStorage.removeItem('cognito-token-storage');
+		expect(getCuratorTaxonCuries().sort()).toEqual([...CANONICAL].sort());
+	});
+
+	it('returns [] when the species cache has not loaded yet', () => {
+		setSpeciesTaxaCache([]);
+		setCognitoGroups(['RGDStaff']);
+		expect(getCuratorTaxonCuries()).toEqual([]);
+	});
+});
+
+describe('buildCuratorSpeciesFilter (SCRUM-6220)', () => {
+	beforeEach(() => setSpeciesTaxaCache(SPECIES));
+	afterEach(() => localStorage.clear());
+
+	it('produces a single-value taxon.curie OR keyword filter for a single MOD', () => {
+		setCognitoGroups(['WBStaff']);
+		expect(buildCuratorSpeciesFilter()).toEqual({
+			speciesFilter: { 'taxon.curie': { queryString: 'NCBITaxon:6239', tokenOperator: 'OR', useKeywordFields: true } },
+		});
+	});
+
+	it('produces a multi-value OR keyword filter for a multi-taxon MOD', () => {
+		setCognitoGroups(['XBStaff']);
+		expect(buildCuratorSpeciesFilter()).toEqual({
+			speciesFilter: { 'taxon.curie': { queryString: 'NCBITaxon:8355 NCBITaxon:8364', tokenOperator: 'OR', useKeywordFields: true } },
+		});
+	});
+
+	it('omits the species filter entirely when the cache has not loaded', () => {
+		setSpeciesTaxaCache([]);
+		setCognitoGroups(['RGDStaff']);
+		expect(buildCuratorSpeciesFilter()).toEqual({});
+	});
+});

--- a/src/main/cliapp/src/utils/utils.js
+++ b/src/main/cliapp/src/utils/utils.js
@@ -3,6 +3,7 @@ import { SORT_FIELDS } from '../constants/SortFields';
 
 import { FIELD_SETS } from '../constants/FilterFields';
 import { Endpoints } from '../constants/Endpoints';
+import { getModTaxa, getCanonicalTaxa } from '../constants/speciesTaxa';
 import { ValidationService } from '../service/ValidationService';
 
 export function returnSorted(event, originalSort) {
@@ -340,6 +341,47 @@ export function buildAutocompleteFilter(event, autocompleteFields) {
 	});
 
 	return filter;
+}
+
+// Resolve the taxon curies the current curator's autocompletes should be limited
+// to: the union of their MOD species (from the cognito `*Staff` groups)
+// The MOD->taxa mapping comes from the Species table via the
+// speciesTaxa cache (loaded by useSpeciesTaxa); returns [] until it has loaded.
+// See constants/speciesTaxa.js (SCRUM-6220).
+export function getCuratorTaxonCuries() {
+	let groups = [];
+	try {
+		const cognitoToken = JSON.parse(localStorage.getItem('cognito-token-storage'));
+		groups = cognitoToken?.accessToken?.payload?.['cognito:groups'] || [];
+	} catch (e) {
+		groups = [];
+	}
+	const taxa = groups
+		.filter((group) => group.includes('Staff'))
+		.map((group) => group.replace('Staff', ''))
+		.flatMap((mod) => getModTaxa(mod) || []);
+	const unique = [...new Set(taxa)];
+	return unique.length > 0 ? unique : [...getCanonicalTaxa()];
+}
+
+// Build an `otherFilters` fragment that constrains an entity autocomplete to the
+// curator's species (a hard constraint). The taxon curies are OR'd within one
+// filter group, which `BaseSQLDAO.searchByParams` AND's against the typed-query
+// filter. Use for the Gene/Allele/AGM subject / genetic-modifier / asserted fields.
+// Returns an empty object (no species narrowing) when the species cache has not
+// loaded yet, so an early search degrades to unfiltered rather than an empty query.
+export function buildCuratorSpeciesFilter() {
+	const taxa = getCuratorTaxonCuries();
+	if (taxa.length === 0) return {};
+	return {
+		speciesFilter: {
+			'taxon.curie': {
+				queryString: taxa.join(' '),
+				tokenOperator: 'OR',
+				useKeywordFields: true,
+			},
+		},
+	};
 }
 
 export function defaultAutocompleteOnChange(rowProps, event, fieldName, setFieldValue, subField = 'curie') {

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/BiologicalEntityCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/BiologicalEntityCrudInterface.java
@@ -1,12 +1,21 @@
 package org.alliancegenome.curation_api.interfaces.crud;
 
+import java.util.HashMap;
+
 import org.alliancegenome.curation_api.interfaces.base.BaseSubmittedObjectCrudInterface;
 import org.alliancegenome.curation_api.model.entities.BiologicalEntity;
+import org.alliancegenome.curation_api.response.SearchResponse;
+import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
+import com.fasterxml.jackson.annotation.JsonView;
+
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
 @Path("/biologicalentity")
@@ -14,5 +23,17 @@ import jakarta.ws.rs.core.MediaType;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public interface BiologicalEntityCrudInterface extends BaseSubmittedObjectCrudInterface<BiologicalEntity> {
+
+	// Override search() to FieldsOnly (instead of the inherited FieldsAndLists),
+	// matching the per-type search endpoints (/gene, /allele, /agm, ...). On this
+	// cross-subtype index FieldsAndLists serializes association collections whose
+	// cycle-guards are incomplete across subtypes, producing a >2GB serialization /
+	// OutOfMemoryError. Callers needing associations use get-by-id.
+	@Override
+	@POST
+	@Path("/search")
+	@Tag(name = "Elastic Search Browsing Endpoints")
+	@JsonView({ CurationView.FieldsOnly.class })
+	SearchResponse<BiologicalEntity> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
 }


### PR DESCRIPTION
Fix the unresponsive/erroring autosuggest fields on the New Disease Annotation form (and the inline table editors), and constrain entity autocompletes to the curator's MOD species.

Unknown-field / OOM fixes:
- Make biologicalEntityAutocompleteConfig bridged-only (curie, primaryExternalId, modInternalId, crossReferences.*, and the BiologicalEntityTypeBridge flat fields name/symbol/synonyms/ secondaryIds). Per-type slot paths (geneSymbol.*, geneSystematicName.*, alleleSymbol.*, agm*.*) threw Hibernate Search "Unknown field" on the single-type /gene, /allele, /agm indexes, so allele/AGM lookups returned nothing.
- Add geneAutocompleteConfig (bridged + geneSystematicName) for the Gene-only fields; drop the old diseaseAnnotationSubjectAutocompleteConfig.
- Add ontologyCrossReferencesFieldSet (depth-1) for ontology autocompletes: the depth-2 crossReferences.resourceDescriptorPage.name path is not indexed on /doterm (includeDepth=1) and threw "Unknown field".
- Override /biologicalentity search() to @JsonView(FieldsOnly), matching the per-type search endpoints. FieldsAndLists serialized association collections with incomplete cross-subtype cycle-guards, causing an OOM.

Species/MOD narrowing:
- Add buildCuratorSpeciesFilter(): a hard taxon.curie constraint derived from the curator's cognito *Staff groups, AND'd against the typed query.
- Derive the MOD->taxa map at runtime from the Species table
- Apply to Subject, genetic-modifier (AGM/Allele/Gene) and asserted (Gene/Allele) fields, in both the form and the inline table editors. The "with" field stays human-pinned; Disease is excluded (no taxon).

SGD strain background: match by taxon.curie=NCBITaxon:559292 (keyword) instead of the brittle taxon.name full-text filter.

Add unit tests for the autocomplete configs and the species filter.