### PR TITLE
SCRUM-6152 include 6 yeast AGMs into indexing

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/constants/YeastStrainTaxonConstants.java
+++ b/src/main/java/org/alliancegenome/curation_api/constants/YeastStrainTaxonConstants.java
@@ -1,0 +1,41 @@
+package org.alliancegenome.curation_api.constants;
+
+import java.util.List;
+
+/**
+ * SCRUM-6152 - SGD strain-level taxa that must resolve to the single curated
+ * Saccharomyces cerevisiae species row when building public search documents.
+ *
+ * Only 7 of the 13 SGD AGMs carry the canonical taxon NCBITaxon:559292; the rest sit on
+ * strain-level taxa that have no row in the `species` table, so the species join in the
+ * search DAOs yields a null species and those models never appear under the
+ * "Saccharomyces cerevisiae" facet on the public site.
+ *
+ * NCBITaxon:4932 is the conceptual root for the yeast strains per SCRUM-6152, but the
+ * curated `species` row stays pinned to NCBITaxon:559292: repointing it would move the
+ * species anchor out from under the ~8k SGD genes and ~23k SGD alleles already on 559292.
+ * The grouping is therefore applied at query time only - no `biologicalentity.taxon_id` is
+ * changed and no new entity is associated with NCBITaxon:4932.
+ *
+ * This is deliberately hardcoded: the NCBITaxon closure is not loaded into
+ * `ontologytermclosure` (only DO/GO are), so there is no generic ancestor lookup available.
+ */
+public final class YeastStrainTaxonConstants {
+
+	private YeastStrainTaxonConstants() {
+		// Hidden from view, as it is a utility class
+	}
+
+	/** The taxon the curated Saccharomyces cerevisiae `species` row is keyed to. */
+	public static final String CANONICAL_SCE_TAXON = "NCBITaxon:559292";
+
+	/** Yeast taxa that carry no `species` row of their own and must fall back to the canonical one. */
+	public static final List<String> SCE_STRAIN_TAXA = List.of(
+		"NCBITaxon:4932",   // Saccharomyces cerevisiae (root term)
+		"NCBITaxon:285006", // Saccharomyces cerevisiae RM11-1a
+		"NCBITaxon:580239", // Saccharomyces cerevisiae SK1
+		"NCBITaxon:580240", // Saccharomyces cerevisiae W303
+		"NCBITaxon:658763", // Saccharomyces cerevisiae Sigma1278b
+		"NCBITaxon:947036"  // Saccharomyces cerevisiae FL100
+	);
+}

