### PR TITLE
SCRUM-6204: add typed findAllForPublic on ResourceDescriptorPageCrudI…

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/controllers/crud/ResourceDescriptorPageCrudController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/crud/ResourceDescriptorPageCrudController.java
@@ -1,10 +1,13 @@
 package org.alliancegenome.curation_api.controllers.crud;
 
+import java.util.HashMap;
+
 import org.alliancegenome.curation_api.controllers.base.BaseEntityCrudController;
 import org.alliancegenome.curation_api.dao.ResourceDescriptorPageDAO;
 import org.alliancegenome.curation_api.interfaces.crud.ResourceDescriptorPageCrudInterface;
 import org.alliancegenome.curation_api.model.entities.ResourceDescriptorPage;
 import org.alliancegenome.curation_api.response.ObjectResponse;
+import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.curation_api.services.ResourceDescriptorPageService;
 
 import jakarta.annotation.PostConstruct;
@@ -36,6 +39,11 @@ public class ResourceDescriptorPageCrudController extends BaseEntityCrudControll
 	@Override
 	public ObjectResponse<ResourceDescriptorPage> update(ResourceDescriptorPage entity) {
 		return resourceDescriptorPageService.update(entity);
+	}
+
+	@Override
+	public SearchResponse<ResourceDescriptorPage> findAllForPublic(Integer page, Integer limit, HashMap<String, Object> params) {
+		return find(page, limit, params);
 	}
 
 }

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ResourceDescriptorPageCrudInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/crud/ResourceDescriptorPageCrudInterface.java
@@ -32,6 +32,12 @@ public interface ResourceDescriptorPageCrudInterface extends BaseIdCrudInterface
 	@Tag(name = "Elastic Search Browsing Endpoints")
 	SearchResponse<ResourceDescriptorPage> search(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
 
+	@POST
+	@Path("/findAllForPublic")
+	@JsonView(CurationView.ForPublic.class)
+	@Tag(name = "Public Web API Database Searching Endpoints")
+	SearchResponse<ResourceDescriptorPage> findAllForPublic(@DefaultValue("0") @QueryParam("page") Integer page, @DefaultValue("10") @QueryParam("limit") Integer limit, HashMap<String, Object> params);
+
 	@Override
 	@POST
 	@Path("/")


### PR DESCRIPTION
…nterface

Consumed by agr_indexer's ResourceDescriptorService. The inherited findForPublic returns raw jakarta.ws.rs.core.Response which RESCU can't deserialize. New method returns typed SearchResponse under CurationView.ForPublic, so all prefix + synonym mappings resolve correctly.