### PR TITLE
SCRUM-6161: Fix AlleleGeneAssociations relation filter crashes and ad…

### DIFF
--- a/src/main/cliapp/src/containers/alleleGeneAssociationsPage/AlleleGeneAssociationsTable.jsx
+++ b/src/main/cliapp/src/containers/alleleGeneAssociationsPage/AlleleGeneAssociationsTable.jsx
@@ -65,6 +65,7 @@ export const AlleleGeneAssociationsTable = () => {
 				field: 'relation.name',
 				columnKey: 'relation.name',
 				header: 'Relation',
+				sortable: true,
 				filterConfig: FILTER_CONFIGS.alleleGeneRelationFilterConfig,
 			},
 			{

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Gene.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Gene.java
@@ -162,7 +162,7 @@ public class Gene extends GenomicEntity {
 	)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@OneToMany(mappedBy = "geneAssociationSubject", cascade = CascadeType.ALL, orphanRemoval = true)
-	@JsonView({ CurationView.GeneDetailView.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
+	@JsonView({ CurationView.FieldsAndLists.class, CurationView.GeneDetailView.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
 	private List<GeneGenomicLocationAssociation> geneGenomicLocationAssociations;
 
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/Gene.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/Gene.java
@@ -162,7 +162,7 @@ public class Gene extends GenomicEntity {
 	)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@OneToMany(mappedBy = "geneAssociationSubject", cascade = CascadeType.ALL, orphanRemoval = true)
-	@JsonView({ CurationView.FieldsAndLists.class, CurationView.GeneDetailView.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
+	@JsonView({ CurationView.GeneDetailView.class, CurationView.GeneSummaryDocument.class, CurationView.GeneCacheDocument.class, CurationView.VariantSummaryDocument.class, CurationView.SequenceSummaryDocument.class })
 	private List<GeneGenomicLocationAssociation> geneGenomicLocationAssociations;
 
 

--- a/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AlleleGeneAssociation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/associations/AlleleGeneAssociation.java
@@ -67,6 +67,6 @@ public class AlleleGeneAssociation extends AlleleGenomicEntityAssociation {
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToOne
 	@JsonView({ CurationView.FieldsOnly.class, CurationView.AlleleView.class, CurationView.ForPublic.class })
-	@JsonIgnoreProperties({ "alleleGeneAssociations", "constructGenomicEntityAssociations", "sequenceTargetingReagentGeneAssociations", "transcriptGeneAssociations" })
+	@JsonIgnoreProperties({ "alleleGeneAssociations", "constructGenomicEntityAssociations", "sequenceTargetingReagentGeneAssociations", "transcriptGeneAssociations", "geneGenomicLocationAssociations" })
 	private Gene alleleGeneAssociationObject;
 }


### PR DESCRIPTION
- Select all relations in the Relation filter (note the wide drop down menu after initial click); systematically start turning the filter checkboxes off for each relation item that shows at the top of the table. When I turn off the checkbox for “inversion_breakpoint” the table invariably crashes - Fixed

- Remove FieldsAndLists from Gene.geneGenomicLocationAssociations so it is not serialized when Gene is embedded in AlleleGeneAssociation search results; filters on full_duplication/partial_duplication were returning 200-400MB responses causing browser tab crashes.
-
- Add sortable: true to Relation column now that SQL debug logging is off and both ASC/DESC sorts complete in under 200ms