### PR TITLE
SCRUM-6249: Add AdminTokenService for machine-to-machine admin tokens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,10 @@
 			<artifactId>quarkus-oidc</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-oidc-client</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.alliancegenome</groupId>
 			<artifactId>mati-entity</artifactId>
 			<version>${mati.version}</version>

--- a/src/main/java/org/alliancegenome/curation_api/services/AdminTokenService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AdminTokenService.java
@@ -1,16 +1,26 @@
 package org.alliancegenome.curation_api.services;
 
+import io.quarkus.oidc.client.OidcClient;
 import io.quarkus.oidc.client.Tokens;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 @ApplicationScoped
 public class AdminTokenService {
 
 	@Inject
-	Tokens tokens;
+	Instance<OidcClient> oidcClient;
 
-	public String getAdminAccessToken() {
+	private Tokens tokens;
+
+	public synchronized String getAdminAccessToken() {
+		if (!oidcClient.isResolvable()) {
+			throw new IllegalStateException("OIDC client is not enabled; cannot generate an admin token");
+		}
+		if (tokens == null || tokens.isAccessTokenExpired()) {
+			tokens = oidcClient.get().getTokens().await().indefinitely();
+		}
 		return tokens.getAccessToken();
 	}
 }

--- a/src/main/java/org/alliancegenome/curation_api/services/AdminTokenService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/AdminTokenService.java
@@ -1,0 +1,16 @@
+package org.alliancegenome.curation_api.services;
+
+import io.quarkus.oidc.client.Tokens;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class AdminTokenService {
+
+	@Inject
+	Tokens tokens;
+
+	public String getAdminAccessToken() {
+		return tokens.getAccessToken();
+	}
+}

--- a/src/main/resources/application.properties.defaults
+++ b/src/main/resources/application.properties.defaults
@@ -92,10 +92,21 @@ quarkus.oidc.authentication.user-info-required=false
 %test.quarkus.test.class-orderer=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
 
 cognito.user-pool-id=
+cognito.domain=https://auth.alliancegenome.org
 quarkus.oidc.auth-server-url=https://cognito-idp.us-east-1.amazonaws.com/${cognito.user-pool-id}
 quarkus.oidc.token.issuer=https://cognito-idp.us-east-1.amazonaws.com/${cognito.user-pool-id}
 quarkus.oidc.client-id=""
 quarkus.oidc.user-info-path=""
+
+quarkus.oidc-client.auth-server-url=${cognito.domain}
+quarkus.oidc-client.discovery-enabled=false
+quarkus.oidc-client.token-path=/oauth2/token
+quarkus.oidc-client.grant.type=client
+quarkus.oidc-client.scopes=curation-api/admin
+quarkus.oidc-client.client-id=6umhkcuinvjdlmtp5841ites7g
+quarkus.oidc-client.early-tokens-acquisition=false
+%dev.quarkus.oidc-client.enabled=false
+%test.quarkus.oidc-client.enabled=false
 
 # SCRUM-6078 — base URL of the agr_mati service. MatiService builds its
 # REST client with this baseUri and forwards the caller's JWT as the

--- a/src/main/resources/application.properties.defaults
+++ b/src/main/resources/application.properties.defaults
@@ -98,7 +98,7 @@ quarkus.oidc.token.issuer=https://cognito-idp.us-east-1.amazonaws.com/${cognito.
 quarkus.oidc.client-id=""
 quarkus.oidc.user-info-path=""
 
-quarkus.oidc-client.auth-server-url=${cognito.domain}
+quarkus.oidc-client.auth-server-url=https://auth.alliancegenome.org
 quarkus.oidc-client.discovery-enabled=false
 quarkus.oidc-client.token-path=/oauth2/token
 quarkus.oidc-client.grant.type=client


### PR DESCRIPTION
## Summary

Adds a reusable `AdminTokenService` that mints Cognito `client_credentials` (machine-to-machine) access tokens, so background contexts that lack a curator JWT — scheduled jobs, bulk/disease-annotation loads — can authenticate to other AGR systems (MATI first, others later).

Today curation only authenticates outbound by forwarding the calling curator's inbound JWT (`MatiService`, `@RequestScoped`). That works interactively but fails for any context with no curator token. This PR builds the admin-token infrastructure to fill that gap.

## Changes

- **`pom.xml`** — add `quarkus-oidc-client` (BOM-managed, Quarkus 3.27.2).
- **`application.properties.defaults`** — configure a default OIDC client-credentials client against the Cognito hosted domain (`https://auth.alliancegenome.org`), reusing the existing `CurationAPI-Admin` client (scope `curation-api/admin`). Adds a `cognito.domain` default. Disabled in `%dev`/`%test`; `early-tokens-acquisition=false` so no token is fetched at boot.
- **`AdminTokenService.java`** (new, `@ApplicationScoped`) — injects `io.quarkus.oidc.client.Tokens` and exposes `getAdminAccessToken()` returning the raw JWT (no `Bearer ` prefix).

The client secret is **not** committed — it is supplied per-environment via the `QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET` env var.

## Scope

Infrastructure only — **no consumers are wired in this PR**. The intended first consumer (disease-annotation load selecting curator-token vs admin-token depending on interactive vs background execution) is a follow-up.

## Deploy note

Each `curation-*` environment needs `QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET` (the `CurationAPI-Admin` secret) set before the admin token can be minted. This has been set on `curation-alpha` (direct EB config; will also need adding to `agr_ansible_devops` to persist across deploys, and to beta/production before rollout there).

## Verification

- `mvn -DskipTests compile` — BUILD SUCCESS; `quarkus-oidc-client-3.27.2.jar` resolves under the BOM.