### PR TITLE
SCRUM-6161: Fix multiselect relation filter using analyzed field inst…

### DIFF
--- a/src/main/cliapp/src/components/Filters/FilterComponentMultiSelect.jsx
+++ b/src/main/cliapp/src/components/Filters/FilterComponentMultiSelect.jsx
@@ -76,7 +76,7 @@ export function FilterComponentMultiSelect({ isInEditMode, filterConfig, current
 						delim = ' ';
 					}
 					filter[fieldSet.fields[0]] = {
-						useKeywordFields: fieldSet.useKeywordFields,
+						useKeywordFields: filterConfig.useKeywordFields,
 						tokenOperator: 'OR',
 						queryString: queryString,
 					};


### PR DESCRIPTION
the filter doesn’t appear to work for the relation type “decreased_translational_product_level”; choosing that relation returns 0 rows in the table, which would be fine if that relation were simply never used, but I found that mouse Pten uses it.