### PR TITLE
SCRUM-2831 Client-side MOD affiliation switching for Tester/POTester

### DIFF
--- a/src/main/cliapp/src/App.jsx
+++ b/src/main/cliapp/src/App.jsx
@@ -3,6 +3,7 @@ import cognitoConfig from './cognitoAuthConfig';
 import { CookiesProvider } from 'react-cookie';
 
 import { Login } from './Login';
+import { AffiliationProvider } from './contexts/AffiliationContext';
 
 import AppRoutes from './routes';
 import './App.scss';
@@ -14,7 +15,9 @@ const App = () => {
 	return (
 		<CookiesProvider defaultSetOptions={{ path: '/' }}>
 			<Login>
-				<AppRoutes />
+				<AffiliationProvider>
+					<AppRoutes />
+				</AffiliationProvider>
 			</Login>
 		</CookiesProvider>
 	);

--- a/src/main/cliapp/src/AppTopbar.jsx
+++ b/src/main/cliapp/src/AppTopbar.jsx
@@ -8,11 +8,16 @@ import { ProgressBar } from 'primereact/progressbar';
 import { useCopyToClipboard } from './hooks/useCopyToClipboard';
 import { useApiVersion, useUserInfo } from './service/SiteQueryHooks';
 import { useAuth } from './hooks/useAuth';
+import { useAffiliation } from './contexts/AffiliationContext';
+import { MOD_AFFILIATIONS } from './utils/affiliation';
 
 export const AppTopbar = (props) => {
 	const menu = useRef(null);
 	const [processingEvent, setProcessingEvent] = useState(null);
 	const { authState } = useAuth();
+	const { isOverridden, override } = useAffiliation();
+	// Human-facing abbreviation of the MOD currently being mocked (e.g. 'RGDStaff' -> 'RGD').
+	const mockedMod = MOD_AFFILIATIONS.find((affiliation) => affiliation.group === override)?.abbreviation;
 	const [cognitoToken] = useState(JSON.parse(localStorage.getItem('cognito-token-storage')));
 
 	const { data: userInfo } = useUserInfo(authState);
@@ -125,7 +130,7 @@ export const AppTopbar = (props) => {
 	];
 
 	return (
-		<div className="layout-topbar">
+		<div className={classNames('layout-topbar', { 'affiliation-override': isOverridden })}>
 			{props.authState?.isAuthenticated && (
 				<>
 					<Link to="/" className="layout-topbar-logo">
@@ -148,6 +153,12 @@ export const AppTopbar = (props) => {
 							{/Mac|iPhone|iPad|iPod/.test(navigator.userAgent) ? '⌘K' : 'Ctrl+K'}
 						</span>
 					</button>
+					{isOverridden && (
+						<span className="affiliation-override-message">
+							You are currently mocking the {mockedMod} affiliation. Please switch your Alliance member affiliation back
+							to your default before proceeding with actual curation work.
+						</span>
+					)}
 				</>
 			)}
 			<button

--- a/src/main/cliapp/src/assets/layout/sass/_topbar.scss
+++ b/src/main/cliapp/src/assets/layout/sass/_topbar.scss
@@ -87,6 +87,35 @@
             margin-left: 1rem;
         }
     }
+
+    // SCRUM-2831: loud red header when a tester has overridden their MOD affiliation.
+    &.affiliation-override {
+        background-color: var(--red-600);
+
+        .layout-topbar-logo,
+        .layout-topbar-button,
+        .layout-topbar-button i,
+        .affiliation-override-message {
+            color: #ffffff;
+        }
+
+        // Keep the logo and icon buttons at their natural size so the message
+        // can't squeeze them out of shape.
+        .layout-topbar-logo,
+        .layout-topbar-button {
+            flex-shrink: 0;
+        }
+
+        // The message takes the free space between the left-hand buttons and the
+        // right-hand user menu, centered.
+        .affiliation-override-message {
+            flex: 1 1 auto;
+            min-width: 0;
+            margin: 0 1.5rem;
+            text-align: center;
+            font-weight: 600;
+        }
+    }
 }
 
 @media (max-width: 991px) {

--- a/src/main/cliapp/src/components/CommandPalette/CommandPalette.scss
+++ b/src/main/cliapp/src/components/CommandPalette/CommandPalette.scss
@@ -117,7 +117,10 @@
 	color: var(--text-color-secondary);
 }
 
-.command-palette-trigger.layout-topbar-button {
+// Scoped under .layout-topbar so these win the specificity tie against the base
+// `.layout-topbar .layout-topbar-button` rules (both 0-2-0); otherwise the button
+// gets forced back to a 3rem circle, off-centering the icon and overflowing the badge.
+.layout-topbar .command-palette-trigger.layout-topbar-button {
 	width: auto;
 	border-radius: 8px;
 	gap: 0.5rem;

--- a/src/main/cliapp/src/containers/diseaseAnnotationsPage/NewAnnotationForm.jsx
+++ b/src/main/cliapp/src/containers/diseaseAnnotationsPage/NewAnnotationForm.jsx
@@ -43,6 +43,7 @@ import { GeneticModifierGenesAdditionalFieldData } from '../../components/FieldD
 import ErrorBoundary from '../../components/Error/ErrorBoundary';
 import { ConfirmButton } from '../../components/ConfirmButton';
 import { getDefaultFormState, getModFormFields } from '../../service/TableStateService';
+import { getEffectiveStaffGroups } from '../../utils/affiliation';
 import { useGetUserSettings } from '../../service/useGetUserSettings';
 import { useVocabularyTermSetService } from '../../service/useVocabularyTermSetService';
 import { Endpoints } from '../../constants/Endpoints';
@@ -108,8 +109,8 @@ export const NewAnnotationForm = ({
 		'Genetic Modifier Genes',
 		'Internal',
 	];
-	const cognitoToken = JSON.parse(localStorage.getItem('cognito-token-storage'));
-	const mod = cognitoToken?.accessToken?.payload?.['cognito:groups']?.filter((group) => group.includes('Staff'));
+	// Effective MOD honors a tester's client-side affiliation override (SCRUM-2831).
+	const mod = getEffectiveStaffGroups();
 	let defaultUserSettings = getDefaultFormState('DiseaseAnnotations', newAnnotationOptionalFields, undefined);
 	const { settings: settingsKey, mutate: setSettingsKey } = useGetUserSettings(
 		'DiseaseAnnotationsFormSettings',

--- a/src/main/cliapp/src/containers/layout/SiteLayout.jsx
+++ b/src/main/cliapp/src/containers/layout/SiteLayout.jsx
@@ -13,6 +13,7 @@ import { AppConfig } from '../../AppConfig';
 import { CommandPalette } from '../../components/CommandPalette/CommandPalette';
 
 import { useApiVersion, useUserInfo } from '../../service/SiteQueryHooks';
+import { clearAffiliationOverride } from '../../utils/affiliation';
 
 import PrimeReact from 'primereact/api';
 import { Tooltip } from 'primereact/tooltip';
@@ -107,6 +108,7 @@ export const SiteLayout = (props) => {
 		try {
 			removeCookie('cognito-token-cookie', { path: '/' });
 			localStorage.removeItem('cognito-token-storage');
+			clearAffiliationOverride();
 			sessionStorage.setItem('cognito-just-logged-out', 'true');
 			setAuthState({ isAuthenticated: false });
 			await signOut();

--- a/src/main/cliapp/src/containers/profilePage/ProfileComponent.css
+++ b/src/main/cliapp/src/containers/profilePage/ProfileComponent.css
@@ -1,0 +1,6 @@
+/* SCRUM-2831: inline MOD affiliation switcher on the Profile page's Alliance Member row. */
+.affiliation-switcher {
+	display: flex;
+	align-items: center;
+	gap: 1.5rem;
+}

--- a/src/main/cliapp/src/containers/profilePage/ProfileComponent.jsx
+++ b/src/main/cliapp/src/containers/profilePage/ProfileComponent.jsx
@@ -2,17 +2,22 @@ import { useState, useRef } from 'react';
 import { Card } from 'primereact/card';
 import { DataTable } from 'primereact/datatable';
 import { Dropdown } from 'primereact/dropdown';
+import { Button } from 'primereact/button';
 import { Column } from 'primereact/column';
 import { useAuth } from '../../hooks/useAuth';
 import { Panel } from 'primereact/panel';
 import { Ripple } from 'primereact/ripple';
+import { Tooltip } from 'primereact/tooltip';
 import * as jose from 'jose';
-import { QUERY_KEYS, useRegenApiToken, useUserInfo } from '../../service/SiteQueryHooks';
+import { QUERY_KEYS, useApiVersion, useRegenApiToken, useUserInfo } from '../../service/SiteQueryHooks';
 import { ConfirmButton } from '../../components/ConfirmButton';
+import { useAffiliation } from '../../contexts/AffiliationContext';
+import { MOD_AFFILIATIONS, canSwitchAffiliation, getCognitoGroups, getTrueStaffGroups } from '../../utils/affiliation';
 import { useGetUserSettings } from '../../service/useGetUserSettings';
 import JsonView from 'react18-json-view';
 import 'react18-json-view/src/style.css';
 import 'react18-json-view/src/dark.css';
+import './ProfileComponent.css';
 import { PersonSettingsService } from '../../service/PersonSettingsService';
 import { useControlledVocabularyService } from '../../service/useControlledVocabularyService';
 import { Toast } from 'primereact/toast';
@@ -43,6 +48,16 @@ export const ProfileComponent = () => {
 	const { authState } = useAuth();
 	const toast_topright = useRef(null);
 	const { data: localUserInfo } = useUserInfo(authState);
+	const { data: apiVersion } = useApiVersion(authState);
+
+	// SCRUM-2831: client-side MOD affiliation switching for Tester / POTester users.
+	const { override, setOverride, reset } = useAffiliation();
+	const canSwitch = canSwitchAffiliation({
+		groups: getCognitoGroups(),
+		env: apiVersion?.env,
+		isDev: import.meta.env.DEV,
+	});
+	const selectedAffiliation = override || getTrueStaffGroups()[0] || null;
 
 	const personSettingsService = new PersonSettingsService();
 	const booleanTerms = useControlledVocabularyService('generic_boolean_terms');
@@ -137,6 +152,32 @@ export const ProfileComponent = () => {
 		return <p style={{ wordBreak: 'break-all' }}>{props.value}</p>;
 	};
 
+	// SCRUM-2831: Tester / POTester users get an inline MOD affiliation switcher on the
+	// Alliance Member row; everyone else just sees their true affiliation as plain text.
+	const affiliationTemplate = (props) => {
+		if (!canSwitch) return textTemplate(props);
+		return (
+			<div className="affiliation-switcher">
+				<Dropdown
+					value={selectedAffiliation}
+					options={MOD_AFFILIATIONS}
+					optionLabel="abbreviation"
+					optionValue="group"
+					placeholder="Select an affiliation"
+					onChange={(e) => setOverride(e.value)}
+				/>
+				<Button label="Reset Affiliation" icon="pi pi-undo" onClick={reset} disabled={!override} />
+				<Tooltip target=".affiliation-help" style={{ maxWidth: '24rem' }} />
+				<i
+					className="affiliation-help pi pi-question-circle"
+					style={{ cursor: 'help' }}
+					data-pr-position="right"
+					data-pr-tooltip="Temporarily switch the MOD affiliation used by the curation interface to test MOD-specific behavior. This change is local to your browser only — your true affiliation remains the source of truth. Please switch back to your default before doing any actual curation work."
+				/>
+			</div>
+		);
+	};
+
 	const headerTemplate = (options, props) => {
 		const toggleIcon = options.collapsed ? 'pi pi-chevron-down' : 'pi pi-chevron-up';
 		const className = `${options.className} justify-content-start`;
@@ -208,7 +249,7 @@ export const ProfileComponent = () => {
 		{
 			name: 'Alliance Member',
 			value: localUserInfo?.allianceMember?.fullName + ' (' + localUserInfo?.allianceMember?.abbreviation + ')',
-			template: textTemplate,
+			template: affiliationTemplate,
 		},
 		{ name: 'Cognito Email', value: localUserInfo?.authEmail, template: textTemplate },
 		{ name: 'Cognito Access Token', value: cognitoToken?.accessToken?.accessToken, template: textTemplate },

--- a/src/main/cliapp/src/contexts/AffiliationContext.jsx
+++ b/src/main/cliapp/src/contexts/AffiliationContext.jsx
@@ -1,0 +1,49 @@
+// SCRUM-2831: reactive wrapper around the client-side MOD affiliation override.
+// The override itself lives in localStorage (see utils/affiliation.js) so the
+// synchronous MOD-resolution chokepoints can read it without React; this context
+// mirrors it into React state so the header banner and Profile control re-render
+// the moment a tester switches or resets their affiliation.
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import {
+	clearAffiliationOverride,
+	getAffiliationOverride,
+	getTrueStaffGroups,
+	setAffiliationOverride,
+} from '../utils/affiliation';
+
+const AffiliationContext = createContext(null);
+
+export const AffiliationProvider = ({ children }) => {
+	const [override, setOverrideState] = useState(() => getAffiliationOverride());
+
+	const setOverride = useCallback((group) => {
+		setAffiliationOverride(group);
+		setOverrideState(group);
+	}, []);
+
+	const reset = useCallback(() => {
+		clearAffiliationOverride();
+		setOverrideState(null);
+	}, []);
+
+	const value = useMemo(
+		() => ({
+			override,
+			// Active only when an override is set and it differs from the user's true affiliation.
+			isOverridden: !!override && !getTrueStaffGroups().includes(override),
+			setOverride,
+			reset,
+		}),
+		[override, setOverride, reset]
+	);
+
+	return <AffiliationContext.Provider value={value}>{children}</AffiliationContext.Provider>;
+};
+
+export const useAffiliation = () => {
+	const context = useContext(AffiliationContext);
+	if (!context) {
+		throw new Error('useAffiliation must be used within an AffiliationProvider');
+	}
+	return context;
+};

--- a/src/main/cliapp/src/service/TableStateService.js
+++ b/src/main/cliapp/src/service/TableStateService.js
@@ -1,3 +1,5 @@
+import { getEffectiveStaffGroups } from '../utils/affiliation';
+
 const modTableSettings = {
 	RGDStaff: {
 		DiseaseAnnotations: {
@@ -422,8 +424,8 @@ const modTableSettings = {
 };
 
 export function getModTableState(table, defaultColumnWidths, defaultColumnNames) {
-	const cognitoToken = JSON.parse(localStorage.getItem('cognito-token-storage'));
-	const mod = cognitoToken?.accessToken?.payload?.['cognito:groups']?.filter((group) => group.includes('Staff'));
+	// Effective MOD honors a tester's client-side affiliation override (SCRUM-2831).
+	const mod = getEffectiveStaffGroups();
 	const modTableState = structuredClone(
 		modTableSettings[mod] ? modTableSettings[mod][table] : modTableSettings['Default'][table]
 	);
@@ -435,8 +437,8 @@ export function getModTableState(table, defaultColumnWidths, defaultColumnNames)
 }
 
 export function getModFormFields(table) {
-	const cognitoToken = JSON.parse(localStorage.getItem('cognito-token-storage'));
-	const mod = cognitoToken?.accessToken?.payload?.['cognito:groups']?.filter((group) => group.includes('Staff'));
+	// Effective MOD honors a tester's client-side affiliation override (SCRUM-2831).
+	const mod = getEffectiveStaffGroups();
 	const modFormFields = modTableSettings[mod]
 		? modTableSettings[mod][table]['selectedFormFields']
 		: modTableSettings['Default'][table]['selectedFormFields'];

--- a/src/main/cliapp/src/utils/__tests__/affiliation.test.js
+++ b/src/main/cliapp/src/utils/__tests__/affiliation.test.js
@@ -1,0 +1,92 @@
+import {
+	AFFILIATION_OVERRIDE_KEY,
+	canSwitchAffiliation,
+	getEffectiveStaffGroups,
+	getTrueStaffGroups,
+	isAffiliationOverridden,
+} from '../affiliation';
+
+// SCRUM-2831: client-side MOD affiliation switching for Tester / POTester users.
+
+const setCognitoGroups = (groups) => {
+	localStorage.setItem(
+		'cognito-token-storage',
+		JSON.stringify({ accessToken: { payload: { 'cognito:groups': groups } } })
+	);
+};
+
+describe('getTrueStaffGroups', () => {
+	afterEach(() => localStorage.clear());
+
+	it('returns only the *Staff groups from the cognito token', () => {
+		setCognitoGroups(['WBStaff', 'Tester', 'SomethingElse']);
+		expect(getTrueStaffGroups()).toEqual(['WBStaff']);
+	});
+
+	it('returns [] when there is no cognito token', () => {
+		localStorage.removeItem('cognito-token-storage');
+		expect(getTrueStaffGroups()).toEqual([]);
+	});
+});
+
+describe('getEffectiveStaffGroups', () => {
+	afterEach(() => localStorage.clear());
+
+	it('returns the true staff groups when no override is set', () => {
+		setCognitoGroups(['WBStaff', 'Tester']);
+		expect(getEffectiveStaffGroups()).toEqual(['WBStaff']);
+	});
+
+	it('returns the override (as a single-element array) when one is set', () => {
+		setCognitoGroups(['WBStaff', 'Tester']);
+		localStorage.setItem(AFFILIATION_OVERRIDE_KEY, 'RGDStaff');
+		expect(getEffectiveStaffGroups()).toEqual(['RGDStaff']);
+	});
+});
+
+describe('isAffiliationOverridden', () => {
+	afterEach(() => localStorage.clear());
+
+	it('is false when no override is set', () => {
+		setCognitoGroups(['WBStaff']);
+		expect(isAffiliationOverridden()).toBe(false);
+	});
+
+	it('is false when the override matches the true affiliation', () => {
+		setCognitoGroups(['WBStaff']);
+		localStorage.setItem(AFFILIATION_OVERRIDE_KEY, 'WBStaff');
+		expect(isAffiliationOverridden()).toBe(false);
+	});
+
+	it('is true when the override differs from the true affiliation', () => {
+		setCognitoGroups(['WBStaff']);
+		localStorage.setItem(AFFILIATION_OVERRIDE_KEY, 'RGDStaff');
+		expect(isAffiliationOverridden()).toBe(true);
+	});
+});
+
+describe('canSwitchAffiliation', () => {
+	it('lets POTester switch on any environment, including production', () => {
+		expect(canSwitchAffiliation({ groups: ['POTester'], env: 'production' })).toBe(true);
+		expect(canSwitchAffiliation({ groups: ['POTester'], env: 'alpha' })).toBe(true);
+		expect(canSwitchAffiliation({ groups: ['POTester'], env: 'beta' })).toBe(true);
+	});
+
+	it('lets Tester switch on alpha/beta/local but not production', () => {
+		expect(canSwitchAffiliation({ groups: ['Tester'], env: 'alpha' })).toBe(true);
+		expect(canSwitchAffiliation({ groups: ['Tester'], env: 'beta' })).toBe(true);
+		expect(canSwitchAffiliation({ groups: ['Tester'], env: 'local' })).toBe(true);
+		expect(canSwitchAffiliation({ groups: ['Tester'], env: 'production' })).toBe(false);
+	});
+
+	it('lets Tester switch in local dev regardless of env', () => {
+		expect(canSwitchAffiliation({ groups: ['Tester'], env: 'production', isDev: true })).toBe(true);
+		expect(canSwitchAffiliation({ groups: ['Tester'], env: undefined, isDev: true })).toBe(true);
+	});
+
+	it('does not let other users switch', () => {
+		expect(canSwitchAffiliation({ groups: ['WBStaff'], env: 'alpha' })).toBe(false);
+		expect(canSwitchAffiliation({ groups: [], env: 'alpha' })).toBe(false);
+		expect(canSwitchAffiliation({})).toBe(false);
+	});
+});

--- a/src/main/cliapp/src/utils/__tests__/curatorSpeciesFilter.test.js
+++ b/src/main/cliapp/src/utils/__tests__/curatorSpeciesFilter.test.js
@@ -72,6 +72,12 @@ describe('getCuratorTaxonCuries (SCRUM-6220)', () => {
 		setCognitoGroups(['RGDStaff']);
 		expect(getCuratorTaxonCuries()).toEqual([]);
 	});
+
+	it('narrows to the overridden MOD taxa when an affiliation override is active (SCRUM-2831)', () => {
+		setCognitoGroups(['RGDStaff', 'Tester']);
+		localStorage.setItem('affiliation-override', 'WBStaff');
+		expect(getCuratorTaxonCuries()).toEqual(['NCBITaxon:6239']);
+	});
 });
 
 describe('buildCuratorSpeciesFilter (SCRUM-6220)', () => {

--- a/src/main/cliapp/src/utils/affiliation.js
+++ b/src/main/cliapp/src/utils/affiliation.js
@@ -1,0 +1,76 @@
+// SCRUM-2831: client-side MOD affiliation switching for "Tester" / "POTester"
+// Cognito group members. The user's real affiliation (the `*Staff` cognito group)
+// remains the source of truth; this module layers a purely client-side override on
+// top so testers can simulate another MOD's curation UI. The override is stored in
+// localStorage and consulted by the MOD-resolution chokepoints
+// (getModTableState / getModFormFields / NewAnnotationForm) via getEffectiveStaffGroups().
+
+export const AFFILIATION_OVERRIDE_KEY = 'affiliation-override';
+
+const COGNITO_TOKEN_KEY = 'cognito-token-storage';
+
+// Cognito groups that are allowed to switch affiliation, and the environments each
+// is allowed to switch in. POTester can switch anywhere (incl. production); Tester
+// is limited to the non-production A-Team environments and local dev. 'local' is the
+// backend `NET` value reported by /version when running against a local API, so it
+// covers local development whether or not the UI is served by the Vite dev server.
+export const TESTER_GROUP = 'Tester';
+export const POTESTER_GROUP = 'POTester';
+const TESTER_ENVS = ['alpha', 'beta', 'local'];
+
+// The MODs a tester can switch to. `group` matches the `*Staff` cognito group the
+// rest of the app keys off of; `abbreviation` is the human-facing MOD label.
+export const MOD_AFFILIATIONS = ['RGD', 'SGD', 'WB', 'FB', 'ZFIN', 'XB', 'MGI'].map((abbreviation) => ({
+	abbreviation,
+	group: `${abbreviation}Staff`,
+}));
+
+// Raw `cognito:groups` claim from the stored access token (e.g. ['WBStaff', 'Tester']).
+export function getCognitoGroups() {
+	try {
+		const cognitoToken = JSON.parse(localStorage.getItem(COGNITO_TOKEN_KEY));
+		return cognitoToken?.accessToken?.payload?.['cognito:groups'] || [];
+	} catch (e) {
+		return [];
+	}
+}
+
+// The user's true MOD affiliation: the `*Staff` cognito groups (unaffected by any override).
+export function getTrueStaffGroups() {
+	return getCognitoGroups().filter((group) => group.includes('Staff'));
+}
+
+// The currently selected override `*Staff` group, or null when none is set.
+export function getAffiliationOverride() {
+	return localStorage.getItem(AFFILIATION_OVERRIDE_KEY) || null;
+}
+
+export function setAffiliationOverride(group) {
+	localStorage.setItem(AFFILIATION_OVERRIDE_KEY, group);
+}
+
+export function clearAffiliationOverride() {
+	localStorage.removeItem(AFFILIATION_OVERRIDE_KEY);
+}
+
+// The effective `*Staff` groups the app should use: the override (as a single-element
+// array) when set, otherwise the user's true affiliation. This is the single value the
+// MOD-resolution chokepoints read so an override transparently retargets the UI.
+export function getEffectiveStaffGroups() {
+	const override = getAffiliationOverride();
+	return override ? [override] : getTrueStaffGroups();
+}
+
+// True when an override is active and actually differs from the user's true affiliation.
+export function isAffiliationOverridden() {
+	const override = getAffiliationOverride();
+	return !!override && !getTrueStaffGroups().includes(override);
+}
+
+// Whether the current user may switch affiliation, given their cognito groups and the
+// running environment. POTester -> any env; Tester -> alpha/beta or local dev; else no.
+export function canSwitchAffiliation({ groups = [], env, isDev = false } = {}) {
+	if (groups.includes(POTESTER_GROUP)) return true;
+	if (groups.includes(TESTER_GROUP)) return isDev || TESTER_ENVS.includes(env);
+	return false;
+}

--- a/src/main/cliapp/src/utils/utils.js
+++ b/src/main/cliapp/src/utils/utils.js
@@ -4,6 +4,7 @@ import { SORT_FIELDS } from '../constants/SortFields';
 import { FIELD_SETS } from '../constants/FilterFields';
 import { Endpoints } from '../constants/Endpoints';
 import { getModTaxa, getCanonicalTaxa } from '../constants/speciesTaxa';
+import { getEffectiveStaffGroups } from './affiliation';
 import { ValidationService } from '../service/ValidationService';
 
 export function returnSorted(event, originalSort) {
@@ -349,13 +350,9 @@ export function buildAutocompleteFilter(event, autocompleteFields) {
 // speciesTaxa cache (loaded by useSpeciesTaxa); returns [] until it has loaded.
 // See constants/speciesTaxa.js (SCRUM-6220).
 export function getCuratorTaxonCuries() {
-	let groups = [];
-	try {
-		const cognitoToken = JSON.parse(localStorage.getItem('cognito-token-storage'));
-		groups = cognitoToken?.accessToken?.payload?.['cognito:groups'] || [];
-	} catch (e) {
-		groups = [];
-	}
+	// Effective groups honor a tester's client-side affiliation override (SCRUM-2831),
+	// so subject / bio-entity autocompletes narrow to the overridden MOD's species.
+	const groups = getEffectiveStaffGroups();
 	const taxa = groups
 		.filter((group) => group.includes('Staff'))
 		.map((group) => group.replace('Staff', ''))


### PR DESCRIPTION
Let Tester/POTester Cognito users temporarily switch their MOD affiliation from the Profile page to test MOD-specific UI. The override is client-side only (localStorage) and never affects Cognito groups or backend data attribution. Gated by env: POTester anywhere incl. production, Tester on alpha/beta/local only.

- affiliation.js: override store + getEffectiveStaffGroups() chokepoint + canSwitchAffiliation() gating; AffiliationContext for reactive UI.
- Route getModTableState/getModFormFields/getCuratorTaxonCuries through the override (DA table layout, form fields, bio-entity species narrowing); no change when no override is set.
- Profile: inline MOD switcher on the Alliance Member row; AppTopbar: red banner naming the mocked MOD; clear override on logout.
- Fix pre-existing specificity tie distorting the command-palette button.
- Add affiliation tests + species-filter override case.