### PR TITLE
initialize OntologyTerm.subsets on cached terms to fix indexing failure

### DIFF
--- a/src/main/java/org/alliancegenome/curation_api/services/ontology/NcbiTaxonTermService.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/ontology/NcbiTaxonTermService.java
@@ -67,6 +67,13 @@ public class NcbiTaxonTermService extends BaseOntologyTermService<NCBITaxonTerm,
 			if (taxon == null) {
 				Log.warn("Taxon ID could not be found");
 			}
+		} else {
+			// Taxa are cached beyond this transaction, so initialize the collections Hibernate Search
+			// reads while indexing entities referring to this taxon; the session is gone by then.
+			taxon.getSecondaryIdentifiers().size();
+			taxon.getSynonyms().size();
+			taxon.getDefinitionUrls().size();
+			taxon.getSubsets().size();
 		}
 		return taxon;
 	}

--- a/src/main/java/org/alliancegenome/curation_api/services/validation/dto/base/BaseDTOValidator.java
+++ b/src/main/java/org/alliancegenome/curation_api/services/validation/dto/base/BaseDTOValidator.java
@@ -69,6 +69,19 @@ public class BaseDTOValidator<E extends Object> {
 	protected HashMap<String, HashMap<String, VocabularyTerm>> vocabularyTermCache = new HashMap<>();
 	protected HashMap<String, HashMap<String, OntologyTerm>> ontologyTermCache = new HashMap<>();
 
+	/**
+	 * Ontology terms are cached across the transactions of a single (bulk) load, so by the time a cached
+	 * term is attached to an entity in a later transaction its original session is gone. Force-initialize
+	 * every lazy collection that Hibernate Search reads while building a document for an entity embedding
+	 * this term, otherwise indexing fails at commit time with a LazyInitializationException (no session).
+	 */
+	private void initializeIndexedCollections(OntologyTerm ontologyTerm) {
+		ontologyTerm.getSecondaryIdentifiers().size();
+		ontologyTerm.getSynonyms().size();
+		ontologyTerm.getDefinitionUrls().size();
+		ontologyTerm.getSubsets().size();
+	}
+
 	protected String getCurieFromCache(String psiMiFormat) {
 		if (miCurieCache.containsKey(psiMiFormat)) {
 			return miCurieCache.get(psiMiFormat);
@@ -89,8 +102,7 @@ public class BaseDTOValidator<E extends Object> {
 			if (curie != null) {
 				MITerm miTerm = miTermService.findByCurie(curie);
 				if (miTerm != null) {
-					miTerm.getSecondaryIdentifiers().size();
-					miTerm.getSynonyms().size();
+					initializeIndexedCollections(miTerm);
 					miTermCache.put(curie, miTerm);
 					return miTerm;
 				}
@@ -286,9 +298,7 @@ public class BaseDTOValidator<E extends Object> {
 				return null;
 			}
 
-			ontologyTerm.getSecondaryIdentifiers().size();
-			ontologyTerm.getSynonyms().size();
-			ontologyTerm.getDefinitionUrls().size();
+			initializeIndexedCollections(ontologyTerm);
 			ontologyTermCache.get(service.getClass().getName()).put(curie, ontologyTerm);
 		}
 
@@ -325,8 +335,7 @@ public class BaseDTOValidator<E extends Object> {
 					return null;
 				}
 
-				ontologyTerm.getSecondaryIdentifiers().size();
-				ontologyTerm.getSynonyms().size();
+				initializeIndexedCollections(ontologyTerm);
 				ontologyTermCache.get(service.getClass().getName()).put(curie, ontologyTerm);
 			}
 			ontologyTerms.add(ontologyTerm);


### PR DESCRIPTION
Ontology terms are cached across the per-record transactions of a bulk load, so a cached term is detached with its session closed by the time it is attached to an entity in a later transaction. The caching sites initialized secondaryIdentifiers, synonyms and definitionUrls but not subsets, which is an indexed @ElementCollection. Hibernate Search then hit a LazyInitializationException while building the document at commit time:

  HSEARCH700083: Exception while building document for entity
  'ExperimentalCondition#...': Cannot lazily initialize collection of role
  'OntologyTerm.subsets' (no session) Context: path '.conditionId...subsets'

Extract initializeIndexedCollections() covering all four collections Hibernate Search reads and use it at every caching site in BaseDTOValidator, and apply the same initialization to the taxon cache in NcbiTaxonTermService, which has the identical defect.