### PR TITLE
SCRUM-6204: Attach resourceDescriptorPage to ExternalDatabaseReference

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ExternalDatabaseReference.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ExternalDatabaseReference.java
@@ -3,11 +3,22 @@ package org.alliancegenome.curation_api.model.entities;
 import org.alliancegenome.curation_api.constants.LinkMLSchemaConstants;
 import org.alliancegenome.curation_api.interfaces.AGRCurationSchemaVersion;
 import org.alliancegenome.curation_api.model.bridges.InformationContentEntityTypeBridge;
+import org.alliancegenome.curation_api.view.CurationView;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.TypeBinderRef;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.TypeBinding;
 
+import com.fasterxml.jackson.annotation.JsonView;
+
 import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -18,7 +29,17 @@ import lombok.ToString;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 @ToString(callSuper = true)
 @Schema(name = "Reference", description = "ExternalDatabaseReference: an external database reference")
-@AGRCurationSchemaVersion(min = "2.10.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {InformationContentEntity.class}, partial = true)
+@AGRCurationSchemaVersion(min = "2.10.0", max = LinkMLSchemaConstants.LATEST_RELEASE, dependencies = {InformationContentEntity.class})
+@Table(indexes = {
+	@Index(name = "externaldatabasereference_resourcedescriptorpage_index", columnList = "resourcedescriptorpage_id")
+})
 public class ExternalDatabaseReference extends InformationContentEntity {
+
+	@IndexedEmbedded(includeDepth = 1)
+	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
+	@ManyToOne
+	@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class, CurationView.GeneExpressionDocument.class})
+	@Fetch(FetchMode.SELECT)
+	private ResourceDescriptorPage resourceDescriptorPage;
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/PhenotypeAnnotationFmsDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/fms/PhenotypeAnnotationFmsDTOValidator.java
@@ -150,6 +150,7 @@ public class PhenotypeAnnotationFmsDTOValidator {
 					if (refCurie.startsWith("MIM:") || refCurie.startsWith("ORPHA:")) {
 						ExternalDatabaseReference externalDbRef = new ExternalDatabaseReference();
 						externalDbRef.setCurie(refCurie);
+						externalDbRef.setResourceDescriptorPage(resourceDescriptorPageService.resolvePageForReferenceCurie(refCurie));
 						reference = externalDatabaseReferenceDAO.persist(externalDbRef);
 					} else {
 						refResponse.addErrorMessage("evidence - publicationId", ValidationConstants.INVALID_MESSAGE + " (" + refCurie + ")");

--- a/src/main/resources/db/migration/v0.51.2.1__external_db_reference_add_rd_page.sql
+++ b/src/main/resources/db/migration/v0.51.2.1__external_db_reference_add_rd_page.sql
@@ -1,0 +1,46 @@
+-- SCRUM-6204: give ExternalDatabaseReference its own resourceDescriptorPage so OMIM/Orphanet
+-- phenotype references carry linkout metadata. Mirrors the CrossReference pattern from SCRUM-6121.
+
+ALTER TABLE externaldatabasereference
+	ADD COLUMN resourcedescriptorpage_id BIGINT;
+
+ALTER TABLE externaldatabasereference
+	ADD CONSTRAINT externaldatabasereference_resourcedescriptorpage_id_fk
+	FOREIGN KEY (resourcedescriptorpage_id)
+	REFERENCES resourcedescriptorpage(id);
+
+CREATE INDEX externaldatabasereference_resourcedescriptorpage_index
+	ON externaldatabasereference (resourcedescriptorpage_id);
+
+-- Backfill existing rows: try (prefix, 'reference') first, then fall back to (prefix, 'default').
+-- Mirrors ResourceDescriptorPageService.resolvePageForReferenceCurie, which reaches
+-- ResourceDescriptorService.getByPrefixOrSynonym -- a prefix-OR-synonym match. The synonym
+-- branch is what lets curies like "ORPHA:1234" resolve to the "Orphanet" descriptor
+-- (which lists "ORPHA" in resourcedescriptor_synonyms).
+UPDATE externaldatabasereference edr
+SET resourcedescriptorpage_id = COALESCE(
+	(SELECT rdp.id
+	   FROM informationcontententity ice
+	   JOIN resourcedescriptor rd
+	     ON rd.prefix = SPLIT_PART(ice.curie, ':', 1)
+	     OR rd.id IN (SELECT rds.resourcedescriptor_id
+	                    FROM resourcedescriptor_synonyms rds
+	                   WHERE rds.synonyms = SPLIT_PART(ice.curie, ':', 1))
+	   JOIN resourcedescriptorpage rdp
+	     ON rdp.resourcedescriptor_id = rd.id
+	    AND rdp.name = 'reference'
+	  WHERE ice.id = edr.id
+	  LIMIT 1),
+	(SELECT rdp.id
+	   FROM informationcontententity ice
+	   JOIN resourcedescriptor rd
+	     ON rd.prefix = SPLIT_PART(ice.curie, ':', 1)
+	     OR rd.id IN (SELECT rds.resourcedescriptor_id
+	                    FROM resourcedescriptor_synonyms rds
+	                   WHERE rds.synonyms = SPLIT_PART(ice.curie, ':', 1))
+	   JOIN resourcedescriptorpage rdp
+	     ON rdp.resourcedescriptor_id = rd.id
+	    AND rdp.name = 'default'
+	  WHERE ice.id = edr.id
+	  LIMIT 1)
+);


### PR DESCRIPTION
Prepares EDR-typed evidenceItems (OMIM MIM:xxx and Orphanet ORPHA:xxx) for upcoming indexer + UI work by giving them the same linkout metadata CrossReference already carries. New rows populate via the FMS validator; existing rows backfill via v0.51.1.1 using a synonym-aware match that mirrors ResourceDescriptorPageService.resolvePageForReferenceCurie.