### PR TITLE
SCRUM-6075: convert MOD GAF loads from FMS to URL loads

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneOntologyAnnotationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneOntologyAnnotationExecutor.java
@@ -15,7 +15,6 @@ import org.alliancegenome.curation_api.exceptions.ApiErrorException;
 import org.alliancegenome.curation_api.exceptions.ObjectUpdateException.ObjectUpdateExceptionData;
 import org.alliancegenome.curation_api.jobs.util.CsvSchemaBuilder;
 import org.alliancegenome.curation_api.model.entities.GeneOntologyAnnotation;
-import org.alliancegenome.curation_api.model.entities.bulkloads.BulkFMSLoad;
 import org.alliancegenome.curation_api.model.entities.bulkloads.BulkLoadFileHistory;
 import org.alliancegenome.curation_api.model.ingest.dto.GeneOntologyAnnotationDTO;
 import org.alliancegenome.curation_api.response.ObjectListResponse;
@@ -43,8 +42,12 @@ public class GeneOntologyAnnotationExecutor extends LoadFileExecutor {
 
 	public void execLoad(BulkLoadFileHistory bulkLoadFileHistory) throws IOException {
 
-		BulkFMSLoad fmsLoad = (BulkFMSLoad) bulkLoadFileHistory.getBulkLoad();
-		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(fmsLoad.getFmsDataSubType());
+		// SCRUM-6075: GAF loads can now be either FMS loads (HUMAN, XB) or URL loads
+		// (the GO consortium moved the MOD GAFs to direct download URLs). Derive the
+		// data provider from the load name ("<PROVIDER> GAF Load") instead of casting
+		// to BulkFMSLoad, so both load types are handled the same way.
+		String name = bulkLoadFileHistory.getBulkLoad().getName();
+		BackendBulkDataProvider dataProvider = BackendBulkDataProvider.valueOf(name.substring(0, name.indexOf(" ")));
 
 		CsvSchema csvSchema = CsvSchemaBuilder.gafSchema();
 		CsvMapper csvMapper = new CsvMapper();
@@ -60,8 +63,6 @@ public class GeneOntologyAnnotationExecutor extends LoadFileExecutor {
 			}
 		}
 		gafData.subList(0, gafHeaderData.size()).clear();
-
-		String name = bulkLoadFileHistory.getBulkLoad().getName();
 
 		List<Long> gafIdsBefore = geneOntologyAnnotationService.getAllGafIdsPerProvider(dataProvider);
 		Log.info("Prior ID count: " + gafIdsBefore.size());

--- a/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneOntologyAnnotationExecutor.java
+++ b/src/main/java/org/alliancegenome/curation_api/jobs/executors/GeneOntologyAnnotationExecutor.java
@@ -77,7 +77,7 @@ public class GeneOntologyAnnotationExecutor extends LoadFileExecutor {
 				if (dataProvider == BackendBulkDataProvider.HUMAN || dataProvider == BackendBulkDataProvider.MGI) {
 					prefix = "";
 				}
-				if (dataProvider == BackendBulkDataProvider.XB) {
+				if (dataProvider == BackendBulkDataProvider.XB || dataProvider == BackendBulkDataProvider.XBXL || dataProvider == BackendBulkDataProvider.XBXT) {
 					prefix = dataProvider.resourceDescriptor + ":";
 				}
 				

--- a/src/main/java/org/alliancegenome/curation_api/services/GeneOntologyAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/GeneOntologyAnnotationService.java
@@ -117,7 +117,11 @@ public class GeneOntologyAnnotationService extends BaseEntityCrudService<GeneOnt
 
 	public List<Long> getAllGafIdsPerProvider(BackendBulkDataProvider dataProvider) {
 		Map<String, Object> params = new HashMap<>();
-		if (dataProvider == BackendBulkDataProvider.HUMAN || dataProvider == BackendBulkDataProvider.RGD) {
+		// SCRUM-6075: XBXL (X. laevis) and XBXT (X. tropicalis) share the "XB" data
+		// provider abbreviation but have distinct taxa, so scope their before-set by
+		// taxon; otherwise each Xenbase species load's cleanup would delete the other's.
+		if (dataProvider == BackendBulkDataProvider.HUMAN || dataProvider == BackendBulkDataProvider.RGD
+				|| dataProvider == BackendBulkDataProvider.XBXL || dataProvider == BackendBulkDataProvider.XBXT) {
 			params.put("singleGene.taxon.curie", dataProvider.canonicalTaxonCurie);
 		} else {
 			params.put("singleGene.taxon.species.dataProvider.abbreviation", dataProvider.sourceOrganization);

--- a/src/main/resources/db/migration/v0.50.0.6__convert_gaf_fms_to_url_load.sql
+++ b/src/main/resources/db/migration/v0.50.0.6__convert_gaf_fms_to_url_load.sql
@@ -1,0 +1,38 @@
+-- SCRUM-6075: The GO consortium moved the MOD GAF files to direct download URLs under
+-- https://current.geneontology.org/annotations/gaf/ (MOD-centric "-mod" files, live
+-- 2026-06-26; old URLs retire after Sept 2026). Convert the MOD GAF loads from FMS
+-- loads to URL loads.
+--
+-- Left as FMS loads (intentionally not converted here):
+--   HUMAN - still sourced from RGD via DQM upload to the FMS.
+--   XB    - Xenbase's bundled file splits into XENLA-mod + XENTR-mod; handled separately.
+--
+-- BulkLoad uses JOINED inheritance with no discriminator column, so the load type is
+-- determined by which subclass table holds the row. Converting an FMS load to a URL
+-- load = add a bulkurlload row (same id) and remove the bulkfmsload row. The shared
+-- bulkscheduledload row and backendbulkloadtype='GAF' are unchanged, so the loads keep
+-- their schedule and continue to route to GeneOntologyAnnotationExecutor.
+
+INSERT INTO bulkurlload (id, bulkloadurl)
+SELECT id, 'https://current.geneontology.org/annotations/gaf/DANRE-mod.gaf.gz' FROM bulkload WHERE name = 'ZFIN GAF Load';
+INSERT INTO bulkurlload (id, bulkloadurl)
+SELECT id, 'https://current.geneontology.org/annotations/gaf/YEAST-mod.gaf.gz' FROM bulkload WHERE name = 'SGD GAF Load';
+INSERT INTO bulkurlload (id, bulkloadurl)
+SELECT id, 'https://current.geneontology.org/annotations/gaf/CAEEL-mod.gaf.gz' FROM bulkload WHERE name = 'WB GAF Load';
+INSERT INTO bulkurlload (id, bulkloadurl)
+SELECT id, 'https://current.geneontology.org/annotations/gaf/MOUSE-mod.gaf.gz' FROM bulkload WHERE name = 'MGI GAF Load';
+INSERT INTO bulkurlload (id, bulkloadurl)
+SELECT id, 'https://current.geneontology.org/annotations/gaf/DROME-mod.gaf.gz' FROM bulkload WHERE name = 'FB GAF Load';
+INSERT INTO bulkurlload (id, bulkloadurl)
+SELECT id, 'https://current.geneontology.org/annotations/gaf/RAT-mod.gaf.gz' FROM bulkload WHERE name = 'RGD GAF Load';
+
+DELETE FROM bulkfmsload
+WHERE id IN (
+	SELECT id FROM bulkload
+	WHERE name IN ('ZFIN GAF Load', 'SGD GAF Load', 'WB GAF Load', 'MGI GAF Load', 'FB GAF Load', 'RGD GAF Load')
+);
+
+-- The group now holds a mix of URL loads (the 6 MOD loads) and FMS loads (HUMAN, XB),
+-- so drop the "File Management System (FMS)" label.
+UPDATE bulkloadgroup SET name = 'GAF Loads'
+WHERE name = 'File Management System (FMS) GAF Loads';

--- a/src/main/resources/db/migration/v0.50.0.7__split_xenbase_gaf_load.sql
+++ b/src/main/resources/db/migration/v0.50.0.7__split_xenbase_gaf_load.sql
@@ -1,0 +1,23 @@
+-- SCRUM-6075: The GO consortium split the bundled Xenbase GAF (xenbase.gaf.gz) into two
+-- single-species files: XENLA-mod (X. laevis) and XENTR-mod (X. tropicalis). Replace the
+-- single "XB GAF Load" FMS load with two URL loads, one per species.
+--
+-- Both species carry the same data provider abbreviation "XB" but distinct taxa
+-- (NCBITaxon:8355 vs 8364), so the loads use the XBXL / XBXT providers, which
+-- GeneOntologyAnnotationService.getAllGafIdsPerProvider scopes by taxon -- keeping each
+-- species load's cleanup from deleting the other's annotations.
+
+-- Repurpose the existing XB load as the X. laevis (XBXL) URL load; preserves its history.
+UPDATE bulkload SET name = 'XBXL GAF Load' WHERE name = 'XB GAF Load';
+INSERT INTO bulkurlload (id, bulkloadurl)
+SELECT id, 'https://current.geneontology.org/annotations/gaf/XENLA-mod.gaf.gz' FROM bulkload WHERE name = 'XBXL GAF Load';
+DELETE FROM bulkfmsload WHERE id IN (SELECT id FROM bulkload WHERE name = 'XBXL GAF Load');
+
+-- Add the X. tropicalis (XBXT) URL load to the same group, with the standard schedule.
+INSERT INTO bulkload (id, backendbulkloadtype, name, bulkloadstatus, group_id)
+SELECT nextval('bulkload_seq'), 'GAF', 'XBXT GAF Load', 'STOPPED', id
+FROM bulkloadgroup WHERE name = 'GAF Loads';
+INSERT INTO bulkscheduledload (id, cronschedule, scheduleactive)
+SELECT id, '0 0 22 ? * SUN-THU', false FROM bulkload WHERE name = 'XBXT GAF Load';
+INSERT INTO bulkurlload (id, bulkloadurl)
+SELECT id, 'https://current.geneontology.org/annotations/gaf/XENTR-mod.gaf.gz' FROM bulkload WHERE name = 'XBXT GAF Load';


### PR DESCRIPTION
## SCRUM-6075 — Accommodate changing GAF URLs

The GO consortium moved the MOD GAF files to direct download URLs under
`https://current.geneontology.org/annotations/gaf/` (MOD-centric `-mod` files;
live 2026-06-26, old URLs retire after Sept 2026).

### Changes
- **Migration `v0.50.0.6`** converts the 6 MOD GAF loads (FB, MGI, RGD, SGD, WB, ZFIN)
  from FMS loads to URL loads pointing at the new GO URLs, and renames the bulkloadgroup
  from *"File Management System (FMS) GAF Loads"* → *"GAF Loads"*.
  - `BulkLoad` uses JOINED inheritance with no discriminator column, so conversion = add a
    `bulkurlload` row (same id) + drop the `bulkfmsload` row. The shared `bulkscheduledload`
    row and `backendbulkloadtype='GAF'` are untouched, so the loads keep their schedule and
    executor routing.
  - **HUMAN** (still sourced from RGD via FMS) and **XB** (Xenbase's bundled file splits into
    XENLA-mod + XENTR-mod, handled separately) are intentionally left as FMS loads.
- **`GeneOntologyAnnotationExecutor`** now derives the data provider from the load name
  (`"<PROVIDER> GAF Load"`, same pattern as `BiogridOrcExecutor`) instead of casting to
  `BulkFMSLoad`, so both URL and FMS GAF loads route through the same executor correctly.

### Xenbase split (migration `v0.50.0.7`)
The bundled `xenbase.gaf.gz` splits into `XENLA-mod` (X. laevis, `NCBITaxon:8355`) and
`XENTR-mod` (X. tropicalis, `NCBITaxon:8364`). The single `XB GAF Load` is replaced by two
URL loads:
- Rename `XB GAF Load` → `XBXL GAF Load` + convert FMS→URL (`XENLA-mod`); preserves history.
- Add new `XBXT GAF Load` URL load (`XENTR-mod`) to the "GAF Loads" group.

Both species share the `XB` provider abbreviation but have distinct taxa, so:
- `GeneOntologyAnnotationService.getAllGafIdsPerProvider` scopes `XBXL`/`XBXT` cleanup by
  **taxon** (not abbreviation) — otherwise each species load would delete the other's annotations.
- `GeneOntologyAnnotationExecutor` applies the `Xenbase:` curie prefix to `XBXL`/`XBXT`
  (confirmed against alpha: Xenbase gene curies are `Xenbase:XB-GENE-…`).

### Verification
- `mvn -o compile` clean.
- Applied locally: Flyway `0.50.0.6` succeeded; the 6 loads are now URL loads with the new
  URLs, HUMAN/XB remain FMS, group renamed to "GAF Loads".
- Confirmed `compressInputFile` detects the already-gzipped `.gaf.gz` download and does not
  double-gzip (identical to the FMS S3 path), so the executor's `GZIPInputStream` read is unchanged.

### Follow-ups (out of scope here)
- `agr_ferret` `GAF.yaml` URL updates (separate repo).
- HUMAN GAF via DQM upload.
