### PR TITLE
SCRUM-6276 add maxToMint cap to /system/mintdacuries backfill endpoint

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/controllers/SystemController.java
+++ b/src/main/java/org/alliancegenome/curation_api/controllers/SystemController.java
@@ -44,8 +44,8 @@ public class SystemController implements SystemControllerInterface {
 	}
 
 	@Override
-	public void mintExistingDiseaseAnnotationCuries(Integer batchSize) {
-		diseaseAnnotationService.mintMissingCuries(batchSize);
+	public void mintExistingDiseaseAnnotationCuries(Integer batchSize, Integer maxToMint) {
+		diseaseAnnotationService.mintMissingCuries(batchSize, maxToMint);
 	}
 
 	@Override

--- a/src/main/java/org/alliancegenome/curation_api/interfaces/SystemControllerInterface.java
+++ b/src/main/java/org/alliancegenome/curation_api/interfaces/SystemControllerInterface.java
@@ -41,10 +41,17 @@ public interface SystemControllerInterface {
 	// SCRUM-6078 backfill endpoint. Mints AGRKB curies for every
 	// DiseaseAnnotation whose curie is currently NULL, in batches.
 	// Idempotent. Remove after rollout on alpha/beta/prod.
+	//
+	// maxToMint caps the TOTAL number of annotations minted in a single call
+	// so a cold full-table run cannot overwhelm the environment. 0 = no cap
+	// (mint every NULL-curie annotation). Because the backfill is idempotent,
+	// the endpoint can be called repeatedly with a bounded maxToMint to work
+	// through the table in safe chunks.
 	@GET
 	@Path("/mintdacuries")
 	void mintExistingDiseaseAnnotationCuries(
-		@DefaultValue("1000") @QueryParam("batchSize") Integer batchSize);
+		@DefaultValue("1000") @QueryParam("batchSize") Integer batchSize,
+		@DefaultValue("0") @QueryParam("maxToMint") Integer maxToMint);
 
 	@DELETE
 	@Path("/deletedUnusedConditionsAndExperiments")

--- a/src/main/java/org/alliancegenome/curation_api/services/DiseaseAnnotationService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/DiseaseAnnotationService.java
@@ -52,8 +52,8 @@ public class DiseaseAnnotationService extends BaseAnnotationCrudService<DiseaseA
 	// SCRUM-6078 backfill: mints AGRKB curies for every DiseaseAnnotation
 	// with a NULL curie. Idempotent. Throwaway — remove together with the
 	// /system/mintdacuries endpoint once it has run on every environment.
-	public void mintMissingCuries(int batchSize) {
-		curieMintHelper.mintMissingCuries(batchSize);
+	public void mintMissingCuries(int batchSize, int maxToMint) {
+		curieMintHelper.mintMissingCuries(batchSize, maxToMint);
 	}
 
 	// SCRUM-6170: mint an AGRKB curie for a newly created/loaded disease

--- a/src/main/java/org/alliancegenome/curation_api/services/helpers/annotations/DiseaseAnnotationCurieMintHelper.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/helpers/annotations/DiseaseAnnotationCurieMintHelper.java
@@ -72,17 +72,35 @@ public class DiseaseAnnotationCurieMintHelper {
 		}
 	}
 
-	public void mintMissingCuries(int batchSize) {
+	/**
+	 * @param batchSize how many annotations to mint per batch/MaTI call
+	 * @param maxToMint hard cap on the TOTAL number of annotations minted in
+	 *        this call; {@code 0} means no cap (mint every NULL-curie row).
+	 *        Bounding the total lets an operator work a large cold backfill
+	 *        through the table in safe chunks instead of in one run that could
+	 *        overwhelm the environment. Idempotent, so repeated capped calls
+	 *        pick up where the previous one left off.
+	 */
+	public void mintMissingCuries(int batchSize, int maxToMint) {
 		if (batchSize <= 0) {
 			throw new IllegalArgumentException("batchSize must be > 0, got " + batchSize);
 		}
+		if (maxToMint < 0) {
+			throw new IllegalArgumentException("maxToMint must be >= 0 (0 = no cap), got " + maxToMint);
+		}
 
 		long totalMissing = countMissing();
-		ProcessDisplayHelper pdh = new ProcessDisplayHelper();
-		pdh.startProcess("DiseaseAnnotation AGRKB curie mint", totalMissing);
+		// maxToMint == 0 means mint everything that is missing.
+		long target = maxToMint == 0 ? totalMissing : Math.min(totalMissing, maxToMint);
 
-		while (true) {
-			List<Long> batchIds = findMissingCurieIds(batchSize);
+		ProcessDisplayHelper pdh = new ProcessDisplayHelper();
+		pdh.startProcess("DiseaseAnnotation AGRKB curie mint", target);
+
+		long minted = 0;
+		while (minted < target) {
+			// Never fetch more than the remaining allowance towards the cap.
+			int thisBatch = (int) Math.min(batchSize, target - minted);
+			List<Long> batchIds = findMissingCurieIds(thisBatch);
 			if (batchIds.isEmpty()) {
 				break;
 			}
@@ -93,6 +111,7 @@ public class DiseaseAnnotationCurieMintHelper {
 
 			assignCuries(batchIds, curies);
 
+			minted += batchIds.size();
 			for (int i = 0; i < batchIds.size(); i++) {
 				pdh.progressProcess();
 			}


### PR DESCRIPTION
Bounds the total number of DiseaseAnnotations minted per call so a cold full-table backfill cannot overwhelm the environment. maxToMint=0 keeps the previous unlimited behavior; a bounded value lets the idempotent endpoint be called repeatedly to work through the table in safe chunks.