--- a/src/main/java/org/alliancegenome/curation_api/dao/AffectedGenomicModelDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/AffectedGenomicModelDAO.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
+import org.alliancegenome.curation_api.constants.YeastStrainTaxonConstants;
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.document.es.ModelSearchResultDocument;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
@@ -145,7 +146,11 @@ public class AffectedGenomicModelDAO extends BaseSQLDAO<AffectedGenomicModel> {
 				ON sa_full.singleagm_id = a.id
 				AND sa_full.slotannotationtype = 'AgmFullNameSlotAnnotation'
 			LEFT JOIN ontologyterm ot ON ot.id = be.taxon_id
-			LEFT JOIN species sp ON sp.taxon_id = ot.id
+			-- SCRUM-6152: SGD strain-level taxa have no `species` row of their own, so they
+			-- resolve through the canonical S. cerevisiae taxon. Everything else joins as-is.
+			LEFT JOIN ontologyterm ot_eff
+				ON ot_eff.curie = CASE WHEN ot.curie IN :strainTaxa THEN :canonicalTaxon ELSE ot.curie END
+			LEFT JOIN species sp ON sp.taxon_id = ot_eff.id
 			LEFT JOIN crossreference cr ON cr.id = be.dataprovidercrossreference_id
 			LEFT JOIN resourcedescriptorpage rd ON rd.id = cr.resourcedescriptorpage_id
 			WHERE a.id IN :ids
@@ -153,6 +158,8 @@ public class AffectedGenomicModelDAO extends BaseSQLDAO<AffectedGenomicModel> {
 
 		Query rootQuery = entityManager.createNativeQuery(rootSql);
 		rootQuery.setParameter("ids", agmIds);
+		rootQuery.setParameter("strainTaxa", YeastStrainTaxonConstants.SCE_STRAIN_TAXA);
+		rootQuery.setParameter("canonicalTaxon", YeastStrainTaxonConstants.CANONICAL_SCE_TAXON);
 		List<Object[]> rootRows = rootQuery.getResultList();
 
 		for (Object[] row : rootRows) {

--- a/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
+++ b/src/main/java/org/alliancegenome/curation_api/dao/AlleleDAO.java
@@ -13,6 +13,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.constants.EntityFieldConstants;
+import org.alliancegenome.curation_api.constants.YeastStrainTaxonConstants;
 import org.alliancegenome.curation_api.dao.associations.AgmAlleleAssociationDAO;
 import org.alliancegenome.curation_api.dao.base.BaseSQLDAO;
 import org.alliancegenome.curation_api.model.document.es.AlleleSummaryDocument;
@@ -292,7 +293,12 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 			INNER JOIN CrossReference cr ON cr.id = b.dataprovidercrossreference_id
 			INNER JOIN resourceDescriptorPage rd ON rd.id = cr.resourcedescriptorpage_id
 			INNER JOIN organization org ON org.id = b.dataprovider_id
-			LEFT JOIN species sp ON sp.taxon_id = ot.id
+			-- SCRUM-6152: SGD strain-level taxa have no `species` row of their own, so they
+			-- resolve through the canonical S. cerevisiae taxon. Everything else joins as-is.
+			-- The allele's own taxon (ot) is unchanged - only the attached species resolves.
+			LEFT JOIN OntologyTerm ot_eff
+				ON ot_eff.curie = CASE WHEN ot.curie IN :strainTaxa THEN :canonicalTaxon ELSE ot.curie END
+			LEFT JOIN species sp ON sp.taxon_id = ot_eff.id
 			LEFT JOIN genomeassembly ga ON ga.id = sp.genomeassembly_id
 			LEFT JOIN biologicalentity ga_be ON ga_be.id = ga.id
 			WHERE a.id IN :alleleIds
@@ -300,6 +306,8 @@ public class AlleleDAO extends BaseSQLDAO<Allele> {
 
 		Query query = entityManager.createNativeQuery(selectQuery);
 		query.setParameter("alleleIds", alleleIds);
+		query.setParameter("strainTaxa", YeastStrainTaxonConstants.SCE_STRAIN_TAXA);
+		query.setParameter("canonicalTaxon", YeastStrainTaxonConstants.CANONICAL_SCE_TAXON);
 		List<Object[]> results = query.getResultList();
 
 		List<Allele> alleles = buildAllelesFromResults(results);

--- a/src/test/java/org/alliancegenome/curation_api/IT_2002_YeastStrainSpeciesResolutionITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_2002_YeastStrainSpeciesResolutionITCase.java
@@ -4,7 +4,9 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.alliancegenome.curation_api.base.BaseITCase;
 import org.alliancegenome.curation_api.constants.VocabularyConstants;
@@ -62,6 +64,18 @@ public class IT_2002_YeastStrainSpeciesResolutionITCase extends BaseITCase {
 	// A real taxon that is neither curated in `species` nor in the yeast strain list.
 	private static final String UNCURATED_TAXON = "NCBITaxon:7955";
 
+	/** The SGD strain taxa this test loads AGMs for, with their NCBI scientific names. */
+	private static final Map<String, String> STRAIN_TAXA = new LinkedHashMap<>() {
+		{
+			put("NCBITaxon:4932", "Saccharomyces cerevisiae");
+			put("NCBITaxon:285006", "Saccharomyces cerevisiae RM11-1a");
+			put("NCBITaxon:580239", "Saccharomyces cerevisiae SK1");
+			put("NCBITaxon:580240", "Saccharomyces cerevisiae W303");
+			put("NCBITaxon:658763", "Saccharomyces cerevisiae Sigma1278b");
+			put("NCBITaxon:947036", "Saccharomyces cerevisiae FL100");
+		}
+	};
+
 	private static final String MODEL_SUMMARY_ENDPOINT = "/api/model/document/summary/byids";
 	private static final String ALLELE_SUMMARY_ENDPOINT = "/api/allele/document/summary/byids";
 
@@ -82,6 +96,17 @@ public class IT_2002_YeastStrainSpeciesResolutionITCase extends BaseITCase {
 		dataProvider = getOrganization("SGD");
 		ResourceDescriptor resourceDescriptor = createResourceDescriptor("YEASTTEST");
 		resourceDescriptorPage = createResourceDescriptorPage("homepage", "http://example.com/yeast/[%s]", resourceDescriptor);
+
+		// Create the strain taxa up front rather than letting getNCBITaxonTerm resolve them.
+		// NcbiTaxonTermService.getByCurie falls back to downloading from eutils.ncbi.nlm.nih.gov
+		// when a taxon is not already in the database, and these six strain-level taxa are used
+		// by no other IT, so every one of them would be a live network call. Requesting them
+		// back to back trips NCBI's rate limit - downloadAndSave retries five times with no
+		// backoff and then returns null, which makes the AGM create fail validation with a 400.
+		// That is what failed CI here: the first four AGMs were created and the fifth was not.
+		for (Map.Entry<String, String> strainTaxon : STRAIN_TAXA.entrySet()) {
+			createNCBITaxonTerm(strainTaxon.getKey(), strainTaxon.getValue(), false);
+		}
 
 		// The IT database ships with no `species` rows: the v0.29.0.2 seed is guarded on
 		// ncbitaxonterm already being populated, which it is not at migration time. Create the

--- a/src/test/java/org/alliancegenome/curation_api/IT_2002_YeastStrainSpeciesResolutionITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_2002_YeastStrainSpeciesResolutionITCase.java
@@ -1,0 +1,278 @@
+package org.alliancegenome.curation_api;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.List;
+
+import org.alliancegenome.curation_api.base.BaseITCase;
+import org.alliancegenome.curation_api.constants.VocabularyConstants;
+import org.alliancegenome.curation_api.constants.YeastStrainTaxonConstants;
+import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
+import org.alliancegenome.curation_api.model.entities.Allele;
+import org.alliancegenome.curation_api.model.entities.CrossReference;
+import org.alliancegenome.curation_api.model.entities.Organization;
+import org.alliancegenome.curation_api.model.entities.ResourceDescriptor;
+import org.alliancegenome.curation_api.model.entities.ResourceDescriptorPage;
+import org.alliancegenome.curation_api.model.entities.Species;
+import org.alliancegenome.curation_api.model.entities.Vocabulary;
+import org.alliancegenome.curation_api.model.entities.VocabularyTerm;
+import org.alliancegenome.curation_api.model.entities.ontology.NCBITaxonTerm;
+import org.alliancegenome.curation_api.model.entities.slotAnnotations.AgmFullNameSlotAnnotation;
+import org.alliancegenome.curation_api.model.entities.slotAnnotations.AlleleSymbolSlotAnnotation;
+import org.alliancegenome.curation_api.resources.TestContainerResource;
+import org.alliancegenome.curation_api.response.ObjectResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+
+/**
+ * SCRUM-6152 - all 13 SGD models must be reachable under the single "Saccharomyces cerevisiae"
+ * species facet on the public site, not just the 7 that carry the canonical NCBITaxon:559292.
+ *
+ * The strain-level taxa have no row of their own in `species`, so before the fix the species
+ * join in the search DAOs yielded a null species and those models produced no facet bucket.
+ * These tests cover the query-time fallback that resolves them to the canonical species row,
+ * for both the model and the allele search documents.
+ */
+@QuarkusIntegrationTest
+@QuarkusTestResource(TestContainerResource.Initializer.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("2002 - YeastStrainSpeciesResolutionITCase")
+@Order(2002)
+@SuppressWarnings("checkstyle:TypeNameCheck")
+public class IT_2002_YeastStrainSpeciesResolutionITCase extends BaseITCase {
+
+	private static final String SCE_FULL_NAME = "Saccharomyces cerevisiae";
+	private static final String SCE_ABBREVIATION = "Sce";
+	private static final String MMU_FULL_NAME = "Mus musculus";
+	private static final String MMU_ABBREVIATION = "Mmu";
+
+	private static final String MOUSE_TAXON = "NCBITaxon:10090";
+	// A real taxon that is neither curated in `species` nor in the yeast strain list.
+	private static final String UNCURATED_TAXON = "NCBITaxon:7955";
+
+	private static final String MODEL_SUMMARY_ENDPOINT = "/api/model/document/summary/byids";
+	private static final String ALLELE_SUMMARY_ENDPOINT = "/api/allele/document/summary/byids";
+
+	private VocabularyTerm fullNameType;
+	private VocabularyTerm symbolNameType;
+	private VocabularyTerm strainSubtype;
+	private Organization dataProvider;
+	private ResourceDescriptorPage resourceDescriptorPage;
+
+	private void loadRequiredEntities() {
+		Vocabulary nameTypeVocabulary = getVocabulary(VocabularyConstants.NAME_TYPE_VOCABULARY);
+		fullNameType = getVocabularyTerm(nameTypeVocabulary, "full_name");
+		symbolNameType = getVocabularyTerm(nameTypeVocabulary, "nomenclature_symbol");
+
+		Vocabulary subtypeVocabulary = getVocabulary(VocabularyConstants.AGM_SUBTYPE_VOCABULARY);
+		strainSubtype = getVocabularyTerm(subtypeVocabulary, "strain");
+
+		dataProvider = getOrganization("SGD");
+		ResourceDescriptor resourceDescriptor = createResourceDescriptor("YEASTTEST");
+		resourceDescriptorPage = createResourceDescriptorPage("homepage", "http://example.com/yeast/[%s]", resourceDescriptor);
+
+		// The IT database ships with no `species` rows: the v0.29.0.2 seed is guarded on
+		// ncbitaxonterm already being populated, which it is not at migration time. Create the
+		// two species rows these tests resolve against.
+		createSpecies(YeastStrainTaxonConstants.CANONICAL_SCE_TAXON, SCE_FULL_NAME, SCE_ABBREVIATION, "SGD", 70);
+		createSpecies(MOUSE_TAXON, MMU_FULL_NAME, MMU_ABBREVIATION, "MGI", 40);
+	}
+
+	// All six strain-level taxa, plus the canonical one, must resolve to the single curated
+	// S. cerevisiae species row - this is what puts all 13 SGD models in one facet bucket.
+	@Test
+	@Order(1)
+	public void testYeastStrainAgmsResolveToCanonicalSpecies() {
+		loadRequiredEntities();
+
+		Long canonical = createYeastAgm("YEASTAGM:S288C", YeastStrainTaxonConstants.CANONICAL_SCE_TAXON, "S288C");
+		Long rm11 = createYeastAgm("YEASTAGM:RM11", "NCBITaxon:285006", "RM11-1a");
+		Long sk1 = createYeastAgm("YEASTAGM:SK1", "NCBITaxon:580239", "SK1");
+		Long w303 = createYeastAgm("YEASTAGM:W303", "NCBITaxon:580240", "W303");
+		Long sigma = createYeastAgm("YEASTAGM:SIGMA", "NCBITaxon:658763", "Sigma1278b");
+		Long fl100 = createYeastAgm("YEASTAGM:FL100", "NCBITaxon:947036", "FL100");
+		Long root = createYeastAgm("YEASTAGM:ROOT", "NCBITaxon:4932", "Other");
+
+		List<Long> ids = List.of(canonical, rm11, sk1, w303, sigma, fl100, root);
+
+		RestAssured.given().
+			contentType("application/json").
+			body(ids).
+			when().
+			post(MODEL_SUMMARY_ENDPOINT).
+			then().
+			statusCode(200).
+			body("totalResults", is(ids.size())).
+			body("results.species", hasItems(SCE_FULL_NAME)).
+			// every document, strain-level or not, carries the canonical species...
+			body("results.findAll { it.species != '" + SCE_FULL_NAME + "' }.size()", is(0)).
+			// ...and the strain name survives in nameKey, per the ticket's display requirement.
+			body("results.nameKey", hasItems(
+				"S288C (" + SCE_ABBREVIATION + ")",
+				"RM11-1a (" + SCE_ABBREVIATION + ")",
+				"SK1 (" + SCE_ABBREVIATION + ")",
+				"W303 (" + SCE_ABBREVIATION + ")",
+				"Sigma1278b (" + SCE_ABBREVIATION + ")",
+				"FL100 (" + SCE_ABBREVIATION + ")",
+				"Other (" + SCE_ABBREVIATION + ")"));
+	}
+
+	// A taxon with its own curated species row must keep resolving directly - the fallback
+	// join must not divert any non-yeast model.
+	@Test
+	@Order(2)
+	public void testNonYeastAgmSpeciesUnchanged() {
+		Long mouseAgm = createYeastAgm("YEASTAGM:MOUSE", MOUSE_TAXON, "MouseModel");
+
+		RestAssured.given().
+			contentType("application/json").
+			body(List.of(mouseAgm)).
+			when().
+			post(MODEL_SUMMARY_ENDPOINT).
+			then().
+			statusCode(200).
+			body("totalResults", is(1)).
+			body("results[0].species", is(MMU_FULL_NAME)).
+			body("results[0].nameKey", is("MouseModel (" + MMU_ABBREVIATION + ")"));
+	}
+
+	// A taxon that is neither curated nor a listed yeast strain must still yield a null
+	// species: the fallback is scoped to the hardcoded SGD strain list only.
+	@Test
+	@Order(3)
+	public void testUncuratedTaxonStillResolvesToNoSpecies() {
+		Long uncuratedAgm = createYeastAgm("YEASTAGM:UNCURATED", UNCURATED_TAXON, "UncuratedModel");
+
+		RestAssured.given().
+			contentType("application/json").
+			body(List.of(uncuratedAgm)).
+			when().
+			post(MODEL_SUMMARY_ENDPOINT).
+			then().
+			statusCode(200).
+			body("totalResults", is(1)).
+			body("results[0].species", is(nullValue())).
+			// with no species abbreviation there is no suffix to compose
+			body("results[0].nameKey", is("UncuratedModel"));
+	}
+
+	// The same fallback applies to the allele search documents, which is what pulls the SGD
+	// alleles sitting on NCBITaxon:4932 into the yeast species facet.
+	@Test
+	@Order(4)
+	public void testYeastStrainAlleleResolvesToCanonicalSpecies() {
+		Long rootAllele = createYeastAllele("YEASTALLELE:ROOT", "NCBITaxon:4932", "yeastAllele1");
+		Long canonicalAllele = createYeastAllele("YEASTALLELE:S288C", YeastStrainTaxonConstants.CANONICAL_SCE_TAXON, "yeastAllele2");
+
+		RestAssured.given().
+			contentType("application/json").
+			body(List.of(rootAllele, canonicalAllele)).
+			when().
+			post(ALLELE_SUMMARY_ENDPOINT).
+			then().
+			statusCode(200).
+			body("totalResults", is(2)).
+			body("results.findAll { it.allele.taxon.species.fullName != '" + SCE_FULL_NAME + "' }.size()", is(0)).
+			// the allele's own taxon is untouched - only the attached species resolves
+			body("results.allele.taxon.curie", hasItems("NCBITaxon:4932", YeastStrainTaxonConstants.CANONICAL_SCE_TAXON));
+	}
+
+	private Species createSpecies(String taxonCurie, String fullName, String abbreviation, String displayName, Integer phylogeneticOrder) {
+		Species species = new Species();
+		species.setTaxon(getNCBITaxonTerm(taxonCurie));
+		species.setFullName(fullName);
+		species.setAbbreviation(abbreviation);
+		species.setDisplayName(displayName);
+		species.setPhylogeneticOrder(phylogeneticOrder);
+
+		ObjectResponse<Species> response = RestAssured.given().
+			contentType("application/json").
+			body(species).
+			when().
+			post("/api/species").
+			then().
+			statusCode(200).
+			extract().body().as(new TypeRef<ObjectResponse<Species>>() { });
+
+		return response.getEntity();
+	}
+
+	private Long createYeastAgm(String primaryExternalId, String taxonCurie, String fullName) {
+		NCBITaxonTerm taxon = getNCBITaxonTerm(taxonCurie);
+
+		AgmFullNameSlotAnnotation agmFullName = new AgmFullNameSlotAnnotation();
+		agmFullName.setDisplayText(fullName);
+		agmFullName.setFormatText(fullName);
+		agmFullName.setNameType(fullNameType);
+
+		AffectedGenomicModel agm = new AffectedGenomicModel();
+		agm.setPrimaryExternalId(primaryExternalId);
+		agm.setTaxon(taxon);
+		agm.setSubtype(strainSubtype);
+		agm.setAgmFullName(agmFullName);
+		agm.setDataProvider(dataProvider);
+		agm.setDataProviderCrossReference(buildCrossReference(primaryExternalId));
+		agm.setInternal(false);
+		agm.setObsolete(false);
+
+		ObjectResponse<AffectedGenomicModel> response = RestAssured.given().
+			contentType("application/json").
+			body(agm).
+			when().
+			post("/api/agm").
+			then().
+			statusCode(200).
+			extract().body().as(new TypeRef<ObjectResponse<AffectedGenomicModel>>() { });
+
+		return response.getEntity().getId();
+	}
+
+	private Long createYeastAllele(String primaryExternalId, String taxonCurie, String symbol) {
+		AlleleSymbolSlotAnnotation alleleSymbol = new AlleleSymbolSlotAnnotation();
+		alleleSymbol.setDisplayText(symbol);
+		alleleSymbol.setFormatText(symbol);
+		alleleSymbol.setNameType(symbolNameType);
+
+		Allele allele = new Allele();
+		allele.setPrimaryExternalId(primaryExternalId);
+		allele.setTaxon(getNCBITaxonTerm(taxonCurie));
+		allele.setAlleleSymbol(alleleSymbol);
+		allele.setDataProvider(dataProvider);
+		// the allele summary query inner-joins the data provider cross reference and its page,
+		// so an allele without one would not be returned at all
+		allele.setDataProviderCrossReference(buildCrossReference(primaryExternalId));
+		allele.setInternal(false);
+		allele.setObsolete(false);
+
+		ObjectResponse<Allele> response = RestAssured.given().
+			contentType("application/json").
+			body(allele).
+			when().
+			post("/api/allele").
+			then().
+			statusCode(200).
+			extract().body().as(new TypeRef<ObjectResponse<Allele>>() { });
+
+		return response.getEntity().getId();
+	}
+
+	private CrossReference buildCrossReference(String referencedCurie) {
+		CrossReference crossReference = new CrossReference();
+		crossReference.setReferencedCurie(referencedCurie);
+		crossReference.setDisplayName(referencedCurie);
+		crossReference.setResourceDescriptorPage(resourceDescriptorPage);
+		return crossReference;
+	}
+}

--- a/src/test/java/org/alliancegenome/curation_api/IT_2002_YeastStrainSpeciesResolutionITCase.java
+++ b/src/test/java/org/alliancegenome/curation_api/IT_2002_YeastStrainSpeciesResolutionITCase.java
@@ -196,6 +196,11 @@ public class IT_2002_YeastStrainSpeciesResolutionITCase extends BaseITCase {
 		species.setAbbreviation(abbreviation);
 		species.setDisplayName(displayName);
 		species.setPhylogeneticOrder(phylogeneticOrder);
+		// SpeciesValidator.validateSpecies calls validateDataProvider(..., newEntity = false).
+		// That third argument is newEntity, not isRequired: with it false and no dataProvider
+		// supplied, the validator adds REQUIRED_MESSAGE and the create 400s. displayName is
+		// the MOD abbreviation here ("SGD"/"MGI"), which is also the organization abbreviation.
+		species.setDataProvider(getOrganization(displayName));
 
 		ObjectResponse<Species> response = RestAssured.given().
 			contentType("application/json").


### PR DESCRIPTION
## SCRUM-6152 — surface all 13 SGD models in the public search

Only 7 of the 13 SGD models reached the "Saccharomyces cerevisiae" species facet on the
public site. The other 6 sit on strain-level taxa that have no row in `species`, so the
species join in the search DAOs returned `NULL`, and a document with no species produces no
bucket in the `species.keyword` terms aggregation that drives the facet.

The models were never missing from the index — the curation API applies no taxon filter and
the indexer relays everything. They were only unreachable from any species-scoped view.

### Approach

`NCBITaxon:4932` is the conceptual root per the ticket discussion, but the curated `species`
row stays pinned to `NCBITaxon:559292`. Repointing it would move the species anchor out from
under ~8k SGD genes and ~23k SGD alleles — and `AlleleDAO` has an inner join on `species`
that would silently drop them.

Instead the six strain taxa resolve to the canonical taxon at query time, via a new
`YeastStrainTaxonConstants`:

```sql
LEFT JOIN ontologyterm ot_eff
    ON ot_eff.curie = CASE WHEN ot.curie IN :strainTaxa THEN :canonicalTaxon ELSE ot.curie END
LEFT JOIN species sp ON sp.taxon_id = ot_eff.id
```

No migration, no schema change, no `biologicalentity.taxon_id` touched, and nothing newly
associated with `NCBITaxon:4932` in the data. Hardcoded because the NCBITaxon closure is not
loaded into `ontologytermclosure` (only DO/GO are), so no generic ancestor lookup exists.

Resolving on the taxon rather than per column means `displayname` and the `genomeassembly`
join off the species row come along automatically, and the existing column ordinals are
unchanged.

### Verified against production data

- All 13 SGD AGMs resolve to *Saccharomyces cerevisiae* / `Sce`, with the strain name
  preserved in `nameKey` — `S288C (Sce)`, `W303 (Sce)`, `SK1 (Sce)`, `RM11-1a (Sce)`,
  `Sigma1278b (Sce)`, `FL100 (Sce)`, `Other (Sce)`.
- A before/after diff over every AGM in the database changes **exactly 6 rows**. No other
  AGM moves.

### Note on the `AlleleDAO` change

It has **no functional effect on current data** and is included for consistency between the
two search DAOs. The only alleles on any of the six strain taxa are 460 FlyBase `Scer\...`
transgenic reagents (GAL4/UAS/GAL80/FLP-FRT) on `NCBITaxon:4932`, and all 460 are
`obsolete = true` **and** `internal = true`, so `getAllAlleleSummaryIds()` never passes them
to the summary query. The species join there is also a `LEFT JOIN`, so it never gated
inclusion — it only ever affected whether the species field was populated.

Happy to drop that hunk if reviewers prefer the diff to match the ticket exactly.

### Deploy

Requires a **full indexer run** afterwards. There is no partial re-index — both
`Main` and `ModelSearchResultReindexUtility` call `IndexManager.startSiteIndex()`, which
creates a fresh empty index, so running the model indexer alone yields an AGM-only index.
`ModelSearchResultReindexUtility` is still the right tool for spot-checking, since it writes
to an isolated `site_index_*` aliased `_temp` and never swaps the live alias.

### Testing

`IT_2002_YeastStrainSpeciesResolutionITCase` covers all six strain taxa, a non-yeast control
(species must resolve directly, not divert), and an uncurated-taxon control (must still yield
a null species). It creates its own `species` rows, because the v0.29.0.2 seed is gated on
`ncbitaxonterm` already being populated, which it is not at migration time in the test
container.

**This IT has not yet been executed** — the local integration harness does not boot
(the untouched `IT_1000` fails identically), so CI here is its first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
