### PR TITLE
SCRUM-6268 fix cascade delete of shared entities referenced by HTPExpressionDatasetAnnotation

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/HTPExpressionDatasetAnnotation.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/HTPExpressionDatasetAnnotation.java
@@ -55,13 +55,17 @@ public class HTPExpressionDatasetAnnotation extends AuditedObject {
 
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
-	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+	// SCRUM-6268: no cascade REMOVE/orphanRemoval - this is a shared lookup row (found/created by curie,
+	// see ExternalDataBaseEntityFmsDTOValidator) that HTPExpressionDatasetSampleAnnotation.datasetIds may
+	// still reference independently, so deleting this annotation must not cascade-delete it.
+	@OneToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE })
 	@JsonView({ CurationView.FieldsOnly.class })
 	private ExternalDataBaseEntity htpExpressionDataset;
 
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToMany
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	@Fetch(FetchMode.JOIN)
 	@JoinTable(indexes = {
 		@Index(name = "htpdatasetannotation_externaldatabaseentity_htpdataset_index", columnList = "htpexpressiondatasetannotation_id"),
@@ -79,6 +83,7 @@ public class HTPExpressionDatasetAnnotation extends AuditedObject {
 	@IndexedEmbedded(includePaths = {"curie", "primaryCrossReferenceCurie", "crossReferences.referencedCurie", "curie_keyword", "primaryCrossReferenceCurie_keyword", "crossReferences.referencedCurie_keyword"})
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@ManyToMany
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	@Fetch(FetchMode.JOIN)
 	@JoinTable(indexes = {
 		@Index(name = "htpdatasetannotation_reference_htpdataset_index", columnList = "htpexpressiondatasetannotation_id"),

--- a/src/main/resources/db/migration/v0.52.0.2__htp_dataset_annotation_join_fk_cascade.sql
+++ b/src/main/resources/db/migration/v0.52.0.2__htp_dataset_annotation_join_fk_cascade.sql
@@ -1,0 +1,20 @@
+-- SCRUM-6268: these join tables back-reference htpexpressiondatasetannotation without ON DELETE CASCADE,
+-- so deleting an obsolete annotation fails with a FK violation whenever categoryTags (required on every
+-- annotation), references, or subSeries are populated. Cascading only the join rows (never the shared
+-- VocabularyTerm/Reference/ExternalDataBaseEntity targets) matches the cascade semantics already declared
+-- on these fields in HTPExpressionDatasetAnnotation.java.
+
+ALTER TABLE htpexpressiondatasetannotation_categorytags
+	DROP CONSTRAINT htpdatasetannotation_categorytags_htpdatasetannotation_id_fk;
+ALTER TABLE htpexpressiondatasetannotation_categorytags
+	ADD CONSTRAINT htpdatasetannotation_categorytags_htpdatasetannotation_id_fk FOREIGN KEY (htpexpressiondatasetannotation_id) REFERENCES htpexpressiondatasetannotation(id) ON DELETE CASCADE;
+
+ALTER TABLE htpexpressiondatasetannotation_reference
+	DROP CONSTRAINT htpdatasetannotation_reference_htpdatasetannotation_id_fk;
+ALTER TABLE htpexpressiondatasetannotation_reference
+	ADD CONSTRAINT htpdatasetannotation_reference_htpdatasetannotation_id_fk FOREIGN KEY (htpexpressiondatasetannotation_id) REFERENCES htpexpressiondatasetannotation(id) ON DELETE CASCADE;
+
+ALTER TABLE htpexpressiondatasetannotation_externaldatabaseentity
+	DROP CONSTRAINT htpannotation_externaldbentity_htpannotation_id_fk;
+ALTER TABLE htpexpressiondatasetannotation_externaldatabaseentity
+	ADD CONSTRAINT htpannotation_externaldbentity_htpannotation_id_fk FOREIGN KEY (htpexpressiondatasetannotation_id) REFERENCES htpexpressiondatasetannotation(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Summary
- Trim `HTPExpressionDatasetAnnotation.htpExpressionDataset` cascade from `ALL`+`orphanRemoval` to `PERSIST`/`MERGE`, since the linked `ExternalDataBaseEntity` is a shared lookup row (found-or-created by curie) that other annotations may still reference.
- Add `@OnDelete(action = OnDeleteAction.CASCADE)` to the `categoryTags`/`reference` `@ManyToMany` join fields, and add a matching migration to cascade the join-table FK constraints at the DB level.
- Net effect: deleting an annotation removes its own join rows but leaves shared datasets/tags/references intact for other annotations.

## Test plan
- [ ] Delete an `HTPExpressionDatasetAnnotation` with populated `categoryTags`/`reference`/`subSeries` and confirm no FK violation
- [ ] Confirm the shared `ExternalDataBaseEntity` dataset row survives deletion of one annotation when referenced elsewhere
- [ ] Run migration `v0.52.0.2` against a local DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)