### PR TITLE
SCRUM-6253: expose resource descriptor fields to public view

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/model/entities/ResourceDescriptor.java
+++ b/src/main/java/org/alliancegenome/curation_api/model/entities/ResourceDescriptor.java
@@ -19,6 +19,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmb
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 
 import jakarta.persistence.CascadeType;
@@ -70,13 +71,13 @@ public class ResourceDescriptor extends AuditedObject {
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "idPattern_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class })
 	@EqualsAndHashCode.Include
 	private String idPattern;
 
 	@FullTextField(analyzer = "autocompleteAnalyzer", searchAnalyzer = "autocompleteSearchAnalyzer")
 	@KeywordField(name = "idExample_keyword", aggregable = Aggregable.YES, sortable = Sortable.YES, searchable = Searchable.YES, normalizer = "sortNormalizer")
-	@JsonView({ CurationView.FieldsOnly.class })
+	@JsonView({ CurationView.FieldsOnly.class, CurationView.ForPublic.class })
 	@EqualsAndHashCode.Include
 	private String idExample;
 
@@ -89,6 +90,7 @@ public class ResourceDescriptor extends AuditedObject {
 	@IndexedEmbedded(includeDepth = 1)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	@OneToMany(mappedBy = "resourceDescriptor", cascade = CascadeType.ALL)
-	@JsonView({ CurationView.ResourceDescriptorView.class, CurationView.FieldsAndLists.class })
+	@JsonView({ CurationView.ResourceDescriptorView.class, CurationView.FieldsAndLists.class, CurationView.ForPublic.class })
+	@JsonIgnoreProperties("resourceDescriptor")
 	private List<ResourceDescriptorPage> resourcePages;
 }


### PR DESCRIPTION
Add CurationView.ForPublic to idExample, idPattern, and resourcePages, and @JsonIgnoreProperties("resourceDescriptor") on resourcePages to break the ResourceDescriptor/ResourceDescriptorPage cycle.